### PR TITLE
fix: release bootstrap wait after load errors

### DIFF
--- a/core/chrome/utils/BootstrapLoader.js
+++ b/core/chrome/utils/BootstrapLoader.js
@@ -396,11 +396,19 @@ const BootstrapLoader = {
       // prepare for bug 1974213 Don't allow file: and jar: schemes in Services.scriptloader.loadSubScript
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1974213
       let isDone = false;
-      ChromeUtils.compileScript(uri).then(script => {
-        script.executeInGlobal(sandbox);
-        isDone = true;
-      });
+      let loadError;
+      let loadFailed = false;
+      ChromeUtils.compileScript(uri)
+        .then(script => script.executeInGlobal(sandbox))
+        .catch(error => {
+          loadError = error;
+          loadFailed = true;
+        })
+        .finally(() => {
+          isDone = true;
+        });
       Services.tm.spinEventLoopUntil('Waiting for bootstrap.js to load', () => isDone);
+      if (loadFailed) throw loadError;
     } catch (e) {
       logger.warn(`Error loading bootstrap.js for ${addon.id}`, e);
     }


### PR DESCRIPTION
## Summary

- always release the synchronous bootstrap wait when compilation or top-level execution fails
- rethrow the original rejection into the existing loader logger
- preserve falsy JavaScript rejection reasons

Fixes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bootstrap script failures.
  * Loading now completes reliably when an error occurs and reports the failure through the standard error handling flow.
  * Prevented asynchronous failures from remaining unhandled or causing loading to wait indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->