### PR TITLE
fix(publish): never upload updater-ui.zip as a release asset

### DIFF
--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -461,6 +461,9 @@ async function publishToGitHub({
     // Pages); installers are release-only; helpers are Pages-only.
     for (const name of builtZips) {
       pagesFiles[zipFileName(name)] = fs.readFileSync(zipPath(name));
+      // updater-ui is internal: the updater downloads and updates it from the
+      // Pages branch itself — never a release asset (mirrors the dev path).
+      if (name === 'updater-ui') continue;
       if (release) {
         await deleteExistingAsset(octokit, release.id, zipFileName(name));
         await uploadAsset(octokit, release.id, zipPath(name), zipFileName(name));


### PR DESCRIPTION
The prod path of `publishToGitHub` uploaded every built zip to the `latest` release; `updater-ui.zip` is internal (the updater fetches it from the Pages branch and self-updates), and the dev path already excluded it. Mirrors that exclusion. Also removes the stray asset from `latest` after merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents the internal `updater-ui.zip` package from being uploaded as a production GitHub release asset while continuing to publish it through the Pages branch.
- Adds the same `updater-ui` release exclusion already used by the development publishing path.
- Leaves publication behavior for all other built ZIP assets unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new guard executes only after the package has been included in Pages output and before release-asset handling, correctly preserving the updater’s distribution path while preventing the unwanted release upload.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/publish/upload.mjs | Adds a narrowly scoped guard that excludes `updater-ui` from production release uploads without removing it from Pages publication. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publish): never upload updater-ui.zi..."](https://github.com/onemen/firefox-scripts/commit/7157c76af8a9ae4994267a9d7e3177f03c4b6b81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55903157)</sub>

<!-- /greptile_comment -->