### PR TITLE
ci: keep baseline artifact outside the worktree

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes
-          path: baseline/
+          path: ${{ runner.temp }}/baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
@@ -106,7 +106,7 @@ jobs:
           # Prod: diff against the shared pre-run baseline, not whatever an
           # earlier job already pushed. Dev rebuilds everything anyway.
           if [ "${{ inputs.mode }}" = "prod" ]; then
-            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$PWD/baseline/hashes.json"
+            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$RUNNER_TEMP/baseline/hashes.json"
           fi
           node tools/publish/upload.mjs $ARGS
 
@@ -126,14 +126,14 @@ jobs:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes
-          path: baseline/
+          path: ${{ runner.temp }}/baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=linux"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
           if [ "${{ inputs.mode }}" = "prod" ]; then
-            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$PWD/baseline/hashes.json"
+            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$RUNNER_TEMP/baseline/hashes.json"
           fi
           node tools/publish/upload.mjs $ARGS
 
@@ -153,13 +153,13 @@ jobs:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes
-          path: baseline/
+          path: ${{ runner.temp }}/baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=mac"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
           if [ "${{ inputs.mode }}" = "prod" ]; then
-            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$PWD/baseline/hashes.json"
+            export FIREFOX_SCRIPTS_STORED_HASHES_FILE="$RUNNER_TEMP/baseline/hashes.json"
           fi
           node tools/publish/upload.mjs $ARGS


### PR DESCRIPTION
Follow-up to #15. `upload.mjs` refuses dirty trees; the downloaded `baseline/hashes.json` artifact sat untracked in the repo root (`?? baseline/`) and failed every publish job on the first dev dispatch ([run](https://github.com/onemen/firefox-scripts/actions/runs/32594831601)). Park it in `RUNNER_TEMP` instead.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the downloaded baseline hash artifact outside the checked-out repository so the publish script continues to see a clean worktree.
- Downloads `baseline/hashes.json` beneath `runner.temp` on Windows, Linux, and macOS.
- Passes the corresponding `$RUNNER_TEMP/baseline/hashes.json` path to production publish runs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The artifact download destination and the path supplied to the publishing script remain aligned across the Windows, Linux, and macOS jobs while keeping the artifact outside the worktree.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/pages.yml | Consistently relocates the baseline artifact and its configured read path to the runner temporary directory across all three publish jobs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: keep baseline artifact outside the w..."](https://github.com/onemen/firefox-scripts/commit/ff9af875b3c8491b5a1c66f095c5ddc09a4cb5af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55896781)</sub>

<!-- /greptile_comment -->