### PR TITLE
docs: add roadmap snapshot and sync AGENTS.md and future-work.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ own `AGENTS.md`, that nested file is more specific and overrides this one where 
   from their sources (see the Generated files section).
 - **Do not publish or upload** unless the user explicitly asks. Use `upload:local` for offline
   validation.
+- **Never merge a PR without the user's explicit approval** — open PRs for review and wait.
 - **Never expose the GitHub token.** It lives only in an untracked root `.env` under the fixed
   `GITHUB_TOKEN_VAR` name — do not commit, log, or rename that variable.
 - **Do not introduce Python**; build and asset tooling uses Node.js.
@@ -186,6 +187,10 @@ Match the change to its validation:
 Pre-PR gates: `pnpm lint`, `pnpm format`, `pnpm test`, and the hash test. **Do not claim tests
 passed if the required toolchain or environment was unavailable.**
 
+PRs that modify `core/**` must add or extend a test where feasible; if not, the PR description must
+explain why. (The mechanical "core changed && no test changed → fail" CI gate lands together with
+the core smoke tests — see issue #30.)
+
 ## Agent workflow
 
 Before changing code:
@@ -205,6 +210,15 @@ Before finishing:
 - `docs/local_plan/` changes remain in its own repository;
 - no unrelated files were modified;
 - failed/unavailable validation is reported.
+
+### Roadmap tracking
+
+- GitHub is the live tracker: the v1.0 milestone, phase issues #3 (Phase 4) / #4 (Phase 5) and the
+  Post-v1.0 roadmap umbrella (#38) hold the checklists; `docs/roadmap.md` is the durable snapshot.
+- Every PR links its issue (`Fixes #x` / `Part of #y`); tick the checklist item when the work
+  merges.
+- Update `docs/roadmap.md` only in the PR that changes scope — never per-commit.
+- Never duplicate a checklist in both a doc and an issue: the doc links to the issues.
 
 ## Tooling
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -494,3 +494,15 @@ Edit these files to change GitHub URLs and repository owners:
 | `config/installer.conf`                            | `REPO_OWNER`, `REPO_NAME`, `ZIP_DOWNLOAD_REPO`, `ZIP_PAGES_URL`, `ZIP_PAGES_REPO`, `ZIP_PAGES_BRANCH`, `HASHES_URL`, `RELEASE_NAME`, `HELPER_BASE_URL`, `DEFAULT_PORT`, `ASSET_SUFFIX`                                   | URLs for zips / manifest / helpers (gh-pages) + releases           |
 | `tools/publish/paths.js`                           | `RELEASE_NAME`, `REPO_OWNER`, `REPO_NAME`, `ZIP_DOWNLOAD_REPO`, `ZIP_PAGES_REPO`, `ZIP_PAGES_BRANCH`, `PROFILE_PATH`, `REMOTE_UI_DIR`, `GITHUB_TOKEN_VAR` + `PUBLISH_MODE`, `DEV_BUILD_ID`, `DEV_BRANCH`, `ASSET_SUFFIX` | Publish settings + mode-derived dev values + updater-ui source dir |
 | `core/chrome/utils/updater/updater-config.sys.mjs` | `CONFIG.HASHES_URL`, `ZIP_BASE_URL`, `HELPER_BASE_URL`, `ASSET_SUFFIX` (generated from `config/installer.conf`; untracked, generated on demand)                                                                          | Auto-update URLs                                                   |
+
+## Appendix: Design decisions (no further action)
+
+These were intentionally kept and documented here for future maintainers.
+
+- `parse_manifest_files()` in the installer is strstr-based JSON parsing — fragile but sufficient; a
+  full JSON parser in C is out of scope.
+- The installer's token/restart race and the zip-derived hash fallback are accepted as-is
+  (documented in their respective code comments).
+- The updater keeps its in-memory state; only the daily check and skip prefs persist.
+- `updater-ui` has no per-package skip or status UI anywhere (installer or tab) — it is a silent
+  self-updating dependency of utils.

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -4,86 +4,80 @@ Status: **Roadmap** — items below are the remaining hardening tasks for the in
 in-browser auto-updater. The updater is implemented (see `docs/auto-updater.md` for the design); the
 hash-based status logic is in `docs/status-logic.md`.
 
-Post-v1.0 items here are tracked by the
-[Post-v1.0 roadmap](https://github.com/onemen/firefox-scripts/issues/38) umbrella issue (milestone
-"Post v1.0"); this file is the detailed backlog. See also `docs/roadmap.md`.
+Each section links to its tracking issue under the
+[Post-v1.0 umbrella (#38)](https://github.com/onemen/firefox-scripts/issues/38).
 
 ## 1. Updater end-to-end test list
 
 The updater UI is now a shipped package (`updater-ui.zip` → `chrome/utils/updater/ui`), updated by
-`scriptsUpdater.sys.mjs` (`ensureUpdaterUi`) before the tab opens. This list is tool-agnostic —
-whether it is automated with Puppeteer, Playwright, the Firefox CDP or a scripted profile is a
-separate decision.
+`scriptsUpdater.sys.mjs` (`ensureUpdaterUi`) before the tab opens. The E2E suite in
+`tools/test/e2e/` (`pnpm test:e2e`) automates the installer and updater flows on CI.
+
+> **Note:** §1.1–§1.4 describe the desired test coverage. Many are already implemented in the E2E
+> suite on `main`; the remaining gaps are tracked as individual checklist items. §1.5 (Firefox 155
+> chrome-frame probes) was moved to the
+> [Historical appendix](#historical-firefox-155-chrome-frame-probes-obsolete) — the updater no
+> longer uses iframes.
 
 ### 1.1 Detection & notification
 
-- **Hash parity:** the JS hash (`computeFilesHash`) equals the C installer's `--test-hash` output
-  and the publish scripts' hash for the same directory (see `installer/test/test_hash.mjs`).
-- **Clean install → detection:** a fresh profile reports **Not Installed**; after installing
-  utils/fx-folder/updater-ui → **Up To Date**; after touching one file → **Update Available**.
-- **Daily gate:** the tab opens at most once per day (`lastUpdateTabShown`); it does NOT open when
-  everything is current, and does NOT open when only `updater-ui` changed (self-update is silent).
-- **Decision pref:** `lastScriptsCheckDate` is set only on install / skip / "Remind me Tomorrow" /
-  restart — closing the tab without acting records nothing.
-- **Skip prefs:** `skippedHash.fx-folder` / `skippedHash.utils` suppress the pending update for that
-  exact hash and are cleared when the remote hash changes or local files match.
-- **Session restore:** a tab restored from a session (manual restart with the tab left open) re-runs
-  the real hash check and renders the truth, never a stale "All packages are up to date.".
-- **Single instance:** the scheduler and the engine both guard against a second updater tab.
+- [x] **Hash parity:** the JS hash (`computeFilesHash`) equals the C installer's `--test-hash`
+      output and the publish scripts' hash for the same directory (see
+      `installer/test/test_hash.mjs`).
+- [x] **Clean install → detection:** a fresh profile reports **Not Installed**; after installing
+      utils/fx-folder/updater-ui → **Up To Date**; after touching one file → **Update Available**.
+- [x] **Daily gate:** the tab opens at most once per day (`lastUpdateTabShown`); it does NOT open
+      when everything is current, and does NOT open when only `updater-ui` changed (self-update is
+      silent).
+- [ ] **Decision pref:** `lastScriptsCheckDate` is set only on install / skip / "Remind me Tomorrow"
+      / restart — closing the tab without acting records nothing.
+- [ ] **Skip prefs:** `skippedHash.fx-folder` / `skippedHash.utils` suppress the pending update for
+      that exact hash and are cleared when the remote hash changes or local files match.
+- [ ] **Session restore:** a tab restored from a session (manual restart with the tab left open)
+      re-runs the real hash check and renders the truth, never a stale "All packages are up to
+      date.".
+- [x] **Single instance:** the scheduler and the engine both guard against a second updater tab.
 
 ### 1.2 updater-ui self-update
 
-- **Missing UI + utils/config update:** `ensureUpdaterUi` downloads, hash-verifies and extracts
-  `updater-ui.zip` into `chrome/utils/updater/ui`, then opens the tab.
-- **Stale UI:** an installed `updater-ui` whose hash no longer matches the manifest is re-downloaded
-  before the tab opens.
-- **Missing remote package:** when `updater-ui.zip` cannot be fetched (404 / offline), the check
-  exits silently — no tab, no error UI — and the daily check retries later.
-- **Hash mismatch:** a downloaded `updater-ui.zip` that fails verification is discarded; the old UI
-  (if any) is kept.
-- **Old manifest:** a manifest without an `updater-ui` entry keeps the installed UI as-is.
+- [x] **Missing UI + utils/config update:** `ensureUpdaterUi` downloads, hash-verifies and extracts
+      `updater-ui.zip` into `chrome/utils/updater/ui`, then opens the tab.
+- [x] **Stale UI:** an installed `updater-ui` whose hash no longer matches the manifest is
+      re-downloaded before the tab opens.
+- [x] **Missing remote package:** when `updater-ui.zip` cannot be fetched (404 / offline), the check
+      exits silently — no tab, no error UI — and the daily check retries later.
+- [x] **Hash mismatch:** a downloaded `updater-ui.zip` that fails verification is discarded; the old
+      UI (if any) is kept.
+- [ ] **Old manifest:** a manifest without an `updater-ui` entry keeps the installed UI as-is.
 
 ### 1.3 Install flows (from the tab)
 
-- **Utils install:** download → extract → verify → copy into `ProfD/chrome/utils`; restart loads the
-  new files.
-- **Config install, portable install** (user-owned `GreD`): direct `IOUtils` copy, no elevation.
-- **Config install, admin install** (Windows Program Files): elevated-copy helper, exactly one UAC
-  prompt, files land in `GreD`.
-- **Elevation cancelled:** helper exit `2` → "elevation cancelled", nothing written.
-- **Zip hash mismatch:** a zip whose extracted hash differs from the manifest is rejected before any
-  copy.
-- **Failure paths:** manifest unreachable, zip download failure, helper download failure — each
-  produces a visible in-tab message, not a silent hang.
-- **Manual download:** the "configuration files" / "utils" links fetch the zip and serve it via a
-  blob URL without navigating the tab.
+- [x] **Utils install:** download → extract → verify → copy into `ProfD/chrome/utils`; restart loads
+      the new files.
+- [x] **Config install, portable install** (user-owned `GreD`): direct `IOUtils` copy, no elevation.
+- [x] **Config install, admin install** (Windows Program Files): elevated-copy helper, exactly one
+      UAC prompt, files land in `GreD`.
+- [x] **Elevation cancelled:** helper exit `2` → "elevation cancelled", nothing written.
+- [x] **Zip hash mismatch:** a zip whose extracted hash differs from the manifest is rejected before
+      any copy.
+- [x] **Failure paths:** manifest unreachable, zip download failure, helper download failure — each
+      produces a visible in-tab message, not a silent hang.
+- [x] **Manual download:** the "configuration files" / "utils" links fetch the zip and serve it via
+      a blob URL without navigating the tab.
 
 ### 1.4 Installer (updater-ui rides along with utils)
 
-- **utils selected:** the installer fetches + POSTs `updater-ui.zip` alongside `utils.zip` and
-  extracts it into `chrome/utils/updater/ui` — with no updater-ui checkbox or status text in the UI.
-- **updater-ui fetch failed:** the installer still installs utils/config (updater-ui is optional;
-  the updater self-heals later).
-- **utils up to date / not selected:** updater-ui is not installed (it is not a separate selectable
-  component).
-
-### 1.5 Firefox 155 chrome-frame regression (the reason for this architecture)
-
-Firefox 155 hardened frame-principal inheritance in system-principal chrome documents, which broke
-the previous hosted-iframe updater UI. The following probes all failed in 155 (see
-`docs/generated-files-decision.md`); re-run them against new Firefox versions to confirm the
-shipped-package approach is still the right call:
-
-1. `iframe` + `srcdoc` (attribute before/after append, and the `.srcdoc` property) → stays
-   `about:blank`.
-2. `iframe` + `document.write` → `SecurityError: The operation is insecure`.
-3. `iframe` + `data:` / `blob:` URL → stays `about:blank`.
-4. `iframe` + `sandbox="allow-scripts"` with srcdoc/data: → stays `about:blank`.
-5. XUL `<browser type="content">` / `<iframe type="content">` via `document.createXULElement` →
-   stays `about:blank`.
-6. No `load` event, no `securitypolicyviolation` event; `contentDocument` readable but empty.
+- [x] **utils selected:** the installer fetches + POSTs `updater-ui.zip` alongside `utils.zip` and
+      extracts it into `chrome/utils/updater/ui` — with no updater-ui checkbox or status text in the
+      UI.
+- [x] **updater-ui fetch failed:** the installer still installs utils/config (updater-ui is
+      optional; the updater self-heals later).
+- [x] **utils up to date / not selected:** updater-ui is not installed (it is not a separate
+      selectable component).
 
 ## 2. Admin-rights (UAC) flow
+
+> Tracked in [#32](https://github.com/onemen/firefox-scripts/issues/32).
 
 The config-install path (`config.js` / `config-prefs.js` → browser install dir) is the riskiest
 part: on Windows it requires elevation into `C:\Program Files\...`. Today it is only exercised
@@ -115,23 +109,21 @@ VM, or a non-elevated user running against an admin-owned install dir. The autom
 
 ## 3. Publish pipeline tasks
 
-- [x] Compile + upload the installer and helper binaries. `tools/publish/upload.mjs` (`pnpm upload`)
-      compiles on source change and publishes `installer_win.exe` / `installer_linux` /
-      `installer_mac` as assets of the `RELEASE_NAME` release and `helper_win.exe` / `helper_linux`
-      / `helper_mac` (+ the hash manifest) to the gh-pages branch. By default it builds only the
-      current OS — run it on each OS (or pass `--platform=win|linux|mac`) to cover all three.
-- [x] The updater tab UI is published as a third package, `updater-ui.zip` (built from
-      `tools/publish/remote-ui/` + generated `updater.css`), with a manifest `updater-ui` entry.
+> Tracked in [#33](https://github.com/onemen/firefox-scripts/issues/33).
+
 - [ ] Re-add a `.github/workflows/build-and-upload.yml` action: a Windows/Linux/macOS build matrix
       (each OS runs `upload` for its platform and stages the binaries) + one upload job that
       publishes the staged set, for fully automated cross-platform publishing.
 - [ ] Publish a `helper_<platform>.sha256` asset alongside the helper binaries and assert the
       downloaded binary matches it (see §2.2 helper-binary trust).
-- [x] `versionInfo.json` stopped shipping (createZip.mjs `CUSTOM_IGNORE_PATTERNS` + `upload.mjs`
-      `HASH_EXCLUDE`) and was deleted from the tree; the obsolete-file entry in
-      `installer/src/obsolete_files.h` now only cleans historically-installed copies.
-- [x] Zips are now published to the `firefox-scripts` repo (`ZIP_DOWNLOAD_REPO=firefox-scripts`) —
-      everything (zips, helpers, installer, manifest) is served from one place.
+
+Items below shipped in v1.0 and are kept for reference:
+
+- ~~Compile + upload the installer and helper binaries~~ (shipped: `upload.mjs` builds + uploads all
+  three platforms).
+- ~~The updater tab UI is published as a third package, `updater-ui.zip`~~ (shipped).
+- ~~`versionInfo.json` stopped shipping~~ (shipped; `obsolete_files.h` cleans existing copies).
+- ~~Zips published to the `firefox-scripts` repo~~ (shipped: `ZIP_DOWNLOAD_REPO=firefox-scripts`).
 
 ### Generated-file consistency (resolved — nothing tracked to drift)
 
@@ -144,11 +136,9 @@ sync problem is gone — there is nothing tracked that can drift (see
   the produced snapshot (hashes, zips, manifest `files` lists) differs between runs.
 - **Build matrix:** the §3 multi-platform binary build (each OS compiles its own installer/helper).
 
-The repo now ships `.github/workflows/` (`ci.yml`, `e2e.yml`, `pages.yml`, `ai-review.yml`); the §3
-publish automation below (cross-platform build-and-upload, deterministic-publish check) is not in CI
-yet — it is a post-v1.0 item (issue #33).
-
 ## 4. Installer UI polish
+
+> Tracked in [#34](https://github.com/onemen/firefox-scripts/issues/34).
 
 - [ ] Expand/collapse all controls in the browser cards.
 - [ ] Scan all profiles and binaries using cityhash for faster status (currently one SHA-256 per
@@ -157,6 +147,8 @@ yet — it is a post-v1.0 item (issue #33).
 
 ## 5. Updater UX follow-ups
 
+> Tracked in [#34](https://github.com/onemen/firefox-scripts/issues/34).
+
 - [ ] Manual-verification fallback when the elevated-copy helper download/elevation fails (show
       copy-paste instructions with the exact source/destination paths).
 - [ ] Verify the tab's per-file progress reporting and the "Restart to apply" flow in a real profile
@@ -164,12 +156,22 @@ yet — it is a post-v1.0 item (issue #33).
 - [ ] Re-verify the `skippedHash.*` clearing logic when the remote hash changes or local files
       match.
 
-## 6. Design decisions that were consciously kept (no further action)
+## Historical: Firefox 155 chrome-frame probes (obsolete)
 
-- `parse_manifest_files()` in the installer is strstr-based JSON parsing — fragile but sufficient; a
-  full JSON parser in C is out of scope.
-- The installer's token/restart race and the zip-derived hash fallback are accepted as-is
-  (documented in their respective code comments).
-- The updater keeps its in-memory state; only the daily check and skip prefs persist.
-- `updater-ui` has no per-package skip or status UI anywhere (installer or tab) — it is a silent
-  self-updating dependency of utils.
+> The updater no longer uses iframes — the UI is a shipped chrome-privileged package
+> (`updater-ui.zip`). This section is kept for architectural context on _why_ the switch was made.
+> Periodic re-validation of the chrome-document embedding model belongs under the core-test Nightly
+> leg ([#30](https://github.com/onemen/firefox-scripts/issues/30)).
+
+Firefox 155 hardened frame-principal inheritance in system-principal chrome documents, which broke
+the previous hosted-iframe updater UI. The following probes all failed in 155 (see
+`docs/generated-files-decision.md`):
+
+1. `iframe` + `srcdoc` (attribute before/after append, and the `.srcdoc` property) → stays
+   `about:blank`.
+2. `iframe` + `document.write` → `SecurityError: The operation is insecure`.
+3. `iframe` + `data:` / `blob:` URL → stays `about:blank`.
+4. `iframe` + `sandbox="allow-scripts"` with srcdoc/data: → stays `about:blank`.
+5. XUL `<browser type="content">` / `<iframe type="content">` via `document.createXULElement` →
+   stays `about:blank`.
+6. No `load` event, no `securitypolicyviolation` event; `contentDocument` readable but empty.

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -4,6 +4,10 @@ Status: **Roadmap** — items below are the remaining hardening tasks for the in
 in-browser auto-updater. The updater is implemented (see `docs/auto-updater.md` for the design); the
 hash-based status logic is in `docs/status-logic.md`.
 
+Post-v1.0 items here are tracked by the
+[Post-v1.0 roadmap](https://github.com/onemen/firefox-scripts/issues/38) umbrella issue (milestone
+"Post v1.0"); this file is the detailed backlog. See also `docs/roadmap.md`.
+
 ## 1. Updater end-to-end test list
 
 The updater UI is now a shipped package (`updater-ui.zip` → `chrome/utils/updater/ui`), updated by
@@ -140,7 +144,9 @@ sync problem is gone — there is nothing tracked that can drift (see
   the produced snapshot (hashes, zips, manifest `files` lists) differs between runs.
 - **Build matrix:** the §3 multi-platform binary build (each OS compiles its own installer/helper).
 
-There is currently **no `.github/workflows/`** in the repo, so these run locally only.
+The repo now ships `.github/workflows/` (`ci.yml`, `e2e.yml`, `pages.yml`, `ai-review.yml`); the §3
+publish automation below (cross-platform build-and-upload, deterministic-publish check) is not in CI
+yet — it is a post-v1.0 item (issue #33).
 
 ## 4. Installer UI polish
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,40 @@
+# Roadmap
+
+Durable snapshot of the release plan and how it is tracked. **The live state lives on GitHub**: the
+[v1.0](https://github.com/onemen/firefox-scripts/milestone/1) milestone, the phase issues (#3 Phase
+4 — E2E matrix, #4 Phase 5 — release gate) and the
+[Post-v1.0 roadmap](https://github.com/onemen/firefox-scripts/issues/38) umbrella (milestone "Post
+v1.0"). This file is updated only when scope changes — see AGENTS.md "Roadmap tracking".
+
+## Current: v1.0 — first public release
+
+Order matters: installer / updater / tests / CI first, core-file PRs last.
+
+- **P1-1** Port `docs/e2e-matrix-plan.md` as historical context; retire `feat/e2e-orig`.
+- **P0-1** `upload --mode=prod` moves the `latest` tag to the uploaded commit.
+- **P0-2** `pnpm dev-clean` removes old `dev-build-*` branches + tags.
+- **P0-3** E2E speed: browser download map (`tools/test/e2e/downloads.mjs`) + shorter waits.
+- **P1-2** Docs restructure (developer/maintainer vs user docs) + `future-work.md` sync.
+- **P2-1** `userChrome.js` `createElement`: `toggleAttribute` for Firefox 149+ (bug 2008041).
+- **P2-2** `BootstrapLoader`: release the spin wait on load errors (#25, PR #26 — merge pending
+  approval).
+- **Release gate (#4)** — remove README banner, v1.0 tag, milestone close, env protection for prod
+  uploads, zip-the-installer-exe decision, tag move (P0-1).
+
+Remaining Phase 4 gaps are tracked by child issues #35–#37 (Dev Edition leg, installer UI layer,
+install-applies path).
+
+## Post v1.0 (umbrella #38, milestone "Post v1.0")
+
+- Astro user-docs site + gh-pages via GitHub Actions (#28).
+- Utils flavor selection — scripts / extensions / both (#29).
+- Core code test coverage — stub smoke tests + Nightly leg + test-required rule (#30).
+- Browser-matrix expansion — Waterfox / Zen / Nightly (#31).
+- UAC/admin-rights automation (#32), publish-pipeline automation (#33), UI/UX polish (#34).
+- Detailed backlog: `docs/future-work.md`.
+
+## How to update
+
+- Prefer issues: every PR links its issue (`Fixes #x` / `Part of #y`); tick the phase/umbrella
+  checklist when the work merges.
+- Update this file only in the PR that changes scope, so it cannot rot.


### PR DESCRIPTION
Roadmap tracking setup (see the Post-v1.0 umbrella #38).

- `docs/roadmap.md` — durable plan snapshot linking the GitHub trackers (v1.0 milestone, phase
  issues #3/#4, Post-v1.0 umbrella #38).
- `AGENTS.md` — roadmap-tracking convention (PRs link issues, checklists tick on merge, snapshot
  updated only on scope change), the core-PR test rule, and the rule that no PR is merged without
  explicit owner approval.
- `docs/future-work.md` — points at the umbrella tracker; drops the stale "no workflows" claim.