### PR TITLE
publish: serve the repository README as the Pages landing page

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -357,10 +357,11 @@ platform would rebuild after a source change. Prod dispatches must target `main`
 `gh-pages`" — the workflow pushes to that branch, it does not switch Pages to the actions deployment
 method.
 
-Every publish also pushes a generated `index.html` (see `pagesIndex()` in
-`tools/publish/uploadToPages.mjs`) to the branch root: a plain static page, because the branch
-inherits `.nojekyll` from `main` (Jekyll and its README fallback are disabled), so the artifact-only
-branch still has a landing page linking downloads and docs.
+Every publish also pushes an `index.html` to the branch root: the repository's own `README.md`,
+rendered server-side by GitHub (`pagesIndex()` in `tools/publish/uploadToPages.mjs`) and wrapped in
+a minimal shell with `github-markdown-css`. Static HTML because the branch ships `.nojekyll` (the
+legacy Jekyll build errored on this repo); fetched fresh each run, so the landing page can never
+drift from the README.
 
 ### Build outputs
 

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -447,10 +447,10 @@ async function publishToGitHub({
   // each blob, so unchanged files are skipped and an idle run creates no
   // commit at all.
   const pagesFiles = {};
-  // Landing page for the Pages site root (static index.html — the branch's
-  // .nojekyll disables the Jekyll README fallback). Content-addressed
-  // downstream: skipped when unchanged.
-  pagesFiles['index.html'] = pagesIndex();
+  // Landing page: the repo's README, rendered by GitHub and served as
+  // index.html (see pagesIndex). Content-addressed downstream: skipped when
+  // unchanged.
+  pagesFiles['index.html'] = await pagesIndex(octokit);
 
   if (PUBLISH_MODE === 'dev') {
     for (const name of builtZips) pagesFiles[zipFileName(name)] = fs.readFileSync(zipPath(name));

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -461,6 +461,9 @@ async function publishToGitHub({
     // Pages); installers are release-only; helpers are Pages-only.
     for (const name of builtZips) {
       pagesFiles[zipFileName(name)] = fs.readFileSync(zipPath(name));
+      // updater-ui is internal: the updater downloads and updates it from the
+      // Pages branch itself — never a release asset (mirrors the dev path).
+      if (name === 'updater-ui') continue;
       if (release) {
         await deleteExistingAsset(octokit, release.id, zipFileName(name));
         await uploadAsset(octokit, release.id, zipPath(name), zipFileName(name));

--- a/tools/publish/uploadToPages.mjs
+++ b/tools/publish/uploadToPages.mjs
@@ -23,17 +23,45 @@ function gitBlobSha(buf) {
 
 /**
  * Landing page for the Pages site: the branch carries only binary artifacts and
- * hashes.json, so without this the site root would be a 404. Plain static
- * index.html on purpose — the branch inherits .nojekyll from the default
- * branch, so Jekyll (and its README-as-index fallback) is disabled. The
- * branch's own README.md stays for people browsing the repo. Content-addressed
- * like every other pushed file: unchanged content is skipped, so idle runs
- * create no commit for it.
+ * hashes.json, so without this the site root would be a 404.
+ *
+ * The site serves the repository's own README.md, rendered by GitHub (the same
+ * HTML the repo page shows) — fetched fresh on every publish and wrapped in a
+ * minimal shell, so the landing page can never drift from the README. Static
+ * HTML on purpose: the branch ships .nojekyll because the legacy Jekyll build
+ * errored on this repo and left pushes undeployed. Content-addressed like every
+ * other pushed file: unchanged content is skipped, so idle runs create no
+ * commit for it.
+ *
+ * @returns {Promise<Buffer>} index.html, or a plain-text fallback when the
+ *   README cannot be fetched (the site must never 404).
  */
-export function pagesIndex() {
+export async function pagesIndex(octokit) {
   const repoUrl = `https://github.com/${REPO_OWNER}/${ZIP_PAGES_REPO}`;
-  const li = (href, label, note = '') =>
-    `    <li><a href="${href}">${label}</a>${note ? ` — ${note}` : ''}</li>`;
+  let body;
+  try {
+    const {data} = await octokit.request('GET /repos/{owner}/{repo}/readme', {
+      owner: REPO_OWNER,
+      repo: ZIP_PAGES_REPO,
+      headers: {accept: 'application/vnd.github.html+json'},
+      mediaType: {format: 'html'},
+    });
+    body = String(data);
+  } catch (error) {
+    console.log(yellow(`README fetch failed (${error.message}) — falling back to plain text.`));
+    try {
+      const {data} = await octokit.request('GET /repos/{owner}/{repo}/readme', {
+        owner: REPO_OWNER,
+        repo: ZIP_PAGES_REPO,
+        headers: {accept: 'application/vnd.github.raw+json'},
+      });
+      body = `<pre>${String(data).replace(/[&<>]/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;'})[c])}</pre>`;
+    } catch (fallbackError) {
+      throw new Error(`Failed to fetch the README for the Pages index: ${fallbackError.message}`, {
+        cause: fallbackError,
+      });
+    }
+  }
   return Buffer.from(
     [
       '<!doctype html>',
@@ -42,26 +70,18 @@ export function pagesIndex() {
       '    <meta charset="utf-8" />',
       '    <meta name="viewport" content="width=device-width, initial-scale=1" />',
       '    <title>firefox-scripts</title>',
+      '    <link',
+      '      rel="stylesheet"',
+      '      href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown.min.css"',
+      '    />',
+      '    <style>',
+      '      body { display: flex; justify-content: center; }',
+      '      .markdown-body { max-width: 980px; padding: 16px 24px; }',
+      '    </style>',
       '  </head>',
-      '  <body>',
-      '    <h1>firefox-scripts</h1>',
-      '    <p>Helper scripts that let Firefox-family browsers run legacy (non-WebExtension) extensions.</p>',
-      '    <p><strong>🚧 Under active development</strong> — expect breaking changes.</p>',
-      '    <h2>Downloads</h2>',
-      '    <p>Installers for Windows, Linux and macOS are attached to the',
-      `      <a href="${repoUrl}/releases/latest">latest release</a>.</p>`,
-      '    <p>Packages fetched by the installer UI (also on this site):</p>',
-      '    <ul>',
-      li('fx-folder.zip', 'fx-folder.zip', 'browser config package'),
-      li('utils.zip', 'utils.zip', 'chrome scripts + updater'),
-      li('hashes.json', 'hashes.json', 'integrity manifest'),
-      '    </ul>',
-      '    <h2>Documentation</h2>',
-      '    <ul>',
-      li(`${repoUrl}/blob/main/docs/DEVELOPING.md`, 'Development guide'),
-      li(`${repoUrl}/blob/main/docs/auto-updater.md`, 'Auto-updater design'),
-      li(`${repoUrl}/blob/main/CONTRIBUTING.md`, 'Contributing'),
-      '    </ul>',
+      '  <body class="markdown-body">',
+      `    <!-- Rendered from ${repoUrl}#readme -->`,
+      body,
       '  </body>',
       '</html>',
       '',

--- a/tools/test/unit/pagesIndex.test.mjs
+++ b/tools/test/unit/pagesIndex.test.mjs
@@ -12,19 +12,41 @@ process.argv.push('--mode=prod');
 
 const {pagesIndex} = await import('../../../tools/publish/uploadToPages.mjs');
 
-test('pagesIndex: renders the landing-page contract', () => {
-  const html = pagesIndex().toString('utf-8');
-  // Static index.html on purpose: the branch's .nojekyll disables Jekyll and
-  // its README-as-index fallback. These are the links a visitor relies on.
+const renderedReadme =
+  '<article class="markdown-body"><h1>firefox-scripts</h1><p>Helper scripts.</p></article>';
+const okOctokit = {
+  request: async (_route, opts) => {
+    if (opts.headers.accept === 'application/vnd.github.html+json') return {data: renderedReadme};
+    throw new Error('unexpected raw fetch');
+  },
+};
+
+test('pagesIndex: serves the GitHub-rendered README as the site index', async () => {
+  const html = (await pagesIndex(okOctokit)).toString('utf-8');
   assert.match(html, /<title>firefox-scripts<\/title>/);
-  assert.match(html, /Under active development/);
-  assert.match(html, /<a href="fx-folder\.zip">/);
-  assert.match(html, /<a href="utils\.zip">/);
-  assert.match(html, /<a href="hashes\.json">/);
-  assert.match(html, /releases\/latest/);
-  assert.match(html, /docs\/DEVELOPING\.md/);
+  assert.match(html, /github-markdown-css/);
+  assert.ok(html.includes(renderedReadme), 'rendered README body is embedded');
 });
 
-test('pagesIndex: deterministic so unchanged runs push no commit', () => {
-  assert.deepEqual(pagesIndex().toString('utf-8'), pagesIndex().toString('utf-8'));
+test('pagesIndex: falls back to escaped plain text when HTML rendering fails', async () => {
+  const flakyOctokit = {
+    request: async (_route, opts) => {
+      if (opts.headers.accept !== 'application/vnd.github.raw+json') throw new Error('boom');
+      return {data: '# readme <with> & markup'};
+    },
+  };
+  const html = (await pagesIndex(flakyOctokit)).toString('utf-8');
+  assert.match(html, /<pre># readme &lt;with&gt; &amp; markup<\/pre>/);
+});
+
+test('pagesIndex: both fetches failing is a hard error', async () => {
+  await assert.rejects(
+    () =>
+      pagesIndex({
+        request: async () => {
+          throw new Error('down');
+        },
+      }),
+    /README/
+  );
 });


### PR DESCRIPTION
The hand-written index.html from #19 was ugly and duplicated links nobody needs. Now the site serves **this repo's own README.md**, rendered by GitHub (identical markup to the repo page), wrapped in a minimal `github-markdown-css` shell.

- Fetched fresh at every publish → can never drift from the README
- Content-addressed: a commit happens only when the README actually changed
- Plain-text fallback if the HTML render fails; hard error only if the README itself is unreachable
- Still static `.nojekyll` serving — re-enabling Jekyll is not an option (it errored on this repo and silently left pushes undeployed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the hand-written Pages landing page with a freshly fetched, GitHub-rendered README and adds escaped-text fallback behavior. It also changes production release-asset selection, updates publishing documentation, and expands landing-page unit coverage.
- Fetches and embeds the repository README during each publish.
- Falls back to escaped raw Markdown if GitHub HTML rendering fails.
- Stops uploading updater-ui.zip as a production release asset.
- Updates Pages documentation and asynchronous index-generation tests.

<h3>Confidence Score: 4/5</h3>

The production publishing change should not merge until updater-ui.zip remains available from the source used by installed browser updaters.

Production now skips the updater UI during release upload, but installed updaters still request that archive from the release download URL, leaving their UI permanently stale after publication.

**Files Needing Attention:** tools/publish/upload.mjs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/publish/uploadToPages.mjs | Replaces the static landing page with asynchronously fetched GitHub-rendered README HTML and an escaped raw-text fallback. |
| tools/publish/upload.mjs | Awaits README index generation and introduces a production updater-ui release-asset omission that conflicts with the updater's configured download source. |
| tools/test/unit/pagesIndex.test.mjs | Updates tests for asynchronous rendering, escaped fallback content, and hard failure when both README requests fail. |
| docs/DEVELOPING.md | Documents the new README-backed static Pages landing page. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  P[Production publish] --> R[Fetch and render README]
  R --> G[Generate index.html]
  P --> B[Build package archives]
  B --> PG[Upload all archives to Pages]
  B --> S{Package is updater-ui?}
  S -->|No| RA[Upload release asset]
  S -->|Yes| X[Skip release upload]
  U[Installed browser updater] --> Z[Download updater-ui from release URL]
  Z --> X
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/publish/upload.mjs:466
**Release asset omission breaks updates**

When a production publish builds `updater-ui`, this branch skips uploading its archive to the release URL used by `ensureUpdaterUi`, causing installed browsers to receive a missing asset and retain a stale updater UI.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(publish): render the repository REA..."](https://github.com/onemen/firefox-scripts/commit/efe879c103d6d3f623ff8f5e3f953e4c7250a610) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55905474)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->