### PR TITLE
docs: port the original E2E matrix plan as historical context

### DIFF
--- a/docs/e2e-matrix-plan.md
+++ b/docs/e2e-matrix-plan.md
@@ -1,0 +1,113 @@
+# Phase 4 — E2E Test Matrix
+
+> **Historical context** — this is the original E2E plan from the `feat/e2e-orig` branch, ported
+> verbatim when the branch was retired. The live state of the E2E matrix is tracked in issue #3 and
+> `.github/workflows/e2e.yml`; the harness details below (URLs, runner setup, profile strategy) may
+> not match what CI does today.
+
+## Decision: Puppeteer-core + WebDriver BiDi
+
+**Why not Playwright?** Playwright doesn't ship Firefox nightly/dev-edition builds — it pins
+specific revisions. We need to test against the user's actual Firefox, Waterfox, Zen, LibreWolf, and
+Floorp installs. Puppeteer-core with WebDriver BiDi connects to whatever Firefox-family build is on
+the machine, which is exactly what our users run.
+
+**Why WebDriver BiDi?** Marionette (the older protocol) is deprecated in Firefox 135+ and will be
+removed. BiDi is the forward-looking protocol, already supported since Firefox 117, and it's what
+geckodriver uses by default for recent builds.
+
+## Matrix
+
+| Browser                   | OS      | Runner                 | Status                  |
+| ------------------------- | ------- | ---------------------- | ----------------------- |
+| Firefox stable            | Windows | `windows-latest`       | Hard gate               |
+| Firefox stable            | macOS   | `macos-latest`         | Hard gate               |
+| Firefox stable            | Linux   | `ubuntu-latest` (xvfb) | Hard gate               |
+| Firefox Developer Edition | Windows | `windows-latest`       | Hard gate               |
+| Firefox Developer Edition | macOS   | `macos-latest`         | Advisory (no brew cask) |
+| Firefox Developer Edition | Linux   | `ubuntu-latest` (xvfb) | Advisory                |
+| Waterfox                  | Windows | `windows-latest`       | Advisory                |
+| Waterfox                  | macOS   | `macos-latest`         | Advisory                |
+| Zen Browser               | Windows | `windows-latest`       | Advisory                |
+| LibreWolf                 | Windows | `windows-latest`       | Advisory                |
+| Floorp                    | Windows | `windows-latest`       | Advisory                |
+
+**Advisory** = `continue-on-error: true` in CI. These browsers don't have stable download URLs for
+CI, so they run manually or when available. The hard gate is Firefox stable across all three OSes +
+Firefox Developer Edition on Windows.
+
+## What each test asserts
+
+### Installer E2E
+
+1. **Binary starts** — `installer_win-dev.exe` / `installer_linux` / `installer_mac` launches and
+   the HTTP server binds to a port.
+2. **Browser detection** — at least one browser card appears with correct name + version (from
+   `application.ini`, not the path).
+3. **Install flow** — clicking Install downloads both packages, extracts them, and writes the
+   expected files (`config.js`, `config-prefs.js`, `chrome/utils/`).
+4. **Token gate** — every `/api/*` route without a valid token returns 401.
+5. **Self-update check** — `/api/self_update` with a valid token returns the expected response for
+   the current version.
+6. **Rescan** — `/api/rescan` triggers a re-detection and returns updated browser cards.
+
+### Updater E2E
+
+1. **UI loads** — `chrome://firefox-scripts/content/scriptsUpdater.xhtml` renders without spinning
+   forever (the Firefox 155 regression).
+2. **Browser name + version** — the card shows the correct name (from `application.ini` `CodeName`,
+   not the folder path) and version (including beta suffix like `154.0b10`).
+3. **Update check** — the updater contacts the remote server and shows either "Up to Date" or
+   "Update Available" with the correct package URLs.
+4. **Install update** — clicking Install downloads the new packages and copies them into the
+   profile's `chrome/utils/` directory.
+5. **Collapse/expand** — card collapse animation works, status reflects actual state.
+
+## Runner setup
+
+### Windows (`windows-latest`)
+
+- Pre-installed: Firefox stable (via `windows-firefox@latest` action or manual download).
+- Dev Edition: downloaded from
+  `https://download.mozilla.org/?product=firefox-developer-latest&os=win64`.
+- Puppeteer-core + geckodriver: installed via `pnpm install`.
+- xvfb: not needed (Windows has a display).
+
+### macOS (`macos-latest`)
+
+- Firefox stable: `brew install --cask firefox`.
+- Dev Edition: downloaded from Mozilla's DMG.
+- Puppeteer-core + geckodriver: installed via `pnpm install`.
+- Display: macOS runners have a display by default.
+
+### Linux (`ubuntu-latest`)
+
+- Firefox stable: pre-installed on the runner.
+- Dev Edition: downloaded from Mozilla's tarball.
+- Puppeteer-core + geckodriver: installed via `pnpm install`.
+- Display: `xvfb-run` wraps the Firefox launch.
+
+## Profile strategy
+
+Each test run uses a **fresh temporary profile** (created via `mktemp -d`). This avoids:
+
+- Locking the user's real profile.
+- Leftover state between runs.
+- Contamination from prior test failures.
+
+The test script:
+
+1. Copies a minimal `prefs.js` + `user.js` into the temp profile.
+2. Copies the `chrome/` tree (utils + fx-folder) that `upload:local --mode=dev` produced.
+3. Launches Firefox with `-profile <temp>`.
+4. Connects puppeteer-core via WebDriver BiDi.
+5. Navigates to the updater xhtml page.
+6. Asserts the expected behavior.
+7. Kills Firefox and cleans up.
+
+## Timeline
+
+1. **PR**: implement the hard-gate subset (Firefox stable × 3 OSes).
+2. **Follow-up PRs**: add advisory entries for Dev Edition, Waterfox, Zen, LibreWolf, Floorp as
+   CI-friendly download URLs become available.
+3. **Release gate**: all hard-gate entries must be green before v1.0 tag.


### PR DESCRIPTION
Part of the v1.0 roadmap (docs track).

Ports the Phase 4 E2E plan from the retired `feat/e2e-orig` branch into `docs/` as historical
context — the live state of the matrix is issue #3 and `.github/workflows/e2e.yml`.