### PR TITLE
CI gates: lint, format, publish build, and installer API security smoke test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Keep the SHA-pinned GitHub Actions in .github/workflows/ci.yml current.
+# Dependabot updates the pinned commit SHA whenever the tracked tag moves.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+# Actions are pinned to full commit SHAs (supply-chain hardening — mutable
+# major-version tags can be silently retagged).  The tag each SHA tracks is in
+# a trailing comment; `.github/dependabot.yml` refreshes the SHAs.
 on:
   pull_request:
   push:
@@ -15,11 +18,11 @@ jobs:
     name: lint + format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -38,11 +41,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -50,7 +53,7 @@ jobs:
 
       - name: Set up MSYS2 toolchain (make + gcc)
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
           update: true
@@ -71,7 +74,7 @@ jobs:
         run: node tools/test/smoke-security.mjs
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist-${{ matrix.os }}
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # Fast static gate: eslint (incl. security plugin) + prettier + clang-format
+  # + the gcc -fanalyzer C analysis.  Runs on every PR and on main pushes.
+  checks:
+    name: lint + format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm format
+
+  # Publish-path gate: `upload:local --mode=dev` rebuilds the zips and the
+  # native binaries for the runner's OS.  This is what catches regressions in
+  # the generated files, hashes and Makefile before they reach a release.
+  build:
+    name: publish gate — ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Set up MSYS2 toolchain (make + gcc)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            make
+
+      - name: Build all packages and binaries
+        shell: bash
+        run: pnpm upload:local --mode=dev
+
+      # Security regression gate: every state-changing /api route must reject
+      # a missing/wrong session token, and no response may carry the wildcard
+      # Access-Control-Allow-Origin header.  Windows only: it drives the win
+      # binary; the same gate logic is covered on other OSes by review.
+      - name: Security smoke test — installer API
+        if: runner.os == 'Windows'
+        shell: bash
+        run: node tools/test/smoke-security.mjs
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         run: node tools/test/smoke-security.mjs
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.os }}
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     name: lint + format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 9
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -41,13 +41,13 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 9
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,7 @@ jobs:
           msystem: UCRT64
           update: true
           install: >-
-            mingw-w64-ucrt-x86_64-gcc
-            make
+            mingw-w64-ucrt-x86_64-gcc make
 
       - name: Build all packages and binaries
         shell: bash

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -175,9 +175,9 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
 
 - **checks** (Linux) — `pnpm lint` (ESLint incl. `eslint-plugin-security`, clang-format,
   `gcc -fanalyzer`) and `pnpm format`.
-- **publish gate** (Windows / Linux / macOS) — `pnpm upload:local --mode=dev` rebuilds every
-  package zip and the native binaries for the runner's OS, so regressions in generated files,
-  hashes or the Makefile fail the PR before they reach a release.
+- **publish gate** (Windows / Linux / macOS) — `pnpm upload:local --mode=dev` rebuilds every package
+  zip and the native binaries for the runner's OS, so regressions in generated files, hashes or the
+  Makefile fail the PR before they reach a release.
 - **Security smoke test** (Windows) — `tools/test/smoke-security.mjs` launches the built installer
   headless and verifies every state-changing `/api` route rejects a missing/wrong session token,
   valid tokens pass the gate, and no response carries `Access-Control-Allow-Origin`.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -169,6 +169,29 @@ node installer/test/test_hash.mjs
 
 Exit code 0 means every package's JS hash matches the C binary's (computed with `--test-hash`).
 
+## Continuous integration
+
+`.github/workflows/ci.yml` runs on every PR and on `main` pushes:
+
+- **checks** (Linux) — `pnpm lint` (ESLint incl. `eslint-plugin-security`, clang-format,
+  `gcc -fanalyzer`) and `pnpm format`.
+- **publish gate** (Windows / Linux / macOS) — `pnpm upload:local --mode=dev` rebuilds every
+  package zip and the native binaries for the runner's OS, so regressions in generated files,
+  hashes or the Makefile fail the PR before they reach a release.
+- **Security smoke test** (Windows) — `tools/test/smoke-security.mjs` launches the built installer
+  headless and verifies every state-changing `/api` route rejects a missing/wrong session token,
+  valid tokens pass the gate, and no response carries `Access-Control-Allow-Origin`.
+
+Run the smoke test locally (Windows, from the repo root):
+
+```bash
+pnpm upload:local --mode=dev
+node tools/test/smoke-security.mjs
+```
+
+The installer's `--smoke-test` flag makes the headless run possible: it skips the
+no-browser-detected abort and the browser-tab open, and prints the session token to stdout.
+
 ## Test the auto-updater
 
 1. Open `about:config` and set `xpinstall.signatures.required` to `false` (Firefox

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,5 +58,9 @@ Run through every item; each maps to code that already exists.
   uninit). Exits nonzero on any finding. Vendored `miniz` is excluded.
 - `pnpm test` / `installer/test/test_hash.mjs` — verifies the C hash algorithm matches the JS
   reference, so a tampered package is detected consistently.
+- `tools/test/smoke-security.mjs` — CI security smoke test: boots the installer headless
+  (`--smoke-test`) and asserts every state-changing `/api` route rejects a missing/wrong session
+  token, valid tokens pass the gate, and no response carries `Access-Control-Allow-Origin`. Runs in
+  the CI workflow on Windows after `pnpm upload:local --mode=dev`; run it locally the same way.
 - External reviews (e.g. Greptile on PRs) act as a second pair of eyes; treat findings as hypotheses
   to verify against this checklist, not as ground truth.

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -16,6 +16,9 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <sys/random.h>
 #endif
 
@@ -221,16 +224,6 @@ static void focus_browser_window(unsigned long pid) {
     SetForegroundWindow(found);
     BringWindowToTop(found);
 }
-#else
-static int find_last_used_browser_index(const RunningBrowser *browsers, int count) {
-    (void)browsers;
-    (void)count;
-    return -1;  // no z-order heuristic off-Windows; caller uses the first entry
-}
-
-static void focus_browser_window(unsigned long pid) {
-    (void)pid;  // launching via open_url_in_profile/xdg-open handles focus
-}
 #endif
 
 static DWORD WINAPI ctrl_c_watchdog(LPVOID unused) {
@@ -253,6 +246,16 @@ static DWORD WINAPI ctrl_c_watchdog(LPVOID unused) {
         }
     }
     return 0;
+}
+#else
+static int find_last_used_browser_index(const RunningBrowser *browsers, int count) {
+    (void)browsers;
+    (void)count;
+    return -1;  // no z-order heuristic off-Windows; caller uses the first entry
+}
+
+static void focus_browser_window(unsigned long pid) {
+    (void)pid;  // launching via open_url_in_profile/xdg-open handles focus
 }
 #endif
 

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -27,6 +27,11 @@
 // ===== Verbose logging =====
 static int g_verbose = 0;
 
+// --smoke-test: run headless for CI security smoke tests — never abort when
+// no browser is detected, never open a browser tab, and print the session
+// token to stdout so the test can drive the API.
+static int g_smoke_test = 0;
+
 #define verbose_printf(...)                 \
     do {                                    \
         if (g_verbose) printf(__VA_ARGS__); \
@@ -2228,6 +2233,9 @@ static void print_help(void) {
     printf("                  Compute SHA256 hash of files in <path> for <type>\n");
     printf("                  (type: \"utils\" or \"fx-folder\") using the canonical\n");
     printf("                  file list from <file> (e.g. a dist/prod-*/hashes.json)\n");
+    printf("  --smoke-test    Headless mode for CI security smoke tests: run the\n");
+    printf("                  HTTP API without aborting on missing browsers or\n");
+    printf("                  opening a browser tab; print the session token.\n");
     printf("\nWhen run without options, the installer starts an HTTP server\n");
     printf("and opens a browser-based UI for choosing installation options.\n");
     printf("Use --verbose when running from a terminal to see progress.\n");
@@ -2298,6 +2306,10 @@ static int main_impl(int argc, char *argv[]) {
 #endif
             g_verbose = 1;
         }
+        if (strcmp(argv[1], "--smoke-test") == 0) {
+            g_smoke_test = 1;
+            g_verbose = 1;
+        }
         if (strcmp(argv[1], "--scan-only") == 0) {
             // Debug helper: run browser detection only, print the result, and
             // exit without network checks, the HTTP server, or the UI.
@@ -2348,7 +2360,7 @@ static int main_impl(int argc, char *argv[]) {
     printf("Scanning for running browsers...\n");
     detected_count = scan_and_filter_browsers(detected_browsers, MAX_BROWSERS);
 
-    if (detected_count == 0) {
+    if (detected_count == 0 && !g_smoke_test) {
         printf("No supported browsers detected.\n");
         printf("Please start Firefox, Waterfox, Zen Browser, LibreWolf, or Floorp and run again.\n");
 #ifdef _WIN32
@@ -2426,6 +2438,12 @@ static int main_impl(int argc, char *argv[]) {
         return 1;
     }
     log_msg("[startup] port=%d session_token=%s\n", port, g_session_token);
+    if (g_smoke_test) {
+        // The smoke test needs the token to prove valid-token requests pass the
+        // gate; print it (flushed) so the spawned process can read it.
+        printf("SMOKE_TEST_SESSION_TOKEN=%s\n", g_session_token);
+        fflush(stdout);
+    }
 
     printf("\nStarting installer UI at http://localhost:%d/\n", port);
 
@@ -2465,24 +2483,26 @@ static int main_impl(int argc, char *argv[]) {
     // is why the restored session had no installer tab).
     snprintf(g_ui_url, sizeof(g_ui_url), "http://localhost:%d/?t=%s", port, g_session_token);
     log_msg("[startup] opening %s\n", g_ui_url);
-    if (detected_count > 0) {
-        // Prefer the most recently used browser window over the first detected
-        // entry, so with several browsers open the tab lands where the user is
-        // actually working instead of an arbitrary instance.
-        int ui_host_idx = find_last_used_browser_index(detected_browsers, detected_count);
-        if (ui_host_idx < 0) ui_host_idx = 0;
-        // Record which profile hosts the UI tab so the restart worker can
-        // reopen the UI there after a restart that kills this browser.
-        if (strlen(detected_browsers[ui_host_idx].profile_path) > 0) {
-            strncpy(g_ui_host_profile, detected_browsers[ui_host_idx].profile_path, MAX_PATH_LEN - 1);
-            g_ui_host_profile[MAX_PATH_LEN - 1] = '\0';
+    if (!g_smoke_test) {
+        if (detected_count > 0) {
+            // Prefer the most recently used browser window over the first
+            // detected entry, so with several browsers open the tab lands where
+            // the user is actually working instead of an arbitrary instance.
+            int ui_host_idx = find_last_used_browser_index(detected_browsers, detected_count);
+            if (ui_host_idx < 0) ui_host_idx = 0;
+            // Record which profile hosts the UI tab so the restart worker can
+            // reopen the UI there after a restart that kills this browser.
+            if (strlen(detected_browsers[ui_host_idx].profile_path) > 0) {
+                strncpy(g_ui_host_profile, detected_browsers[ui_host_idx].profile_path, MAX_PATH_LEN - 1);
+                g_ui_host_profile[MAX_PATH_LEN - 1] = '\0';
+            }
+            open_url_in_profile(detected_browsers[ui_host_idx].binary_path,
+                                detected_browsers[ui_host_idx].profile_path, g_ui_url);
+            // Bring the hosting window to the foreground so the new tab is visible.
+            focus_browser_window(detected_browsers[ui_host_idx].pid);
+        } else {
+            open_browser(g_ui_url, NULL);  // fallback to default browser
         }
-        open_url_in_profile(detected_browsers[ui_host_idx].binary_path,
-                            detected_browsers[ui_host_idx].profile_path, g_ui_url);
-        // Bring the hosting window to the foreground so the new tab is visible.
-        focus_browser_window(detected_browsers[ui_host_idx].pid);
-    } else {
-        open_browser(g_ui_url, NULL);  // fallback to default browser
     }
 
     printf("Press Ctrl+C to stop the installer.\n");

--- a/tools/test/smoke-security.mjs
+++ b/tools/test/smoke-security.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Security smoke test for the installer's local HTTP API.
+ *
+ * Starts the installer binary headless (--smoke-test), then verifies:
+ *   1. Every state-changing /api route rejects a MISSING token.
+ *   2. Every state-changing /api route rejects a WRONG token.
+ *   3. Every state-changing route accepts a VALID token (passes the gate;
+ *      the handler may still return a business error — that's fine).
+ *   4. No response carries an Access-Control-Allow-Origin header (the wildcard
+ *      CORS that made cross-origin pages able to drive the API is gone).
+ *
+ * Usage (run from the repo root, after `pnpm upload:local --mode=dev`):
+ *   node tools/test/smoke-security.mjs
+ *   INSTALLER_BIN=/path/to/installer_win-dev.exe node tools/test/smoke-security.mjs
+ *
+ * Exits non-zero on the first failed category so CI fails the build.
+ */
+
+import {spawn} from 'node:child_process';
+import {existsSync, readdirSync, statSync} from 'node:fs';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+// tools/test/smoke-security.mjs → repo root
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const PORT = 8777;
+const BASE = `http://127.0.0.1:${PORT}`;
+const WRONG_TOKEN = '0'.repeat(16);
+
+// Every state-changing route must reject a missing/wrong token.  Keep this
+// list in sync with the `request_has_valid_token` gates in installer/src/
+// (main.c + http_server.c).  `/api/shutdown` is special: it replies
+// {"status":"ignored"} instead of {"error":"unauthorized"}.
+const GATED_ROUTES = [
+  'status',
+  'install',
+  'self-update',
+  'manifest',
+  'upload',
+  'waterfox',
+  'hg-tags',
+  'close-browser',
+  'open-folder',
+  'rescan',
+  'restart',
+];
+const SHUTDOWN_ROUTE = 'shutdown';
+const SHUTDOWN_REJECT = 'ignored';
+
+// Read-only routes: usable without a token, but still must never carry CORS.
+const OPEN_ROUTES = ['ping', 'build-info', 'browsers', 'package-urls'];
+
+let failures = 0;
+let checks = 0;
+
+function check(ok, label, detail = '') {
+  checks += 1;
+  if (ok) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    failures += 1;
+    console.log(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+/** Locate the freshly built installer binary (dev snapshot or .build staging). */
+function findInstaller() {
+  if (process.env.INSTALLER_BIN) return process.env.INSTALLER_BIN;
+  const candidates =
+    process.platform === 'win32'
+      ? ['installer_win-dev.exe', 'installer_win.exe']
+      : process.platform === 'darwin'
+        ? ['installer_mac-dev', 'installer_mac']
+        : ['installer_linux-dev', 'installer_linux'];
+  const searchDirs = [join(REPO_ROOT, 'dist', '.build', 'installer')];
+  // dist/dev-<branch>-<hash>/ snapshots from `upload:local`.
+  const distRoot = join(REPO_ROOT, 'dist');
+  if (existsSync(distRoot)) {
+    for (const entry of readdirSync(distRoot)) {
+      const full = join(distRoot, entry);
+      if (entry.startsWith('dev-') && statSync(full).isDirectory()) {
+        searchDirs.push(full);
+      }
+    }
+  }
+  for (const dir of searchDirs) {
+    for (const name of candidates) {
+      const p = join(dir, name);
+      if (existsSync(p)) return p;
+    }
+  }
+  throw new Error(
+    `installer binary not found in ${searchDirs.join(', ')} — run "pnpm upload:local --mode=dev" first (or set INSTALLER_BIN)`,
+  );
+}
+
+/** GET (or POST) an installer API path; returns {status, text, acao}. */
+async function hit(route, {token, method = 'GET', body} = {}) {
+  const qs = new URLSearchParams();
+  if (token) qs.set('t', token);
+  const url = `${BASE}/api/${route}${qs.size ? `?${qs}` : ''}`;
+  const res = await fetch(url, {
+    method,
+    body,
+    signal: AbortSignal.timeout(10_000),
+  });
+  const text = await res.text();
+  return {status: res.status, text, acao: res.headers.get('access-control-allow-origin')};
+}
+
+async function waitForServer(token, child) {
+  const deadline = Date.now() + 15_000;
+  for (;;) {
+    if (child.exitCode !== null) {
+      throw new Error(`installer exited early (code ${child.exitCode}) before serving`);
+    }
+    try {
+      const ping = await hit('ping');
+      // Prove the port is served by OUR instance: a foreign installer on the
+      // same port would report current:0 for our freshly generated token.
+      const claim = await hit('claim', {token});
+      if (claim.text.includes('"current":1')) return;
+      if (claim.text.includes('"current":0')) {
+        throw new Error('another installer instance already holds port 8777');
+      }
+      void ping;
+    } catch {
+      // not up yet — keep polling
+    }
+    if (Date.now() > deadline) throw new Error('installer did not start serving in time');
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+async function main() {
+  const installer = findInstaller();
+  console.log(`\nSecurity smoke test — ${installer}\n`);
+
+  const child = spawn(installer, ['--smoke-test'], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  child.stdout.on('data', (d) => (stdout += d.toString()));
+  child.stderr.on('data', (d) => (stdout += d.toString()));
+
+  let token = null;
+  try {
+    const deadline = Date.now() + 10_000;
+    while (!token && Date.now() < deadline) {
+      const m = stdout.match(/SMOKE_TEST_SESSION_TOKEN=([0-9a-f]{16})/);
+      if (m) token = m[1];
+      if (child.exitCode !== null) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    if (!token) {
+      throw new Error(`installer did not print a session token. Output so far:\n${stdout.slice(0, 2000)}`);
+    }
+    await waitForServer(token, child);
+
+    console.log('Missing token → must be refused on every state-changing route');
+    for (const route of [...GATED_ROUTES, SHUTDOWN_ROUTE]) {
+      const reject = route === SHUTDOWN_ROUTE ? SHUTDOWN_REJECT : 'unauthorized';
+      const res = await hit(route);
+      check(res.text.includes(reject), `/api/${route} rejects missing token`, `got: ${res.text.slice(0, 80)}`);
+      check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
+    }
+
+    console.log('\nWrong token → must be refused on every state-changing route');
+    for (const route of [...GATED_ROUTES, SHUTDOWN_ROUTE]) {
+      const reject = route === SHUTDOWN_ROUTE ? SHUTDOWN_REJECT : 'unauthorized';
+      const res = await hit(route, {token: WRONG_TOKEN});
+      check(res.text.includes(reject), `/api/${route} rejects wrong token`, `got: ${res.text.slice(0, 80)}`);
+      check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
+    }
+
+    console.log('\nClaim reflects token validity');
+    {
+      const wrong = await hit('claim', {token: WRONG_TOKEN});
+      check(wrong.text.includes('"current":0'), '/api/claim with wrong token reports current:0', wrong.text.slice(0, 80));
+      const good = await hit('claim', {token});
+      check(good.text.includes('"current":1'), '/api/claim with valid token reports current:1', good.text.slice(0, 80));
+      check(good.acao === null, '/api/claim has no Access-Control-Allow-Origin');
+    }
+
+    console.log('\nRead-only routes work without a token and carry no CORS');
+    for (const route of OPEN_ROUTES) {
+      const res = await hit(route);
+      check(!res.text.includes('unauthorized'), `/api/${route} usable without token`, `got: ${res.text.slice(0, 80)}`);
+      check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
+    }
+
+    console.log('\nValid token → the gate lets requests through (business errors are fine)');
+    for (const route of GATED_ROUTES) {
+      // self-update with a GET hits the network; POST an empty payload instead
+      // so it fails fast on parsing, past the gate.
+      const res =
+        route === 'self-update'
+          ? await hit(route, {token, method: 'POST', body: '{}'})
+          : await hit(route, {token});
+      check(!res.text.includes('unauthorized'), `/api/${route} passes with valid token`, `got: ${res.text.slice(0, 80)}`);
+      check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
+    }
+
+    console.log('\nShutdown (last): valid token stops the server');
+    const shut = await hit(SHUTDOWN_ROUTE, {token});
+    check(!shut.text.includes('unauthorized') && !shut.text.includes(SHUTDOWN_REJECT), '/api/shutdown honors valid token', shut.text.slice(0, 80));
+    check(shut.acao === null, '/api/shutdown has no Access-Control-Allow-Origin');
+    const exited = await Promise.race([
+      new Promise((r) => child.once('exit', (code) => r(code))),
+      new Promise((r) => setTimeout(() => r('timeout'), 10_000)),
+    ]);
+    check(exited !== 'timeout', `installer exited after shutdown (code ${exited})`, exited === 'timeout' ? 'still running' : '');
+  } catch (err) {
+    failures += 1;
+    console.log(`  ✗ smoke test error: ${err.message}`);
+  } finally {
+    if (child.exitCode === null) {
+      child.kill();
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  console.log(`\n${checks - failures}/${checks} checks passed`);
+  if (failures > 0) {
+    console.log(`\n✗ ${failures} check(s) FAILED`);
+    process.exit(1);
+  }
+  console.log('\n✓ all security smoke checks passed');
+}
+
+main().catch((err) => {
+  console.error(`✗ ${err.message}`);
+  process.exit(1);
+});

--- a/tools/test/smoke-security.mjs
+++ b/tools/test/smoke-security.mjs
@@ -3,16 +3,17 @@
  * Security smoke test for the installer's local HTTP API.
  *
  * Starts the installer binary headless (--smoke-test), then verifies:
- *   1. Every state-changing /api route rejects a MISSING token.
- *   2. Every state-changing /api route rejects a WRONG token.
- *   3. Every state-changing route accepts a VALID token (passes the gate;
- *      the handler may still return a business error — that's fine).
- *   4. No response carries an Access-Control-Allow-Origin header (the wildcard
- *      CORS that made cross-origin pages able to drive the API is gone).
  *
- * Usage (run from the repo root, after `pnpm upload:local --mode=dev`):
- *   node tools/test/smoke-security.mjs
- *   INSTALLER_BIN=/path/to/installer_win-dev.exe node tools/test/smoke-security.mjs
+ * 1. Every state-changing /api route rejects a MISSING token.
+ * 2. Every state-changing /api route rejects a WRONG token.
+ * 3. Every state-changing route accepts a VALID token (passes the gate; the
+ *    handler may still return a business error — that's fine).
+ * 4. No response carries an Access-Control-Allow-Origin header (the wildcard CORS
+ *    that made cross-origin pages able to drive the API is gone).
+ *
+ * Usage (run from the repo root, after `pnpm upload:local --mode=dev`): node
+ * tools/test/smoke-security.mjs INSTALLER_BIN=/path/to/installer_win-dev.exe
+ * node tools/test/smoke-security.mjs
  *
  * Exits non-zero on the first failed category so CI fails the build.
  */
@@ -68,11 +69,9 @@ function check(ok, label, detail = '') {
 function findInstaller() {
   if (process.env.INSTALLER_BIN) return process.env.INSTALLER_BIN;
   const candidates =
-    process.platform === 'win32'
-      ? ['installer_win-dev.exe', 'installer_win.exe']
-      : process.platform === 'darwin'
-        ? ['installer_mac-dev', 'installer_mac']
-        : ['installer_linux-dev', 'installer_linux'];
+    process.platform === 'win32' ? ['installer_win-dev.exe', 'installer_win.exe']
+    : process.platform === 'darwin' ? ['installer_mac-dev', 'installer_mac']
+    : ['installer_linux-dev', 'installer_linux'];
   const searchDirs = [join(REPO_ROOT, 'dist', '.build', 'installer')];
   // dist/dev-<branch>-<hash>/ snapshots from `upload:local`.
   const distRoot = join(REPO_ROOT, 'dist');
@@ -91,7 +90,7 @@ function findInstaller() {
     }
   }
   throw new Error(
-    `installer binary not found in ${searchDirs.join(', ')} — run "pnpm upload:local --mode=dev" first (or set INSTALLER_BIN)`,
+    `installer binary not found in ${searchDirs.join(', ')} — run "pnpm upload:local --mode=dev" first (or set INSTALLER_BIN)`
   );
 }
 
@@ -129,7 +128,7 @@ async function waitForServer(token, child) {
       // not up yet — keep polling
     }
     if (Date.now() > deadline) throw new Error('installer did not start serving in time');
-    await new Promise((r) => setTimeout(r, 250));
+    await new Promise(r => setTimeout(r, 250));
   }
 }
 
@@ -142,8 +141,8 @@ async function main() {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   let stdout = '';
-  child.stdout.on('data', (d) => (stdout += d.toString()));
-  child.stderr.on('data', (d) => (stdout += d.toString()));
+  child.stdout.on('data', d => (stdout += d.toString()));
+  child.stderr.on('data', d => (stdout += d.toString()));
 
   let token = null;
   try {
@@ -152,10 +151,12 @@ async function main() {
       const m = stdout.match(/SMOKE_TEST_SESSION_TOKEN=([0-9a-f]{16})/);
       if (m) token = m[1];
       if (child.exitCode !== null) break;
-      await new Promise((r) => setTimeout(r, 100));
+      await new Promise(r => setTimeout(r, 100));
     }
     if (!token) {
-      throw new Error(`installer did not print a session token. Output so far:\n${stdout.slice(0, 2000)}`);
+      throw new Error(
+        `installer did not print a session token. Output so far:\n${stdout.slice(0, 2000)}`
+      );
     }
     await waitForServer(token, child);
 
@@ -163,7 +164,11 @@ async function main() {
     for (const route of [...GATED_ROUTES, SHUTDOWN_ROUTE]) {
       const reject = route === SHUTDOWN_ROUTE ? SHUTDOWN_REJECT : 'unauthorized';
       const res = await hit(route);
-      check(res.text.includes(reject), `/api/${route} rejects missing token`, `got: ${res.text.slice(0, 80)}`);
+      check(
+        res.text.includes(reject),
+        `/api/${route} rejects missing token`,
+        `got: ${res.text.slice(0, 80)}`
+      );
       check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
     }
 
@@ -171,23 +176,39 @@ async function main() {
     for (const route of [...GATED_ROUTES, SHUTDOWN_ROUTE]) {
       const reject = route === SHUTDOWN_ROUTE ? SHUTDOWN_REJECT : 'unauthorized';
       const res = await hit(route, {token: WRONG_TOKEN});
-      check(res.text.includes(reject), `/api/${route} rejects wrong token`, `got: ${res.text.slice(0, 80)}`);
+      check(
+        res.text.includes(reject),
+        `/api/${route} rejects wrong token`,
+        `got: ${res.text.slice(0, 80)}`
+      );
       check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
     }
 
     console.log('\nClaim reflects token validity');
     {
       const wrong = await hit('claim', {token: WRONG_TOKEN});
-      check(wrong.text.includes('"current":0'), '/api/claim with wrong token reports current:0', wrong.text.slice(0, 80));
+      check(
+        wrong.text.includes('"current":0'),
+        '/api/claim with wrong token reports current:0',
+        wrong.text.slice(0, 80)
+      );
       const good = await hit('claim', {token});
-      check(good.text.includes('"current":1'), '/api/claim with valid token reports current:1', good.text.slice(0, 80));
+      check(
+        good.text.includes('"current":1'),
+        '/api/claim with valid token reports current:1',
+        good.text.slice(0, 80)
+      );
       check(good.acao === null, '/api/claim has no Access-Control-Allow-Origin');
     }
 
     console.log('\nRead-only routes work without a token and carry no CORS');
     for (const route of OPEN_ROUTES) {
       const res = await hit(route);
-      check(!res.text.includes('unauthorized'), `/api/${route} usable without token`, `got: ${res.text.slice(0, 80)}`);
+      check(
+        !res.text.includes('unauthorized'),
+        `/api/${route} usable without token`,
+        `got: ${res.text.slice(0, 80)}`
+      );
       check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
     }
 
@@ -196,29 +217,41 @@ async function main() {
       // self-update with a GET hits the network; POST an empty payload instead
       // so it fails fast on parsing, past the gate.
       const res =
-        route === 'self-update'
-          ? await hit(route, {token, method: 'POST', body: '{}'})
-          : await hit(route, {token});
-      check(!res.text.includes('unauthorized'), `/api/${route} passes with valid token`, `got: ${res.text.slice(0, 80)}`);
+        route === 'self-update' ?
+          await hit(route, {token, method: 'POST', body: '{}'})
+        : await hit(route, {token});
+      check(
+        !res.text.includes('unauthorized'),
+        `/api/${route} passes with valid token`,
+        `got: ${res.text.slice(0, 80)}`
+      );
       check(res.acao === null, `/api/${route} has no Access-Control-Allow-Origin`);
     }
 
     console.log('\nShutdown (last): valid token stops the server');
     const shut = await hit(SHUTDOWN_ROUTE, {token});
-    check(!shut.text.includes('unauthorized') && !shut.text.includes(SHUTDOWN_REJECT), '/api/shutdown honors valid token', shut.text.slice(0, 80));
+    check(
+      !shut.text.includes('unauthorized') && !shut.text.includes(SHUTDOWN_REJECT),
+      '/api/shutdown honors valid token',
+      shut.text.slice(0, 80)
+    );
     check(shut.acao === null, '/api/shutdown has no Access-Control-Allow-Origin');
     const exited = await Promise.race([
-      new Promise((r) => child.once('exit', (code) => r(code))),
-      new Promise((r) => setTimeout(() => r('timeout'), 10_000)),
+      new Promise(r => child.once('exit', code => r(code))),
+      new Promise(r => setTimeout(() => r('timeout'), 10_000)),
     ]);
-    check(exited !== 'timeout', `installer exited after shutdown (code ${exited})`, exited === 'timeout' ? 'still running' : '');
+    check(
+      exited !== 'timeout',
+      `installer exited after shutdown (code ${exited})`,
+      exited === 'timeout' ? 'still running' : ''
+    );
   } catch (err) {
     failures += 1;
     console.log(`  ✗ smoke test error: ${err.message}`);
   } finally {
     if (child.exitCode === null) {
       child.kill();
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, 500));
     }
   }
 
@@ -230,7 +263,7 @@ async function main() {
   console.log('\n✓ all security smoke checks passed');
 }
 
-main().catch((err) => {
+main().catch(err => {
   console.error(`✗ ${err.message}`);
   process.exit(1);
 });


### PR DESCRIPTION
## What's in this PR

The Phase 3 CI gate (part of #2) — the pipeline that makes "works locally == works in CI" true.

**`.github/workflows/ci.yml`** runs on every PR and on `main` pushes:

1. **checks** (Linux) — `pnpm lint` (ESLint incl. `eslint-plugin-security`, clang-format,
   `gcc -fanalyzer` C analysis) + `pnpm format`. Fast static gate.
2. **publish gate** (Windows / Linux / macOS) — `pnpm upload:local --mode=dev` rebuilds every
   package zip and the native binaries for the runner's OS.
3. **Security smoke test** (Windows) — `tools/test/smoke-security.mjs` boots the built installer
   headless and asserts:
   - every state-changing `/api` route rejects a **missing** session token,
   - every state-changing `/api` route rejects a **wrong** session token,
   - valid tokens pass the gate on every route,
   - no response carries `Access-Control-Allow-Origin` (the wildcard CORS is gone).

**Supporting changes:**

- `installer/src/main.c` — `--smoke-test` headless flag (skip the no-browser abort and the tab
  open, print the session token to stdout).
- `installer/src/main.c` — **fixed pre-existing Linux/macOS build breakage the gate caught**: the
  POSIX fallbacks for `find_last_used_browser_index`/`focus_browser_window` were nested inside a
  Windows-only `#ifdef` block, and `tcp_listening`'s POSIX branch lacked socket headers. The
  publish gate now passes on all three OSes.
- `.github/dependabot.yml` + SHA-pinned actions — supply-chain hardening (Greptile P2): no mutable
  action tags; Dependabot refreshes the pins weekly.
- `docs/DEVELOPING.md` + `docs/security.md` — CI workflow description and how to run the smoke
  test locally.

## Verified

- Locally: `pnpm lint` + `pnpm format` green; `pnpm upload:local --mode=dev` builds; smoke test
  **84/84 checks passed** against the freshly built exe.
- In CI: lint+format, publish gate on Windows/Linux/macOS, and the Windows smoke test all green.

## Notes

- The unit-test layer (`pnpm test`, hash + zip + config generators) lands separately in #1 /
  Phase 2; E2E (browsers × OSes) is #3.
- The security smoke test runs on Windows only (it drives the Windows binary); the same gate
  logic is enforced on all OSes by the shared `request_has_valid_token` code reviewed in #5.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds cross-platform CI gates for static checks, publish builds, and a Windows installer API security smoke test, together with the installer headless mode and portability fixes needed to run those gates.
- Pins all GitHub Actions to immutable commit SHAs and configures weekly Dependabot updates.
- Builds publish artifacts on Windows, Linux, and macOS.
- Exercises installer API token enforcement and CORS-header absence on Windows.
- Documents the CI workflow and local smoke-test procedure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds SHA-pinned lint, cross-platform publish-build, Windows security-smoke-test, and artifact-upload jobs; the prior mutable-reference issue is fixed. |
| installer/src/main.c | Adds the headless smoke-test mode and repairs POSIX build boundaries and socket includes without leaving a supported prior-thread issue. |
| tools/test/smoke-security.mjs | Adds a smoke harness that starts the installer, verifies API token gates and absent CORS headers, and shuts the process down. |
| .github/dependabot.yml | Adds weekly GitHub Actions updates to maintain the workflow’s immutable SHA pins. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Pull request or main push] --> B[Lint and format checks]
  A --> C{OS build matrix}
  C --> D[Windows publish build]
  C --> E[Linux publish build]
  C --> F[macOS publish build]
  D --> G[Installer API security smoke test]
  D --> H[Upload Windows artifacts]
  E --> I[Upload Linux artifacts]
  F --> J[Upload macOS artifacts]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["ci: bump upload-artifact to v7.0.1 (Node..."](https://github.com/onemen/firefox-scripts/commit/2d8400cc8e8c9c30d92b26dfc6a9e5c0c705e63d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55360965)</sub>

<!-- /greptile_comment -->