### PR TITLE
tmp: scratch PR — verify E2E gate blocks merges

### DIFF
--- a/tools/test/e2e/helpers.mjs
+++ b/tools/test/e2e/helpers.mjs
@@ -217,3 +217,9 @@ export function waitForProcessExit(child, timeoutMs) {
     });
   });
 }
+
+// TEMP scratch PR: deliberate E2E failure to verify the E2E gate branch
+// protection rule blocks merges. Remove before this PR is ever merged.
+if (process.env.CI) {
+  throw new Error('Scratch test: deliberate E2E failure — verify E2E gate blocks');
+}


### PR DESCRIPTION
**Scratch test PR — do NOT merge.**

Adds a CI-only `throw` to `tools/test/e2e/helpers.mjs` so every E2E job fails
deterministically while lint/format/unit tests still pass.

Purpose: prove the new branch-protection rule (required `E2E gate`) blocks
merging when the E2E matrix fails.