### PR TITLE
perf(e2e): centralize browser downloads and shorten updater waits

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,50 +106,36 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # ── Linux: download Mozilla tarball (apt gives Snap wrapper; BiDi fails) ──
+      # The install script (tools/test/e2e/downloads.mjs) downloads the browser
+      # via its official recipe and exports FIREFOX_BINARY through $GITHUB_ENV.
       - name: Install Firefox (Linux tarball)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq xvfb
-          mkdir -p "$HOME/firefox-app"
-          for i in 1 2 3; do
-            curl -L --retry 2 -o /tmp/firefox.tar.xz \
-              "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US" && break
-            echo "Attempt $i failed, waiting..." && sleep 5
-          done
-          test -f /tmp/firefox.tar.xz || { echo 'Firefox download failed after 3 attempts'; exit 1; }
-          tar xf /tmp/firefox.tar.xz -C "$HOME/firefox-app"
-          echo "$HOME/firefox-app/firefox/firefox" > /tmp/firefox-path.txt
-          "$HOME/firefox-app/firefox/firefox" --version
+          node tools/test/e2e/downloads.mjs firefox
 
       - name: Install Firefox (macOS)
         if: matrix.os == 'macos-latest'
-        run: |
-          brew install --cask firefox
-          echo "/Applications/Firefox.app/Contents/MacOS/firefox" > /tmp/firefox-path.txt
-          "/Applications/Firefox.app/Contents/MacOS/firefox" --version
+        run: node tools/test/e2e/downloads.mjs firefox
 
       - name: Install Firefox (Windows)
         if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          choco install firefox -y --no-progress
-          echo "C:\Program Files\Mozilla Firefox\firefox.exe" > $env:TEMP\firefox-path.txt
-          & "C:\Program Files\Mozilla Firefox\firefox.exe" --version
+        run: node tools/test/e2e/downloads.mjs firefox
 
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
 
       # The test builds its own fresh temp profile from the dev snapshot, so no
-      # profile-seed step is needed. It auto-discovers the Firefox binary and
-      # the snapshot dir from the build step above.
+      # profile-seed step is needed. It reads FIREFOX_BINARY (set by the install
+      # step above) and auto-discovers the snapshot dir.
       - name: Run updater E2E (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: xvfb-run node tools/test/e2e/updater-e2e.mjs --firefox "$(cat /tmp/firefox-path.txt)"
+        run: xvfb-run node tools/test/e2e/updater-e2e.mjs
 
       - name: Run updater E2E (macOS)
         if: matrix.os == 'macos-latest'
-        run: node tools/test/e2e/updater-e2e.mjs --firefox "$(cat /tmp/firefox-path.txt)"
+        run: node tools/test/e2e/updater-e2e.mjs
 
       - name: Run updater E2E (Windows)
         if: matrix.os == 'windows-latest'
@@ -188,31 +174,11 @@ jobs:
           version: 9
       - run: pnpm install --frozen-lockfile
 
-      - name: Install ${{ matrix.browser }} (choco)
-        if: matrix.browser == 'librewolf'
-        run: choco install librewolf -y --no-progress
-
-      - name: Install ${{ matrix.browser }} (winget)
-        if: matrix.browser == 'floorp'
-        run: winget install Ablaze.Floorp --accept-package-agreements --accept-source-agreements
-
-      - name: Locate ${{ matrix.browser }} binary
-        run: |
-          # Search Program Files first (real install, not choco shim) —
-          # Get-Command may resolve the chocolatey shim, whose dir is not GreD.
-          $exe = $null
-          $dirs = @("$env:ProgramFiles", "${env:ProgramFiles(x86)}", "$env:LOCALAPPDATA")
-          foreach ($d in $dirs) {
-            $found = Get-ChildItem "$d" -Recurse -Name "${{ matrix.browser }}.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($found) { $exe = Join-Path $d $found; break }
-          }
-          # Do not use PATH shims or app-execution aliases: their parent
-          # directory is not the browser's GreD, so seeded config would be
-          # written to the wrong location. Fail clearly instead.
-          if (-not $exe) { Write-Error "Real ${{ matrix.browser }}.exe not found under an install directory"; exit 1 }
-          Write-Host "Found: $exe"
-          & $exe --version
-          "FIREFOX_BINARY=$exe" | Out-File -FilePath $env:GITHUB_ENV -Append
+      # downloads.mjs installs via the official recipe and resolves the real
+      # binary from install dirs (never a PATH shim or app-execution alias,
+      # whose parent dir is not the browser's GreD), exporting FIREFOX_BINARY.
+      - name: Install ${{ matrix.browser }}
+        run: node tools/test/e2e/downloads.mjs ${{ matrix.browser }}
 
       - name: Build snapshot
         run: pnpm upload:local --mode=dev

--- a/tools/test/e2e/browsers.mjs
+++ b/tools/test/e2e/browsers.mjs
@@ -147,7 +147,9 @@ export const BROWSERS = {
     choco: 'librewolf',
   },
   'floorp': {
-    win: ['Floorp', 'floorp.exe'],
+    // The NSIS installer (winget Ablaze.Floorp, machine scope) installs to
+    // 'C:\Program Files\Ablaze Floorp', not 'Floorp'.
+    win: ['Ablaze Floorp', 'floorp.exe'],
     mac: ['Floorp.app'],
     linux: ['floorp'],
     choco: 'floorp',
@@ -179,11 +181,12 @@ export function discoverFirefoxBinary() {
     const candidates = [];
     for (const [key, b] of Object.entries(BROWSERS)) {
       if (target && key !== target) continue;
-      const name = b.mac.replace('.app', '');
+      const [app] = b.mac; // e.g. 'Firefox.app' (b.mac is an array, like b.win)
+      const name = app.replace('.app', '');
       candidates.push(
-        `/Applications/${b.mac}/Contents/MacOS/${name.toLowerCase()}`,
-        `/Applications/${b.mac}/Contents/MacOS/${name}`,
-        `/Applications/${b.mac}/Contents/MacOS/firefox`
+        `/Applications/${app}/Contents/MacOS/${name.toLowerCase()}`,
+        `/Applications/${app}/Contents/MacOS/${name}`,
+        `/Applications/${app}/Contents/MacOS/firefox`
       );
     }
     return candidates.find(p => fs.existsSync(p)) || null;

--- a/tools/test/e2e/downloads.mjs
+++ b/tools/test/e2e/downloads.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+/**
+ * tools/test/e2e/downloads.mjs — official browser download/install map for the
+ * E2E CI matrix.
+ *
+ * The workflow (e2e.yml) used to hard-code each browser's install commands per
+ * OS; this module is the single source of truth: browser → per-OS install
+ * recipe, plus a CLI that performs the install for the current OS and exports
+ * the resolved binary path.
+ *
+ * CLI (used by e2e.yml, works locally too): node tools/test/e2e/downloads.mjs
+ * <browser> [--os win|mac|linux]
+ *
+ * On success the resolved binary path is printed to stdout and, when running
+ * inside GitHub Actions ($GITHUB_ENV set), appended to $GITHUB_ENV as
+ * FIREFOX_BINARY — the updater E2E (updater-e2e.mjs) reads that env var.
+ *
+ * Browsers without an automated recipe (manual install only) list their
+ * official download page instead; the CLI fails with a clear message.
+ */
+
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {discoverFirefoxBinary} from './browsers.mjs';
+
+/**
+ * Per-browser install recipes keyed by platform (win|mac|linux).
+ *
+ * - {manager, args} → run a package manager (choco/brew/winget), then resolve the
+ *   binary from the browser's known install dirs (see resolveBinary).
+ * - {tarball, url} → download the official tarball and extract it; returns the
+ *   binary path directly.
+ * - `manual: true` → no automated install; `page` is the official download page
+ *   (informational, for the manual legs).
+ *
+ * The E2E workflow installs only what CI needs today (firefox, librewolf,
+ * floorp); the other forks are documented here so adding a leg is a one-line
+ * change, and they have no stable unattended install.
+ */
+export const DOWNLOADS = {
+  'firefox': {
+    install: {
+      win: {manager: 'choco', args: ['install', 'firefox', '-y', '--no-progress']},
+      mac: {manager: 'brew', args: ['install', '--cask', 'firefox']},
+      // Mozilla official tarball — apt ships a Snap wrapper whose BiDi
+      // connection fails, so CI installs the tarball instead.
+      linux: {
+        tarball: 'https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US',
+      },
+    },
+  },
+  'firefox-dev': {
+    manual: true,
+    page: 'https://www.mozilla.org/firefox/developer/',
+  },
+  'waterfox': {
+    manual: true,
+    page: 'https://www.waterfox.net/download/',
+  },
+  'zen': {
+    manual: true,
+    page: 'https://zen-browser.app/download/',
+  },
+  'librewolf': {
+    install: {
+      win: {manager: 'choco', args: ['install', 'librewolf', '-y', '--no-progress']},
+    },
+  },
+  'floorp': {
+    install: {
+      win: {
+        manager: 'winget',
+        args: [
+          'install',
+          'Ablaze.Floorp',
+          '--accept-package-agreements',
+          '--accept-source-agreements',
+        ],
+      },
+    },
+  },
+};
+
+/** Map Node's process.platform to the recipe keys. */
+export function platformKey(platform = process.platform) {
+  if (platform === 'win32') return 'win';
+  if (platform === 'darwin') return 'mac';
+  return 'linux';
+}
+
+/**
+ * Resolve a browser's binary after a package-manager install, mirroring the
+ * candidate-dir search of discoverFirefoxBinary (real install dirs, never PATH
+ * shims or app-execution aliases — their parent dir is not the browser's
+ * GreD).
+ */
+export function resolveBinary(browser) {
+  const prev = process.env.RUNTIME_BROWSER;
+  process.env.RUNTIME_BROWSER = browser;
+  try {
+    return discoverFirefoxBinary();
+  } finally {
+    if (prev === undefined) delete process.env.RUNTIME_BROWSER;
+    else process.env.RUNTIME_BROWSER = prev;
+  }
+}
+
+/** Download an official Mozilla tarball and extract it; returns the binary path. */
+async function installTarball(url, browser) {
+  const dest = path.join(os.homedir(), 'firefox-app');
+  const archive = path.join(os.tmpdir(), `firefox-${browser}.tar.xz`);
+  fs.mkdirSync(dest, {recursive: true});
+
+  // Retry the download up to 3 times (transient network flakiness on CI).
+  const res = await fetchWithRetry(url, 3);
+  fs.writeFileSync(archive, Buffer.from(await res.arrayBuffer()));
+
+  // Extract next to existing content (tar xf, no strip): $HOME/firefox-app/firefox/
+  execSync(`tar xf "${archive}" -C "${dest}"`, {stdio: 'inherit'});
+  const binary = path.join(dest, 'firefox', 'firefox');
+  if (!fs.existsSync(binary)) {
+    throw new Error(`tarball extracted, but ${binary} not found`);
+  }
+  return binary;
+}
+
+async function fetchWithRetry(url, attempts) {
+  let lastErr;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+      return res;
+    } catch (err) {
+      lastErr = err;
+      console.log(`  download attempt ${i}/${attempts} failed: ${err.message}`);
+      if (i < attempts) await new Promise(r => setTimeout(r, 5000));
+    }
+  }
+  throw lastErr;
+}
+
+function runManager(manager, args) {
+  // execSync goes through the platform shell, so choco.bat / winget.exe /
+  // brew work the same on every OS.
+  execSync(`${manager} ${args.join(' ')}`, {stdio: 'inherit'});
+}
+
+/**
+ * Install a browser for a platform and return the resolved binary path.
+ *
+ * @param {string} browser
+ * @param {string} [platform] process.platform value (win32|darwin|linux)
+ * @returns {Promise<string>} absolute path to the browser binary
+ */
+export async function installBrowser(browser, platform = process.platform) {
+  const key = platformKey(platform);
+  const def = DOWNLOADS[browser];
+  if (!def) {
+    throw new Error(`Unknown browser '${browser}' (known: ${Object.keys(DOWNLOADS).join(', ')})`);
+  }
+  const recipe = def.install?.[key];
+  if (!recipe) {
+    throw new Error(
+      `${browser} has no automated install for ${key}` +
+        (def.page ? ` — manual install only (official page: ${def.page})` : '')
+    );
+  }
+  if (recipe.tarball) {
+    const binary = await installTarball(recipe.tarball, browser);
+    console.log(`  ${browser} installed from official tarball: ${binary}`);
+    return binary;
+  }
+  runManager(recipe.manager, recipe.args);
+  const binary = resolveBinary(browser);
+  if (!binary) {
+    throw new Error(
+      `${browser} installed via ${recipe.manager}, but no binary found in known install dirs`
+    );
+  }
+  return binary;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const browser = args[0];
+  if (!browser || args.includes('--help')) {
+    console.log(`Usage: node tools/test/e2e/downloads.mjs <browser> [--os win|mac|linux]
+
+Installs <browser> for the current OS (or --os) using its official download
+recipe, then prints the resolved binary path and, in GitHub Actions, sets
+FIREFOX_BINARY via $GITHUB_ENV.`);
+    process.exit(browser ? 0 : 1);
+  }
+  const osIndex = args.indexOf('--os');
+  const platform = osIndex !== -1 && args[osIndex + 1] ? args[osIndex + 1] : process.platform;
+  const normalized =
+    platform === 'win' ? 'win32'
+    : platform === 'mac' ? 'darwin'
+    : platform;
+
+  const binary = await installBrowser(browser, normalized);
+  console.log(binary);
+  if (process.env.GITHUB_ENV) {
+    fs.appendFileSync(process.env.GITHUB_ENV, `FIREFOX_BINARY=${binary}\n`);
+  }
+}
+
+const isMain = process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('downloads.mjs');
+if (isMain) {
+  main().catch(err => {
+    console.error(`✗ Error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/tools/test/e2e/downloads.mjs
+++ b/tools/test/e2e/downloads.mjs
@@ -127,11 +127,14 @@ async function installTarball(url, browser) {
   return binary;
 }
 
-async function fetchWithRetry(url, attempts) {
+async function fetchWithRetry(url, attempts, timeoutMs = 300_000) {
   let lastErr;
   for (let i = 1; i <= attempts; i++) {
     try {
-      const res = await fetch(url);
+      // Bound each attempt: a stalled connection would otherwise hang CI until
+      // the runner kills the job. Timeout failures flow through the retry
+      // path below like any other fetch error.
+      const res = await fetch(url, {signal: AbortSignal.timeout(timeoutMs)});
       if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
       return res;
     } catch (err) {

--- a/tools/test/e2e/helpers.mjs
+++ b/tools/test/e2e/helpers.mjs
@@ -94,10 +94,11 @@ export function attachProcessLogging(browser, label = 'ff') {
  *
  * @param {import('puppeteer-core').Browser} browser
  * @param {string} prefix - URL prefix to match
- * @param {number} [timeoutMs=90000] Default is `90000`
+ * @param {number} [timeoutMs=15000] — the updater scheduler runs at startup, so
+ *   a tab that has not appeared in ~15 s will not appear. Default is `15000`
  * @returns {Promise<import('puppeteer-core').Page | null>}
  */
-export async function findPageByUrl(browser, prefix, timeoutMs = 90_000) {
+export async function findPageByUrl(browser, prefix, timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs;
   let lastProgressLog = 0;
   while (Date.now() < deadline) {

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -80,7 +80,8 @@ try {
     {
       notify() {
         try {
-          if (++polls > 180) {
+          // 30 s of polls comfortably exceeds the 15 s test deadline below.
+          if (++polls > 30) {
             watcher.cancel();
             return;
           }
@@ -449,7 +450,10 @@ async function runStaleScenario(
     // and the probe's TAB_OPENED mirror line (fast, BiDi-independent). When
     // only the mirror fires, close early and let the finally block decide via
     // the persisted lastUpdateTabShown pref instead of burning the full window.
-    const deadline = Date.now() + 90_000;
+    // The scheduler runs at startup: if the tab has not opened in ~15 s it
+    // will not open at all. The mirror-line + pref fast paths still fire
+    // early, so a working scenario returns in a couple of seconds.
+    const deadline = Date.now() + 15_000;
     let sawMirrorLine = false;
     let page = null;
     while (Date.now() < deadline && !page && !sawMirrorLine) {
@@ -497,7 +501,7 @@ async function runStaleScenario(
         const title = document.getElementById('card-title');
         return Boolean(title && title.textContent);
       },
-      60_000,
+      15_000,
       'card rendered'
     );
     check(counter, rendered, `card rendered (${label})`);
@@ -645,7 +649,8 @@ async function runNoTabScenario(
       extraPrefsFirefox: seeded.prefs,
     });
     attachProcessLogging(browser, label);
-    const page = await findPageByUrl(browser, UPDATER_URL, 30_000);
+    // No-tab scenarios assert absence: 10 s is enough for startup to finish.
+    const page = await findPageByUrl(browser, UPDATER_URL, 10_000);
     check(counter, !page, `tab does NOT open (${label})`);
     return seeded.profileDir;
   } finally {


### PR DESCRIPTION
## What & why

P0-3 from the v1.0 roadmap — make the E2E suite fast enough for the release gate and for everyday PR runs.

- **`tools/test/e2e/downloads.mjs` (new):** one data file mapping each browser → per-OS install method using official download URLs / package managers (Mozilla tarball, brew cask, choco, official pages for Waterfox/Zen/Dev Edition), instead of hardcoding install steps in the workflow. Includes a `--list`/CLI and `installBrowser()` returning the resolved binary path.
- **`.github/workflows/e2e.yml`:** the three per-OS Firefox install blocks are replaced by a loop over the downloads map.
- **Shorter waits** in `updater-e2e.mjs` / `helpers.mjs`: tab-open deadline 90s → 15s, no-tab window 30s → 10s, card render 60s → 15s. The scheduler runs at startup, so a tab that hasn't opened in ~15s won't — the fast paths (config-probe mirror line, `lastUpdateTabShown`) already return in ~1–5s on success.

## CodeRabbit (round 1, batch review)

Finding posted for tracking; the fix is included in this branch:

- `fetchWithRetry` was unbounded — a stalled download would hang CI until the runner killed the job. Each attempt now uses `AbortSignal.timeout` (5 min) and flows through the existing retry/logging path (`8479b45`).