### PR TITLE
ci: publish release artifacts via manual Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,10 +10,13 @@ name: Pages publish
 # (enforced inside upload.mjs); dev mode publishes a disposable
 # dev-build-<branch>-<sha> branch + pre-release and never touches prod.
 #
-# The three jobs run SEQUENTIALLY on purpose: each one re-reads the hash
-# manifest the previous job just pushed, so the zips are uploaded exactly
-# once (by the first job) and every platform uploads only the binaries it
-# built. A parallel matrix would race on hashes.json / the release.
+# The three publish jobs run SEQUENTIALLY so they can never interleave
+# gh-pages commits or release-asset uploads. Change detection is anchored to
+# a shared PRE-RUN baseline (`baseline` job captures the current hashes.json;
+# every job diffs against it via FIREFOX_SCRIPTS_STORED_HASHES_FILE): the
+# installer/helper/zips hashes in the manifest are platform-independent, so
+# if each job re-read the branch after the previous job pushed, only the
+# first platform would ever rebuild after a source change.
 #
 # Pages serving stays "Deploy from branch: gh-pages" — this workflow pushes
 # to that branch; it does not use the actions-pages deployment method.
@@ -45,8 +48,35 @@ env:
   GITHUB_TOKEN_VAR: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  # Snapshot the hash manifest as it was BEFORE this run started. Every
+  # publish job diffs its sources against this same baseline, so a source
+  # change makes all three platforms rebuild their native binaries.
+  baseline:
+    name: capture pre-run hash manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch current hashes.json from gh-pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p baseline
+          if gh api "repos/${{ github.repository }}/contents/hashes.json?ref=gh-pages" \
+              --jq '.content' > /tmp/content.b64 2>/dev/null; then
+            base64 -d /tmp/content.b64 > baseline/hashes.json
+            echo "captured $(wc -c < baseline/hashes.json) bytes"
+          else
+            echo "no hashes.json on gh-pages yet — first publish starts fresh"
+            echo '{}' > baseline/hashes.json
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: baseline-hashes
+          path: baseline/hashes.json
+          if-no-files-found: error
+
   publish-win:
     name: publish — windows binaries
+    needs: baseline
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -64,11 +94,20 @@ jobs:
           update: true
           install: >-
             mingw-w64-ucrt-x86_64-gcc make
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: baseline-hashes
+          path: baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=win"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          # Prod: diff against the shared pre-run baseline, not whatever an
+          # earlier job already pushed. Dev rebuilds everything anyway.
+          if [ "${{ inputs.mode }}" = "prod" ]; then
+            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$PWD/baseline/hashes.json"
+          fi
           node tools/publish/upload.mjs $ARGS
 
   publish-linux:
@@ -84,11 +123,18 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: baseline-hashes
+          path: baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=linux"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          if [ "${{ inputs.mode }}" = "prod" ]; then
+            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$PWD/baseline/hashes.json"
+          fi
           node tools/publish/upload.mjs $ARGS
 
   publish-mac:
@@ -104,9 +150,16 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: baseline-hashes
+          path: baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=mac"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          if [ "${{ inputs.mode }}" = "prod" ]; then
+            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$PWD/baseline/hashes.json"
+          fi
           node tools/publish/upload.mjs $ARGS

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,112 @@
+name: Pages publish
+
+# Publishes the release artifacts (package zips, installer/helper binaries,
+# hash manifest) to the `latest` release + the `gh-pages` site — the same
+# `node tools/publish/upload.mjs` run that was previously executed by hand.
+#
+# Trigger is manual only (workflow_dispatch): every run touches live
+# artifacts consumed by installed browsers, so it must stay a deliberate,
+# human-initiated act. Prod mode refuses to run from any branch but main
+# (enforced inside upload.mjs); dev mode publishes a disposable
+# dev-build-<branch>-<sha> branch + pre-release and never touches prod.
+#
+# The three jobs run SEQUENTIALLY on purpose: each one re-reads the hash
+# manifest the previous job just pushed, so the zips are uploaded exactly
+# once (by the first job) and every platform uploads only the binaries it
+# built. A parallel matrix would race on hashes.json / the release.
+#
+# Pages serving stays "Deploy from branch: gh-pages" — this workflow pushes
+# to that branch; it does not use the actions-pages deployment method.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'prod = latest release + gh-pages (main only) · dev = disposable dev-build-*'
+        type: choice
+        default: 'dev'
+        options:
+          - dev
+          - prod
+      force:
+        description: 'Rebuild + re-upload even when hashes are unchanged (prod only)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write # release assets + gh-pages pushes
+
+concurrency:
+  group: pages-publish
+  cancel-in-progress: false # a publish must never be killed mid-upload
+
+env:
+  # upload.mjs reads its token from this fixed variable name.
+  GITHUB_TOKEN_VAR: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  publish-win:
+    name: publish — windows binaries
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Set up MSYS2 toolchain (make + gcc)
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc make
+      - run: pnpm install --frozen-lockfile
+      - shell: bash
+        run: |
+          ARGS="--mode=${{ inputs.mode }} --platform=win"
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          node tools/publish/upload.mjs $ARGS
+
+  publish-linux:
+    name: publish — linux binaries
+    needs: publish-win
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - shell: bash
+        run: |
+          ARGS="--mode=${{ inputs.mode }} --platform=linux"
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          node tools/publish/upload.mjs $ARGS
+
+  publish-mac:
+    name: publish — mac binaries
+    needs: publish-linux
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - shell: bash
+        run: |
+          ARGS="--mode=${{ inputs.mode }} --platform=mac"
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          node tools/publish/upload.mjs $ARGS

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -341,6 +341,18 @@ The same run compiles the installer and helper binaries when their source (`inst
 - By default it builds only the current OS. Use `--ci` to cover all three platforms, or
   `--platform=win|linux|mac` for an explicit set (each platform needs its own build machine).
 
+### Run from CI
+
+`.github/workflows/pages.yml` publishes via GitHub Actions: a manual `workflow_dispatch` (Actions →
+Pages publish → Run workflow) with a `mode` (prod/dev) and an optional `force` input. It runs the
+**same** `node tools/publish/upload.mjs` as the local commands above — no separate publish logic —
+once per OS (`--platform=win|linux|mac`) in three sequential jobs, so all three installer/helper
+platforms get built on their native toolchains. The jobs are serial by design: each re-reads the
+hash manifest the previous job pushed, so zips upload exactly once and each platform uploads only
+what it built. Prod dispatches must target `main` (enforced inside `upload.mjs`); dev dispatches
+work from any branch. Pages serving stays "Deploy from branch: `gh-pages`" — the workflow pushes to
+that branch, it does not switch Pages to the actions deployment method.
+
 ### Build outputs
 
 All build artifacts land in a single gitignored `dist/` tree at the repo root:

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -357,6 +357,10 @@ platform would rebuild after a source change. Prod dispatches must target `main`
 `gh-pages`" — the workflow pushes to that branch, it does not switch Pages to the actions deployment
 method.
 
+Every publish also pushes a generated `README.md` (see `pagesReadme()` in
+`tools/publish/uploadToPages.mjs`) to the branch root: GitHub's Jekyll build renders it as the site
+index, so the artifact-only branch still has a landing page linking downloads and docs.
+
 ### Build outputs
 
 All build artifacts land in a single gitignored `dist/` tree at the repo root:

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -347,11 +347,15 @@ The same run compiles the installer and helper binaries when their source (`inst
 Pages publish → Run workflow) with a `mode` (prod/dev) and an optional `force` input. It runs the
 **same** `node tools/publish/upload.mjs` as the local commands above — no separate publish logic —
 once per OS (`--platform=win|linux|mac`) in three sequential jobs, so all three installer/helper
-platforms get built on their native toolchains. The jobs are serial by design: each re-reads the
-hash manifest the previous job pushed, so zips upload exactly once and each platform uploads only
-what it built. Prod dispatches must target `main` (enforced inside `upload.mjs`); dev dispatches
-work from any branch. Pages serving stays "Deploy from branch: `gh-pages`" — the workflow pushes to
-that branch, it does not switch Pages to the actions deployment method.
+platforms get built on their native toolchains. The jobs are serial so gh-pages commits and
+release-asset uploads can never interleave; change detection is anchored to a shared **pre-run
+baseline**: a first job captures the current `hashes.json` and every publish job diffs against it
+(via `FIREFOX_SCRIPTS_STORED_HASHES_FILE`) instead of the manifest an earlier sibling just pushed —
+the package hashes in the manifest are platform-independent, so without the baseline only the first
+platform would rebuild after a source change. Prod dispatches must target `main` (enforced inside
+`upload.mjs`); dev dispatches work from any branch. Pages serving stays "Deploy from branch:
+`gh-pages`" — the workflow pushes to that branch, it does not switch Pages to the actions deployment
+method.
 
 ### Build outputs
 

--- a/tools/publish/hashUtils.mjs
+++ b/tools/publish/hashUtils.mjs
@@ -177,8 +177,23 @@ function readLocalSnapshot() {
  *   in a real run means "fresh" — publish everything. Default is `false`
  */
 export async function getStoredHashes({localOnly = false} = {}) {
-  const remote = localOnly ? null : await readFromPages();
-  const text = remote ?? (localOnly ? readLocalSnapshot() : null);
+  let text;
+  // Explicit manifest override (env): CI publishes run one upload per OS as
+  // sequential jobs, and an earlier job's push would otherwise make later
+  // jobs diff against the just-updated manifest and skip their platform's
+  // binaries. All jobs must diff against the same pre-run baseline instead.
+  const overrideFile = process.env.FIREFOX_SCRIPTS_STORED_HASHES_FILE;
+  if (overrideFile) {
+    try {
+      text = fs.readFileSync(overrideFile, 'utf-8');
+    } catch {
+      warn(`stored-hashes override not readable: ${overrideFile}, starting fresh`);
+      return {};
+    }
+  } else {
+    const remote = localOnly ? null : await readFromPages();
+    text = remote ?? (localOnly ? readLocalSnapshot() : null);
+  }
   if (text == null) return {};
   try {
     return JSON.parse(text);

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -74,7 +74,7 @@ import {
   loadSharedPatterns,
   REPO_ROOT,
 } from './publishCommon.mjs';
-import {uploadFilesToPages} from './uploadToPages.mjs';
+import {pagesReadme, uploadFilesToPages} from './uploadToPages.mjs';
 import {
   bold,
   detail,
@@ -443,6 +443,9 @@ async function publishToGitHub({
   // each blob, so unchanged files are skipped and an idle run creates no
   // commit at all.
   const pagesFiles = {};
+  // Landing page for the Pages site root (rendered from README.md by the
+  // Jekyll build). Content-addressed downstream: skipped when unchanged.
+  pagesFiles['README.md'] = pagesReadme();
 
   if (PUBLISH_MODE === 'dev') {
     for (const name of builtZips) pagesFiles[zipFileName(name)] = fs.readFileSync(zipPath(name));

--- a/tools/publish/uploadToPages.mjs
+++ b/tools/publish/uploadToPages.mjs
@@ -22,6 +22,47 @@ function gitBlobSha(buf) {
 }
 
 /**
+ * Landing page for the Pages site: the branch carries only binary artifacts and
+ * hashes.json, so without this the site root would be a 404. GitHub's Jekyll
+ * build renders a branch README.md as the index page when no index.html exists
+ * — which is also why the branch must NOT get a .nojekyll. Content-addressed
+ * like every other pushed file: unchanged content is skipped, so idle runs
+ * create no commit for it.
+ */
+export function pagesReadme() {
+  const repoUrl = `https://github.com/${REPO_OWNER}/${ZIP_PAGES_REPO}`;
+  return Buffer.from(
+    [
+      '# firefox-scripts',
+      '',
+      'Helper scripts that let Firefox-family browsers run legacy',
+      '(non-WebExtension) extensions.',
+      '',
+      '> **🚧 Under active development** — expect breaking changes.',
+      '',
+      '## Downloads',
+      '',
+      'Installers for Windows, Linux and macOS are attached to the',
+      `[latest release](${repoUrl}/releases/latest).`,
+      '',
+      'Packages fetched by the installer UI (also on this site):',
+      '',
+      '- [`fx-folder.zip`](fx-folder.zip) — browser config package',
+      '- [`utils.zip`](utils.zip) — chrome scripts + updater',
+      '- [`hashes.json`](hashes.json) — integrity manifest',
+      '',
+      '## Documentation',
+      '',
+      `- [Development guide](${repoUrl}/blob/main/docs/DEVELOPING.md)`,
+      `- [Auto-updater design](${repoUrl}/blob/main/docs/auto-updater.md)`,
+      `- [Contributing](${repoUrl}/blob/main/CONTRIBUTING.md)`,
+      '',
+    ].join('\n'),
+    'utf-8'
+  );
+}
+
+/**
  * Ensure the Pages branch ref exists, creating it from the default branch if
  * needed.
  */

--- a/tools/test/unit/hashUtils.test.mjs
+++ b/tools/test/unit/hashUtils.test.mjs
@@ -12,7 +12,7 @@ import path from 'path';
 
 process.argv.push('--mode=prod');
 
-const {collectDirEntries, computeDirectoryHash, computeFileSetHash} =
+const {collectDirEntries, computeDirectoryHash, computeFileSetHash, getStoredHashes} =
   await import('../../../tools/publish/hashUtils.mjs');
 
 function makeTree(files) {
@@ -117,5 +117,38 @@ test('computeFileSetHash: labeled set, order-independent', () => {
     assert.deepEqual(h1.files, ['a/x.js', 'b/y.js']);
   } finally {
     fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+test('getStoredHashes: env override reads a local manifest instead of the network', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hashutils-override-'));
+  const file = path.join(dir, 'hashes.json');
+  try {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({utils: {hash: 'abc', files: ['a.js']}, installer: {hash: 'def'}})
+    );
+    process.env.FIREFOX_SCRIPTS_STORED_HASHES_FILE = file;
+    try {
+      // localOnly=false would hit the network without the override; with it
+      // the file wins and no fetch happens.
+      assert.deepEqual(await getStoredHashes({localOnly: false}), {
+        utils: {hash: 'abc', files: ['a.js']},
+        installer: {hash: 'def'},
+      });
+    } finally {
+      delete process.env.FIREFOX_SCRIPTS_STORED_HASHES_FILE;
+    }
+  } finally {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+test('getStoredHashes: unreadable env override starts fresh', async () => {
+  process.env.FIREFOX_SCRIPTS_STORED_HASHES_FILE = path.join(os.tmpdir(), 'does-not-exist.json');
+  try {
+    assert.deepEqual(await getStoredHashes({localOnly: false}), {});
+  } finally {
+    delete process.env.FIREFOX_SCRIPTS_STORED_HASHES_FILE;
   }
 });

--- a/tools/test/unit/pagesReadme.test.mjs
+++ b/tools/test/unit/pagesReadme.test.mjs
@@ -1,0 +1,29 @@
+// tools/test/unit/pagesReadme.test.mjs — Tests for the generated Pages-site
+// README (tools/publish/uploadToPages.mjs).
+//
+// uploadToPages.mjs imports paths.js, which calls requireMode() at import
+// time, so the test pushes --mode=prod into process.argv before the dynamic
+// import.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+
+process.argv.push('--mode=prod');
+
+const {pagesReadme} = await import('../../../tools/publish/uploadToPages.mjs');
+
+test('pagesReadme: renders the landing-page contract', () => {
+  const md = pagesReadme().toString('utf-8');
+  // Jekyll renders README.md as the site index; these are the lines a
+  // visitor (and the repo owner) rely on.
+  assert.match(md, /^# firefox-scripts$/m);
+  assert.match(md, /Under active development/);
+  assert.match(md, /\[`utils\.zip`\]\(utils\.zip\)/);
+  assert.match(md, /\[`fx-folder\.zip`\]\(fx-folder\.zip\)/);
+  assert.match(md, /\[`hashes\.json`\]\(hashes\.json\)/);
+  assert.match(md, /releases\/latest/);
+});
+
+test('pagesReadme: deterministic so unchanged runs push no commit', () => {
+  assert.deepEqual(pagesReadme().toString('utf-8'), pagesReadme().toString('utf-8'));
+});


### PR DESCRIPTION
## What

Adds `.github/workflows/pages.yml`: manual (`workflow_dispatch`) publishing of the release artifacts — package zips, installer/helper binaries for all three OSes, hash manifest — using the **existing** `node tools/publish/upload.mjs`. No publish logic is duplicated; the workflow is setup steps (copied from ci.yml) plus one upload command per OS.

## Why this trigger

- `workflow_dispatch` mirrors today's deliberate manual `pnpm upload`; every run touches live artifacts consumed by installed browsers, so it stays human-initiated.
- Tags don't fit: the project ships a rolling `latest` release with no version scheme.
- Commit-message triggers are fragile/invisible; auto-publish on push to main has no human gate.
- Prod safety is unchanged: `upload.mjs` still refuses prod from any branch but `main`.

## Design notes

- Three sequential jobs (`win -> linux -> mac`, `--platform=` each): each job re-reads the hash manifest the previous one pushed, so zips upload exactly once and each platform uploads only what it built. Parallel would race on `hashes.json`/release assets.
- `concurrency: pages-publish` prevents interleaved runs.
- Explicit `permissions: contents: write`; token = default `GITHUB_TOKEN` mapped into `upload.mjs`'s fixed `GITHUB_TOKEN_VAR`.
- **No Pages settings change**: serving stays "Deploy from branch: gh-pages"; the workflow pushes to that branch like the manual runs did.

Inputs: `mode` (default `dev`), `force`.

Docs: new "Run from CI" subsection in `docs/DEVELOPING.md` § Publishing a release.

## Test plan

`workflow_dispatch` only registers once merged (404s from non-default branches), so after merge:

1. Dispatch `mode=dev` from main → verify disposable `dev-build-main-<sha>` branch + pre-release with `-dev` zips and all three installers → delete both.
2. Dispatch `mode=prod` → verify `latest` gains installer_win/linux/mac assets, gh-pages gets helpers + updated `hashes.json`.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a manually dispatched, serialized multi-platform publishing workflow and supporting shared-baseline hash handling.
- Captures the pre-run `hashes.json` once and supplies it to all three native publish jobs.
- Publishes Windows, Linux, and macOS artifacts sequentially to avoid concurrent release and Pages updates.
- Adds a generated Pages landing page, documentation, and unit coverage for the new behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The shared pre-run hash baseline ensures that all three native jobs rebuild changed installer and helper sources, so the previously reported cross-platform publication failure no longer remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/pages.yml | Adds the manual serialized publishing workflow and fixes the previously reported cross-platform skip by giving every production job the same pre-run hash baseline. |
| tools/publish/hashUtils.mjs | Adds local-manifest override support so sequential CI jobs perform change detection against the captured baseline. |
| tools/publish/upload.mjs | Adds the generated Pages README to each content-addressed publication without changing artifact selection. |
| tools/publish/uploadToPages.mjs | Generates a deterministic landing-page README for the artifact branch. |
| tools/test/unit/hashUtils.test.mjs | Covers readable and missing stored-hash override files. |
| tools/test/unit/pagesReadme.test.mjs | Covers the landing page’s links, content, and deterministic generation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor Maintainer
    participant Baseline as Baseline job
    participant Win as Windows publish
    participant Linux as Linux publish
    participant Mac as macOS publish
    participant GitHub as Release and gh-pages
    Maintainer->>Baseline: Dispatch dev or prod workflow
    Baseline->>GitHub: Read pre-run hashes.json
    Baseline-->>Win: baseline-hashes artifact
    Win->>GitHub: Publish Windows artifacts and manifest
    Win-->>Linux: Continue after success
    Baseline-->>Linux: Same baseline-hashes artifact
    Linux->>GitHub: Publish Linux artifacts and manifest
    Linux-->>Mac: Continue after success
    Baseline-->>Mac: Same baseline-hashes artifact
    Mac->>GitHub: Publish macOS artifacts and manifest
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(publish): generate a landing page f..."](https://github.com/onemen/firefox-scripts/commit/8984a18855cdd8e46c89e78bffd2bec027ea739f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55884548)</sub>

<!-- /greptile_comment -->