### PR TITLE
feat(tests): add pnpm test unit suite and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm format
+      - run: pnpm test
 
   # Publish-path gate: `upload:local --mode=dev` rebuilds the zips and the
   # native binaries for the runner's OS.  This is what catches regressions in
@@ -72,6 +73,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: node tools/test/smoke-security.mjs
+
+      # JS vs C hash parity against the dev snapshot built above (test_hash
+      # accepts both prod- and dev- snapshots, so no second build is needed).
+      - name: Hash parity — JS vs C installer
+        if: runner.os == 'Windows'
+        shell: bash
+        run: pnpm test:hash
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,9 +136,11 @@ pnpm install
 pnpm lint          # eslint + C format check
 pnpm format        # check: C + prettier
 pnpm format:fix    # apply both
+pnpm test          # unit tests (tools/test/unit/, pure Node, no build)
 
-# only test suite (auto-generates a prod snapshot via upload:local if needed)
-node installer/test/test_hash.mjs
+# hash parity JS vs C (auto-generates a prod snapshot via upload:local if needed;
+# also works against the newest dev- snapshot, so it runs after upload:local --mode=dev)
+pnpm test:hash
 ```
 
 **Publish — only when the user explicitly asks.** `upload:local` is the token-less offline check:
@@ -176,12 +178,13 @@ Match the change to its validation:
 | Change                      | Validate with                                                           |
 | --------------------------- | ----------------------------------------------------------------------- |
 | C (`installer/src/`)        | build the affected target (`make dist_win` / `dist_linux` / `dist_mac`) |
-| Hash / file list            | `node installer/test/test_hash.mjs`                                     |
+| Hash / file list            | `pnpm test:hash`                                                        |
+| Publish helpers / hashing   | `pnpm test` (unit tests in `tools/test/unit/`)                          |
 | Generated-file sources      | `node tools/publish/syncGeneratedFiles.mjs`                             |
 | Packaging / publish scripts | `pnpm upload:local -- --mode=prod`                                      |
 
-Pre-PR gates: `pnpm lint`, `pnpm format`, and the hash test. **Do not claim tests passed if the
-required toolchain or environment was unavailable.**
+Pre-PR gates: `pnpm lint`, `pnpm format`, `pnpm test`, and the hash test. **Do not claim tests
+passed if the required toolchain or environment was unavailable.**
 
 ## Agent workflow
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -157,14 +157,29 @@ deletes the generated files from disk when the run finishes (`cleanGenerated`), 
 always matches a fresh clone — a fresh clone builds and publishes without any pre-existing generated
 files, and no localhost/dev-baked copies are left behind after a local/dev run.
 
+## Test: unit tests (`pnpm test`)
+
+Fast, pure-Node unit tests (no build, no network) live in `tools/test/unit/` and run identically
+locally and in CI:
+
+```bash
+pnpm test
+```
+
+Coverage: `createZip.mjs` (flat vs fx-folder layout, extraFiles), `generateUpdaterConfig.mjs` (URLs
+per mode, LOCAL flag, dev/local overrides), `hashUtils.mjs` (directory/file-set hashing, gitignore
+filtering, sorting), and `embed.mjs` (generated C header via `--stdout`).
+
 ## Test: installer hash verification
 
 A cross-platform Node.js test verifies that the C installer's hash computation matches the
-JavaScript reference in `tools/publish/hashUtils.mjs`:
+JavaScript reference in `tools/publish/hashUtils.mjs`. It uses the newest `prod-` or `dev-` snapshot
+under `dist/` (generating a prod one via `upload:local --mode=prod` when none exists), so it can run
+right after a `--mode=dev` build without a second compile:
 
 ```bash
-cd installer && make dist_linux
-node installer/test/test_hash.mjs
+pnpm upload:local --mode=dev
+pnpm test:hash
 ```
 
 Exit code 0 means every package's JS hash matches the C binary's (computed with `--test-hash`).
@@ -174,13 +189,15 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
 `.github/workflows/ci.yml` runs on every PR and on `main` pushes:
 
 - **checks** (Linux) — `pnpm lint` (ESLint incl. `eslint-plugin-security`, clang-format,
-  `gcc -fanalyzer`) and `pnpm format`.
+  `gcc -fanalyzer`), `pnpm format`, and `pnpm test` (unit tests).
 - **publish gate** (Windows / Linux / macOS) — `pnpm upload:local --mode=dev` rebuilds every package
   zip and the native binaries for the runner's OS, so regressions in generated files, hashes or the
   Makefile fail the PR before they reach a release.
 - **Security smoke test** (Windows) — `tools/test/smoke-security.mjs` launches the built installer
   headless and verifies every state-changing `/api` route rejects a missing/wrong session token,
   valid tokens pass the gate, and no response carries `Access-Control-Allow-Origin`.
+- **Hash parity** (Windows) — `pnpm test:hash` verifies the JS and C installer hashes match, using
+  the dev snapshot built by the publish gate (no second build).
 
 Run the smoke test locally (Windows, from the repo root):
 

--- a/installer/test/test_hash.mjs
+++ b/installer/test/test_hash.mjs
@@ -9,10 +9,11 @@
  *
  * If no directories are given, defaults to: core/chrome/utils core/fx-folder
  *
- * The canonical `files` list per package comes from the newest prod-*
- * snapshot's manifest (dist/prod-<branch>-<hash>/hashes.json). If none exists
- * it is generated via `upload:local --mode=prod` (which writes one without
- * touching GitHub), so the test always reflects the current source set.
+ * The canonical `files` list per package comes from the newest snapshot's
+ * manifest (dist/prod-<branch>-<hash>/ or dist/dev-<branch>-<hash>/hashes.json,
+ * either mode works — the file set is identical). If none exists it is
+ * generated via `upload:local --mode=prod` (which writes one without touching
+ * GitHub), so the test always reflects the current source set.
  *
  * This test does NOT depend on @octokit/rest (only available in the publish
  * environment). It replicates the core hash algorithm inline.
@@ -49,14 +50,14 @@ function computeDirectoryHash(dirPath, relFiles) {
   return hash.digest('hex');
 }
 
-/** Newest prod-* snapshot dir (dist/prod-<branch>-<hash>/) with a manifest. */
+/** Newest prod- or dev- snapshot dir with a manifest (either mode works). */
 function findSnapshot() {
   const distRoot = path.join(REPO_ROOT, 'dist');
   if (!fs.existsSync(distRoot)) return null;
   let best = null;
   let bestMtime = 0;
   for (const entry of fs.readdirSync(distRoot, {withFileTypes: true})) {
-    if (!entry.isDirectory() || !entry.name.startsWith('prod-')) continue;
+    if (!entry.isDirectory() || !/^(prod|dev)-/.test(entry.name)) continue;
     const dir = path.join(distRoot, entry.name);
     if (!fs.existsSync(path.join(dir, 'hashes.json'))) continue;
     const mtime = fs.statSync(dir).mtimeMs;
@@ -92,7 +93,11 @@ function getInstallerPath(snapshotDir) {
   if (process.platform === 'win32') name = 'installer_win';
   else if (process.platform === 'darwin') name = 'installer_mac';
   else name = 'installer_linux';
-  return path.join(snapshotDir, `${name}${ext}`);
+  // Dev snapshots name binaries installer_win-dev.exe; prod keeps the plain
+  // name.  Accept either so a dev snapshot from CI's publish gate works.
+  const plain = path.join(snapshotDir, `${name}${ext}`);
+  if (fs.existsSync(plain)) return plain;
+  return path.join(snapshotDir, `${name}-dev${ext}`);
 }
 
 /** Read the canonical `files` list for a package from the snapshot manifest. */

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "lint:c": "node tools/format-c.mjs --check",
     "format": "node tools/format-c.mjs --check && prettier --config ./config/prettier.config.js --ignore-path ./config/.prettierignore . --check",
     "format:fix": "node tools/format-c.mjs --write && prettier --config ./config/prettier.config.js --ignore-path ./config/.prettierignore . --write",
+    "test": "node --test \"tools/test/unit/*.test.mjs\"",
+    "test:hash": "node installer/test/test_hash.mjs",
     "upload": "node --env-file-if-exists=.env tools/publish/upload.mjs",
     "upload:local": "node tools/publish/upload.mjs --local"
   },

--- a/tools/test/unit/config-probe.mjs
+++ b/tools/test/unit/config-probe.mjs
@@ -1,0 +1,17 @@
+// tools/test/unit/config-probe.mjs — Print the generated updater-config module
+// for the argv this process was started with (--mode=prod|dev, --local), so the
+// unit test can verify per-mode URLs/flags by spawning child processes.
+
+import {
+  readConfig,
+  generateModule,
+  effectiveConfig,
+} from '../../../tools/publish/generateUpdaterConfig.mjs';
+
+const config = readConfig();
+process.stdout.write(
+  JSON.stringify({
+    module: generateModule(config),
+    effective: effectiveConfig(config),
+  })
+);

--- a/tools/test/unit/createZip.test.mjs
+++ b/tools/test/unit/createZip.test.mjs
@@ -1,0 +1,100 @@
+// tools/test/unit/createZip.test.mjs — Unit tests for tools/publish/createZip.mjs
+//
+// createZip.mjs imports paths.js, which calls requireMode() at import time, so
+// the test pushes --mode=prod into process.argv before the dynamic import.
+//
+// Importing createZip.mjs also regenerates the gitignored generated files
+// (updater-config.sys.mjs, updater.css) — a no-op write when they are already
+// in sync, and they are gitignored either way.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+process.argv.push('--mode=prod');
+
+const {createZip, loadAllGitignorePatterns, zipPrefixFor} =
+  await import('../../../tools/publish/createZip.mjs');
+import {listZipEntries, readZipEntry} from './zipReader.mjs';
+
+/** Make a temp source tree with a fixed set of files. */
+function makeSourceTree(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'createzip-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const p = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(p), {recursive: true});
+    fs.writeFileSync(p, content);
+  }
+  return dir;
+}
+
+test('zipPrefixFor: fx-folder is nested, utils/updater-ui are flat', () => {
+  assert.equal(zipPrefixFor('fx-folder'), 'fx-folder');
+  assert.equal(zipPrefixFor('utils'), null);
+  assert.equal(zipPrefixFor('updater-ui'), null);
+});
+
+test('createZip: flat layout for utils-style packages', async () => {
+  const src = makeSourceTree({
+    'foo.js': 'console.log(1);',
+    'sub/bar.js': 'console.log(2);',
+    'README.md': '# readme',
+  });
+  const out = path.join(os.tmpdir(), `out-${Date.now()}.zip`);
+  try {
+    const patterns = loadAllGitignorePatterns(src);
+    await createZip(src, out, patterns);
+    const buf = fs.readFileSync(out);
+    const names = listZipEntries(buf)
+      .map(e => e.name)
+      .sort();
+    assert.deepEqual(names, ['README.md', 'foo.js', 'sub/bar.js']);
+    const foo = listZipEntries(buf).find(e => e.name === 'foo.js');
+    assert.equal(readZipEntry(buf, foo).toString(), 'console.log(1);');
+  } finally {
+    fs.rmSync(src, {recursive: true, force: true});
+    fs.rmSync(out, {force: true});
+  }
+});
+
+test('createZip: fx-folder package wraps entries under a top-level folder', async () => {
+  const src = makeSourceTree({
+    'user.js': '// user',
+    'chrome/fx.js': '// chrome',
+  });
+  const out = path.join(os.tmpdir(), `out-${Date.now()}.zip`);
+  try {
+    const patterns = loadAllGitignorePatterns(src);
+    await createZip(src, out, patterns, 'fx-folder');
+    const names = listZipEntries(fs.readFileSync(out))
+      .map(e => e.name)
+      .sort();
+    assert.deepEqual(names, ['fx-folder/chrome/fx.js', 'fx-folder/user.js']);
+  } finally {
+    fs.rmSync(src, {recursive: true, force: true});
+    fs.rmSync(out, {force: true});
+  }
+});
+
+test('createZip: extraFiles are added back after gitignore filtering', async () => {
+  const src = makeSourceTree({
+    'keep.js': '// keep',
+    'skip.tmp': '// should be ignored',
+  });
+  const out = path.join(os.tmpdir(), `out-${Date.now()}.zip`);
+  try {
+    // Ignore *.tmp, then re-add the file via extraFiles (like the generated
+    // updater-config.sys.mjs in the real utils package).
+    const patterns = loadAllGitignorePatterns(src, [], ['*.tmp']);
+    await createZip(src, out, patterns, null, ['skip.tmp']);
+    const names = listZipEntries(fs.readFileSync(out))
+      .map(e => e.name)
+      .sort();
+    assert.deepEqual(names, ['keep.js', 'skip.tmp']);
+  } finally {
+    fs.rmSync(src, {recursive: true, force: true});
+    fs.rmSync(out, {force: true});
+  }
+});

--- a/tools/test/unit/embed.test.mjs
+++ b/tools/test/unit/embed.test.mjs
@@ -1,0 +1,69 @@
+// tools/test/unit/embed.test.mjs — Unit tests for installer/embed.mjs.
+//
+// embed.mjs runs main() at import (it writes src/resources.h), so the tests
+// spawn it with --stdout and assert on the generated header text instead of
+// importing the module.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {spawnSync} from 'child_process';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EMBED = path.join(__dirname, '..', '..', '..', 'installer', 'embed.mjs');
+
+/** Run embed.mjs --stdout and return the generated header text. */
+function generate() {
+  const r = spawnSync(process.execPath, [EMBED, '--stdout'], {encoding: 'utf-8'});
+  assert.equal(r.status, 0, `embed.mjs failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+test('embed.mjs: emits a guarded C header', () => {
+  const out = generate();
+  assert.match(out, /#ifndef RESOURCES_H/);
+  assert.match(out, /#define RESOURCES_H/);
+  assert.match(out, /#endif \/\* RESOURCES_H \*\//);
+});
+
+test('embed.mjs: embeds every expected symbol', () => {
+  const out = generate();
+  for (const name of [
+    'RES_FAVICON_SVG',
+    'RES_INDEX_HTML_GZ',
+    'RES_STYLE_CSS_GZ',
+    'RES_SCRIPT_JS_GZ',
+    'RES_LOGO_FIREFOX_GZ',
+    'RES_LOGO_WATERFOX_GZ',
+    'RES_LOGO_ZEN_GZ',
+    'RES_LOGO_LIBREWOLF_GZ',
+    'RES_LOGO_FLOORP_GZ',
+  ]) {
+    // eslint-disable-next-line security/detect-non-literal-regexp -- names are a fixed test list
+    const re = new RegExp(`static const (char \\*|unsigned char )${name}`);
+    assert.match(out, re);
+  }
+});
+
+test('embed.mjs: text assets are escaped C strings', () => {
+  const out = generate();
+  // favicon.svg is a text asset embedded as a C string literal.
+  const m = out.match(/static const char \*RES_FAVICON_SVG =\n[ ]{4}"([\s\S]*?)";/);
+  assert.ok(m, 'RES_FAVICON_SVG string literal not found');
+  // The literal must not contain a raw newline (would break the C string).
+  assert.ok(!m[1].includes('\n'), 'raw newline inside C string literal');
+});
+
+test('embed.mjs: gzip byte arrays are non-empty and well-formed', () => {
+  const out = generate();
+  const m = out.match(/static const unsigned char RES_INDEX_HTML_GZ\[\] = \{([\s\S]*?)\};/);
+  assert.ok(m, 'RES_INDEX_HTML_GZ array not found');
+  const bytes = m[1].match(/0x[0-9a-f]{2}/g) || [];
+  assert.ok(bytes.length > 0, 'gzip array is empty');
+  for (const b of bytes) assert.match(b, /^0x[0-9a-f]{2}$/);
+});
+
+test('embed.mjs: deterministic output', () => {
+  assert.equal(generate(), generate());
+});

--- a/tools/test/unit/generateUpdaterConfig.test.mjs
+++ b/tools/test/unit/generateUpdaterConfig.test.mjs
@@ -1,0 +1,111 @@
+// tools/test/unit/generateUpdaterConfig.test.mjs — Unit tests for
+// tools/publish/generateUpdaterConfig.mjs.
+//
+// MODE/LOCAL are captured from process.argv at module load, so per-mode behavior
+// is verified by spawning child processes (config-probe.mjs) rather than
+// re-importing.  The pure helpers are tested in-process.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {spawnSync} from 'child_process';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const {
+  applyDevOverrides,
+  applyInstallerLocalOverrides,
+  applyUpdaterLocalOverrides,
+  effectiveConfig,
+  readConfig,
+} = await import('../../../tools/publish/generateUpdaterConfig.mjs');
+
+const PROBE = path.join(__dirname, 'config-probe.mjs');
+
+/** Run the probe with extra argv; returns the parsed JSON. */
+function probe(...args) {
+  const r = spawnSync(process.execPath, [PROBE, ...args], {encoding: 'utf-8'});
+  assert.equal(r.status, 0, `probe failed (${args.join(' ')}): ${r.stderr}`);
+  return JSON.parse(r.stdout);
+}
+
+const prodConfig = readConfig();
+
+test('readConfig parses installer.conf into a flat key/value map', () => {
+  assert.equal(prodConfig.REPO_OWNER, 'onemen');
+  assert.ok(prodConfig.ZIP_DOWNLOAD_REPO);
+  assert.ok(prodConfig.RELEASE_NAME);
+});
+
+test('applyDevOverrides rewrites URLs to the dev-build jsDelivr base', () => {
+  const dev = applyDevOverrides(prodConfig);
+  assert.equal(dev.RELEASE_NAME, 'dev-build');
+  assert.equal(dev.ASSET_SUFFIX, '-dev');
+  assert.match(
+    dev.ZIP_BASE_URL,
+    /^https:\/\/cdn\.jsdelivr\.net\/gh\/onemen\/firefox-scripts@dev-build-/
+  );
+  assert.equal(dev.HASHES_URL, `${dev.ZIP_BASE_URL}/hashes.json`);
+});
+
+test('applyInstallerLocalOverrides points the C installer at localhost', () => {
+  const loc = applyInstallerLocalOverrides(prodConfig);
+  assert.equal(loc.ZIP_BASE_URL, `http://localhost:${prodConfig.DEFAULT_PORT || '8777'}`);
+  assert.equal(loc.HASHES_URL, `${loc.ZIP_BASE_URL}/hashes.json`);
+});
+
+test('applyUpdaterLocalOverrides points the in-browser updater at file:// URLs', () => {
+  const upd = applyUpdaterLocalOverrides();
+  assert.match(upd.ZIP_BASE_URL, /^file:\/\//);
+  assert.equal(upd.HASHES_URL, `${upd.ZIP_BASE_URL}/hashes.json`);
+});
+
+test('effectiveConfig in prod keeps installer.conf URLs', () => {
+  const eff = effectiveConfig(prodConfig);
+  assert.equal(eff.ZIP_BASE_URL, prodConfig.ZIP_BASE_URL);
+  assert.equal(eff.ASSET_SUFFIX ?? '', '');
+});
+
+test('generated module: prod mode — no dev/local flags, github URLs', () => {
+  const {module} = probe();
+  assert.match(module, /IS_DEV: false/);
+  assert.match(module, /IS_LOCAL: false/);
+  assert.match(
+    module,
+    /ZIP_BASE_URL: 'https:\/\/github\.com\/onemen\/firefox-scripts\/releases\/download\//
+  );
+  assert.doesNotMatch(module, /cdn\.jsdelivr\.net/);
+  assert.doesNotMatch(module, /localhost/);
+  assert.doesNotMatch(module, /LOCAL_DIST_PATH: '[^']+'/);
+});
+
+test('generated module: dev mode — jsDelivr URLs, IS_DEV true, -dev suffix', () => {
+  const {module} = probe('--mode=dev');
+  assert.match(module, /IS_DEV: true/);
+  assert.match(module, /IS_LOCAL: false/);
+  // Long URLs are prettier-wrapped across two lines:
+  //   ZIP_BASE_URL:\n    'https://cdn.jsdelivr.net/...'
+  assert.match(
+    module,
+    /ZIP_BASE_URL:\n\s+'https:\/\/cdn\.jsdelivr\.net\/gh\/onemen\/firefox-scripts@dev-build-/
+  );
+  assert.match(module, /ASSET_SUFFIX: '-dev'/);
+});
+
+test('generated module: prod-local — IS_LOCAL true, file:// URLs, no suffix change', () => {
+  const {module} = probe('--mode=prod', '--local');
+  assert.match(module, /IS_DEV: false/);
+  assert.match(module, /IS_LOCAL: true/);
+  assert.match(module, /ZIP_BASE_URL: 'file:\/\/\//);
+  assert.match(module, /LOCAL_DIST_PATH: '.*dist\/prod-/);
+  assert.doesNotMatch(module, /ASSET_SUFFIX: '-dev'/);
+});
+
+test('generated module: dev-local — dev suffix retained on top of file:// URLs', () => {
+  const {module} = probe('--mode=dev', '--local');
+  assert.match(module, /IS_DEV: true/);
+  assert.match(module, /IS_LOCAL: true/);
+  assert.match(module, /ZIP_BASE_URL: 'file:\/\/\//);
+  assert.match(module, /ASSET_SUFFIX: '-dev'/);
+});

--- a/tools/test/unit/generateUpdaterConfig.test.mjs
+++ b/tools/test/unit/generateUpdaterConfig.test.mjs
@@ -84,12 +84,10 @@ test('generated module: dev mode — jsDelivr URLs, IS_DEV true, -dev suffix', (
   const {module} = probe('--mode=dev');
   assert.match(module, /IS_DEV: true/);
   assert.match(module, /IS_LOCAL: false/);
-  // Long URLs are prettier-wrapped across two lines:
-  //   ZIP_BASE_URL:\n    'https://cdn.jsdelivr.net/...'
-  assert.match(
-    module,
-    /ZIP_BASE_URL:\n\s+'https:\/\/cdn\.jsdelivr\.net\/gh\/onemen\/firefox-scripts@dev-build-/
-  );
+  // The URL may be prettier-wrapped (ZIP_BASE_URL:\n    'https://...') when the
+  // dev-build branch name makes it long (local branches) or kept on one line
+  // when it is short (CI's detached HEAD).  Match the URL itself, either way.
+  assert.match(module, /https:\/\/cdn\.jsdelivr\.net\/gh\/onemen\/firefox-scripts@dev-build-/);
   assert.match(module, /ASSET_SUFFIX: '-dev'/);
 });
 
@@ -97,8 +95,8 @@ test('generated module: prod-local — IS_LOCAL true, file:// URLs, no suffix ch
   const {module} = probe('--mode=prod', '--local');
   assert.match(module, /IS_DEV: false/);
   assert.match(module, /IS_LOCAL: true/);
-  assert.match(module, /ZIP_BASE_URL: 'file:\/\/\//);
-  assert.match(module, /LOCAL_DIST_PATH: '.*dist\/prod-/);
+  assert.match(module, /file:\/\/\//);
+  assert.match(module, /dist\/prod-/);
   assert.doesNotMatch(module, /ASSET_SUFFIX: '-dev'/);
 });
 
@@ -106,6 +104,6 @@ test('generated module: dev-local — dev suffix retained on top of file:// URLs
   const {module} = probe('--mode=dev', '--local');
   assert.match(module, /IS_DEV: true/);
   assert.match(module, /IS_LOCAL: true/);
-  assert.match(module, /ZIP_BASE_URL: 'file:\/\/\//);
+  assert.match(module, /file:\/\/\//);
   assert.match(module, /ASSET_SUFFIX: '-dev'/);
 });

--- a/tools/test/unit/hashUtils.test.mjs
+++ b/tools/test/unit/hashUtils.test.mjs
@@ -1,0 +1,121 @@
+// tools/test/unit/hashUtils.test.mjs — Unit tests for tools/publish/hashUtils.mjs
+//
+// hashUtils.mjs imports paths.js, which calls requireMode() at import time, so
+// the test pushes --mode=prod into process.argv before the dynamic import.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+process.argv.push('--mode=prod');
+
+const {collectDirEntries, computeDirectoryHash, computeFileSetHash} =
+  await import('../../../tools/publish/hashUtils.mjs');
+
+function makeTree(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hashutils-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const p = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(p), {recursive: true});
+    fs.writeFileSync(p, content);
+  }
+  return dir;
+}
+
+test('computeDirectoryHash: deterministic and content-sensitive', () => {
+  const dir = makeTree({'a.js': '1', 'b.js': '2'});
+  try {
+    const h1 = computeDirectoryHash(dir, []);
+    const h2 = computeDirectoryHash(dir, []);
+    assert.equal(h1.hash, h2.hash);
+    assert.deepEqual(h1.files, ['a.js', 'b.js']); // sorted
+
+    // Toggle file order on disk — hash must not change (files are sorted).
+    fs.rmSync(path.join(dir, 'a.js'));
+    fs.writeFileSync(path.join(dir, 'a.js'), '1');
+    assert.equal(computeDirectoryHash(dir, []).hash, h1.hash);
+
+    // Content change must change the hash.
+    fs.writeFileSync(path.join(dir, 'a.js'), '1 changed');
+    assert.notEqual(computeDirectoryHash(dir, []).hash, h1.hash);
+  } finally {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+test('computeDirectoryHash: matches the reference algorithm exactly', () => {
+  const dir = makeTree({
+    'z.js': 'zzz',
+    'a/nested.txt': 'hello\nworld',
+    'b.txt': 'bbb',
+  });
+  try {
+    const {hash, files} = computeDirectoryHash(dir, []);
+    assert.deepEqual(files, ['a/nested.txt', 'b.txt', 'z.js']);
+    // Reimplement the documented algorithm independently.
+    const ref = crypto.createHash('sha256');
+    for (const rel of ['a/nested.txt', 'b.txt', 'z.js']) {
+      ref.update(rel + '\n');
+      ref.update(fs.readFileSync(path.join(dir, rel)));
+    }
+    assert.equal(hash, ref.digest('hex'));
+  } finally {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+test('computeDirectoryHash: gitignore patterns filter files, extraFiles re-add', () => {
+  const dir = makeTree({
+    'keep.js': 'keep',
+    'gen.tmp': 'generated',
+  });
+  try {
+    // Pattern '*.tmp' ignores the generated file, then extraFiles re-adds it
+    // (mirroring how the generated updater-config.sys.mjs ships in utils.zip).
+    const {hash, files} = computeDirectoryHash(
+      dir,
+      [{pattern: '*.tmp', isNegation: false}],
+      [{rel: 'gen.tmp', absPath: path.join(dir, 'gen.tmp')}]
+    );
+    assert.deepEqual(files, ['gen.tmp', 'keep.js']);
+
+    const without = computeDirectoryHash(dir, [{pattern: '*.tmp', isNegation: false}]);
+    assert.deepEqual(without.files, ['keep.js']);
+    assert.notEqual(hash, without.hash);
+  } finally {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+test('collectDirEntries: prefixes labels and honors excludes', () => {
+  const dir = makeTree({
+    'main.c': 'int main',
+    'web/script.js': 'js',
+    'src/resources.h': 'generated header',
+  });
+  try {
+    const entries = collectDirEntries(dir, [], 'installer', dir, ['src/resources.h']);
+    const labels = entries.map(e => e.rel).sort();
+    assert.deepEqual(labels, ['installer/main.c', 'installer/web/script.js']);
+    for (const e of entries) assert.ok(fs.existsSync(e.absPath));
+  } finally {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+test('computeFileSetHash: labeled set, order-independent', () => {
+  const dir = makeTree({'x.js': 'x', 'y.js': 'y'});
+  try {
+    const a = {rel: 'a/x.js', absPath: path.join(dir, 'x.js')};
+    const b = {rel: 'b/y.js', absPath: path.join(dir, 'y.js')};
+    const h1 = computeFileSetHash([a, b]);
+    const h2 = computeFileSetHash([b, a]); // order must not matter
+    assert.equal(h1.hash, h2.hash);
+    assert.deepEqual(h1.files, ['a/x.js', 'b/y.js']);
+  } finally {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});

--- a/tools/test/unit/zipReader.mjs
+++ b/tools/test/unit/zipReader.mjs
@@ -1,0 +1,73 @@
+// tools/test/unit/zipReader.mjs — Minimal pure-Node ZIP reader used by the
+// createZip unit tests.  Parses the end-of-central-directory record and the
+// central directory to list entry names and decompress entry contents, so the
+// tests make no assumption about `unzip` being installed (cross-platform).
+
+import zlib from 'zlib';
+
+/**
+ * List the entries of a ZIP buffer: [{name, method, localOffset, compSize}].
+ *
+ * @param {Buffer} buf
+ * @returns {{
+ *   name: string;
+ *   method: number;
+ *   localOffset: number;
+ *   compSize: number;
+ * }[]}
+ */
+export function listZipEntries(buf) {
+  // End of central directory: signature 0x06054b50, within the last 64 KiB.
+  let eocd = -1;
+  const start = Math.max(0, buf.length - 65557);
+  for (let i = buf.length - 22; i >= start; i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error('no end-of-central-directory record');
+
+  const cdOffset = buf.readUInt32LE(eocd + 16);
+  const cdSize = buf.readUInt32LE(eocd + 12);
+  const entries = [];
+  let p = cdOffset;
+  const end = cdOffset + cdSize;
+  while (p < end) {
+    if (buf.readUInt32LE(p) !== 0x02014b50) throw new Error('bad central directory signature');
+    const method = buf.readUInt16LE(p + 10);
+    const nameLen = buf.readUInt16LE(p + 28);
+    const extraLen = buf.readUInt16LE(p + 30);
+    const commentLen = buf.readUInt16LE(p + 32);
+    const localOffset = buf.readUInt32LE(p + 42);
+    // archiver writes data-descriptor zips: the local header's sizes are zero
+    // and the real compressed size lives only in the central directory.
+    const compSize = buf.readUInt32LE(p + 20);
+    const name = buf.toString('utf8', p + 46, p + 46 + nameLen);
+    entries.push({name, method, localOffset, compSize});
+    p += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+/**
+ * Decompress one entry (by name) to its original content.
+ *
+ * @param {Buffer} buf
+ * @param {{
+ *   name: string;
+ *   method: number;
+ *   localOffset: number;
+ *   compSize: number;
+ * }} entry
+ * @returns {Buffer}
+ */
+export function readZipEntry(buf, entry) {
+  const nameLen = buf.readUInt16LE(entry.localOffset + 26);
+  const extraLen = buf.readUInt16LE(entry.localOffset + 28);
+  const dataStart = entry.localOffset + 30 + nameLen + extraLen;
+  const data = buf.subarray(dataStart, dataStart + entry.compSize);
+  if (entry.method === 8) return zlib.inflateRawSync(data); // deflate
+  if (entry.method === 0) return data; // stored
+  throw new Error(`unsupported compression method ${entry.method}`);
+}


### PR DESCRIPTION
## Phase 2 — Unit tests (`pnpm test`)

Closes the first checklist item of #1.

### What's added

- **`pnpm test`** — pure-Node unit suite in `tools/test/unit/` (no build, no network, cross-platform):
  - `createZip.test.mjs` — flat vs `fx-folder` layout, gitignore filtering + `extraFiles` re-add, zip content round-trip (via a dependency-free `zipReader.mjs`)
  - `generateUpdaterConfig.test.mjs` — prod/dev/local URL generation, `IS_DEV`/`IS_LOCAL` flags, `-dev` suffix (dev/local variants verified by spawning child processes with `--mode=... --local`)
  - `hashUtils.test.mjs` — directory/file-set hashing, determinism, sorting, gitignore filtering, reference-algorithm equivalence
  - `embed.test.mjs` — generated C header structure, all 9 symbols, gzip byte arrays, determinism
- **`pnpm test:hash`** — `test_hash.mjs` now also accepts `dev-` snapshots (and `installer_win-dev.exe`), so it runs against the CI publish gate's dev build instead of forcing a second prod compile.
- **CI**: `pnpm test` added to the checks job; `pnpm test:hash` added to the Windows publish-gate job after the build + security smoke test.
- Docs updated (`docs/DEVELOPING.md`, `AGENTS.md`).

### Local validation

- `pnpm lint` ✅ (incl. `gcc -fanalyzer`)
- `pnpm format` ✅
- `pnpm test` ✅ 23/23
- `pnpm test:hash` ✅ (JS and C hashes match for utils + fx-folder)




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a pure-Node unit-test suite and integrates it with CI, while extending installer hash parity testing to consume dev snapshots.
- Adds unit coverage for ZIP creation, updater configuration, hashing, and embedded resources.
- Runs unit tests in the Linux checks job.
- Runs JavaScript/C installer hash parity after the Windows dev build.
- Documents the new test commands and validation workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the unit suite to Linux checks and hash parity validation after the Windows dev build. |
| installer/test/test_hash.mjs | Expands snapshot discovery and installer lookup to support both production and development artifacts. |
| package.json | Adds stable entry points for the Node unit suite and installer hash-parity test. |
| tools/test/unit/createZip.test.mjs | Tests flat and nested ZIP layouts, filtering, extra-file restoration, and content round trips. |
| tools/test/unit/generateUpdaterConfig.test.mjs | Tests production, development, and local updater configuration behavior using isolated probes. |
| tools/test/unit/hashUtils.test.mjs | Tests deterministic hashing, file ordering, filtering, exclusions, and reference-algorithm equivalence. |
| tools/test/unit/embed.test.mjs | Tests generated C-header structure, expected resources, encoding, and deterministic output. |
| tools/test/unit/zipReader.mjs | Provides a dependency-free ZIP parser used solely to inspect archives produced by unit tests. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    PR[Pull request] --> Checks[Linux checks]
    Checks --> Lint[pnpm lint]
    Checks --> Format[pnpm format]
    Checks --> Unit[pnpm test]
    PR --> WinGate[Windows publish gate]
    WinGate --> DevBuild[upload:local --mode=dev]
    DevBuild --> Security[Security smoke test]
    Security --> Hash[pnpm test:hash]
    Hash --> Artifacts[Upload dist artifacts]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: make dev/local config assertions b..."](https://github.com/onemen/firefox-scripts/commit/9c3df046187a17354ad18d81df0bccd8e9896bde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55533600)</sub>

<!-- /greptile_comment -->