### PR TITLE
fix(publish): drop trailing dot from linux/mac binary asset names

### DIFF
--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -174,8 +174,12 @@ const VALID_PLATFORMS = new Set(Object.keys(PLATFORM));
 
 const zipFileName = name => `${name}${ASSET_SUFFIX}.zip`;
 const zipPath = name => path.join(SCRIPTS_DIST, zipFileName(name));
-const installerAssetName = p => `installer_${p}${ASSET_SUFFIX}.${PLATFORM[p].ext}`;
-const helperAssetName = p => `helper_${p}${ASSET_SUFFIX}.${PLATFORM[p].ext}`;
+// linux/mac binaries have no extension (Makefile: `installer_linux$(ASSET_SUFFIX)`);
+// only win carries `.exe` — no trailing dot for the others.
+const withExt = (base, p) =>
+  `${base}${ASSET_SUFFIX}${PLATFORM[p].ext ? `.${PLATFORM[p].ext}` : ''}`;
+const installerAssetName = p => withExt(`installer_${p}`, p);
+const helperAssetName = p => withExt(`helper_${p}`, p);
 const installerPath = p => path.join(INSTALLER_DIST, installerAssetName(p));
 const helperPath = p => path.join(INSTALLER_DIST, helperAssetName(p));
 


### PR DESCRIPTION
Latent bug exposed by the new multi-OS publish workflow ([failed run](https://github.com/onemen/firefox-scripts/actions/runs/32595267399)): `installerAssetName`/`helperAssetName` hardcode `.` before the platform ext, so linux/mac names came out as `installer_linux-dev.` — the Makefile emits `installer_linux-dev` (no ext). Every consumer already uses extensionless names (`updater.js` HELPER_FILENAMES, installer `INSTALLER_BINARY_NAME`). Win (`.exe`) unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects Linux and macOS publish asset names by appending a period only when the platform has a nonempty extension.
- Adds a shared helper for constructing installer and helper asset names.
- Preserves Windows `.exe` names while removing the erroneous trailing dot from extensionless Linux and macOS names.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the corrected names matching both generated binaries and their consumers.

The extension is now conditionally added, preserving Windows `.exe` filenames while producing the extensionless Linux and macOS filenames emitted by the Makefile.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/publish/upload.mjs | The revised filename construction matches Makefile outputs and existing installer/updater consumer expectations across Windows, Linux, and macOS. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publish): drop trailing dot from lin..."](https://github.com/onemen/firefox-scripts/commit/a19cf890935077c53c15cb8478915ebf85d286be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55898099)</sub>

<!-- /greptile_comment -->