### PR TITLE
ci(ai): verify reviewdog checksum in Groq lane

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -45,6 +45,9 @@ jobs:
       # explicitly to post comments.
       GH_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ github.token }}
+      # Pinned sha256 of reviewdog_0.21.0_Linux_x86_64.tar.gz (from the
+      # release's checksums.txt) — verified before extraction.
+      REVIEWDOG_SHA256: ad5ce7d5ffa52aaa7ec8710a8fa764181b6cecaab843cc791e1cce1680381569
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -239,6 +242,7 @@ jobs:
             # v0.21.0+ assets are <version>_<os>_<arch>.tar.gz (earlier versions
             # shipped a bare reviewdog_linux_amd64 binary).
             curl -sSfL https://github.com/reviewdog/reviewdog/releases/download/v0.21.0/reviewdog_0.21.0_Linux_x86_64.tar.gz -o /tmp/reviewdog.tgz
+            echo "$REVIEWDOG_SHA256  /tmp/reviewdog.tgz" | sha256sum -c -
             tar -xzf /tmp/reviewdog.tgz -C /tmp
             chmod +x /tmp/reviewdog
             # rdjson input; reviewdog filters to lines present in the PR diff


### PR DESCRIPTION
## What

Ports the reviewdog **sha256 verification** from the (deferred) CodeRabbit PR into a standalone change on `main`:

- Pins `REVIEWDOG_SHA256` (from the v0.21.0 release's `checksums.txt`) in the Groq job env
- Runs `sha256sum -c` on the downloaded tarball **before** extraction

## Why

The Groq lane downloads and extracts a binary from GitHub releases with no integrity check. This is the supply-chain hardening we deferred earlier — now as its own tiny PR so it isn't blocked by the CodeRabbit CLI work.

## Notes

- Workflow-only change: `4 insertions`, 1 file. No behavior change when the checksum matches.
- actionlint passes; the sha256 was verified against the official `checksums.txt` for v0.21.0.
- PR #23 (CodeRabbit CLI in CI) remains open and deferred — this PR does **not** touch it.