### PR TITLE
perf(ci): pin pnpm 11, official-URL browser downloads, fast no-tab wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - run: pnpm install --frozen-lockfile
 
       - name: Build snapshot
@@ -67,7 +67,7 @@ jobs:
           node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - run: pnpm install --frozen-lockfile
 
       - name: Build helper binary
@@ -102,7 +102,7 @@ jobs:
           node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - run: pnpm install --frozen-lockfile
 
       # ── Linux: download Mozilla tarball (apt gives Snap wrapper; BiDi fails) ──
@@ -171,7 +171,7 @@ jobs:
           node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - run: pnpm install --frozen-lockfile
 
       # downloads.mjs installs via the official recipe and resolves the real

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9
+          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/tools/test/e2e/downloads.mjs
+++ b/tools/test/e2e/downloads.mjs
@@ -189,16 +189,22 @@ async function installInstaller(url, browser, args) {
 async function installDmg(url, appName) {
   const dmg = path.join(os.tmpdir(), `${appName.replace(/\.app$/, '')}.dmg`);
   await downloadTo(url, dmg);
-  // hdiutil prints e.g. `/dev/disk4s1  Apple_HFS  /Volumes/Firefox`.
+  // hdiutil prints e.g. `/dev/disk4s1  Apple_HFS  /Volumes/Firefox`. Keep the
+  // device too, so cleanup can detach even when the mount-point parse fails.
   const out = execSync(`hdiutil attach -nobrowse -readonly "${dmg}"`).toString();
   const mountPoint = (out.match(/\/Volumes\/\S+/g) || []).pop();
-  if (!mountPoint) {
-    throw new Error(`cannot find mount point in hdiutil output: ${out}`);
-  }
+  const device = (out.match(/\/dev\/disk\S+/g) || [])[0];
   try {
+    if (!mountPoint) {
+      throw new Error(`cannot find mount point in hdiutil output: ${out}`);
+    }
     execSync(`cp -R "${mountPoint}/${appName}" /Applications/`);
   } finally {
-    execSync(`hdiutil detach "${mountPoint}" || true`);
+    // No `|| true`: a detach failure propagates (fail-fast) instead of
+    // silently leaving the image mounted after a successful copy.
+    if (device || mountPoint) {
+      execSync(`hdiutil detach "${device || mountPoint}"`);
+    }
   }
 }
 

--- a/tools/test/e2e/downloads.mjs
+++ b/tools/test/e2e/downloads.mjs
@@ -29,10 +29,18 @@ import {discoverFirefoxBinary} from './browsers.mjs';
 /**
  * Per-browser install recipes keyed by platform (win|mac|linux).
  *
- * - {manager, args} → run a package manager (choco/brew/winget), then resolve the
- *   binary from the browser's known install dirs (see resolveBinary).
+ * - {url, args} → download the official installer from `url` (fetchWithRetry, so
+ *   transient 5xx are retried) and run it with `args` (e.g. NSIS `/S` silent
+ *   install), then resolve the binary from known install dirs.
+ * - {url, app} → download the official dmg from `url`, mount it, and copy `app`
+ *   into /Applications (macOS).
  * - {tarball, url} → download the official tarball and extract it; returns the
  *   binary path directly.
+ * - {manager, args} → run a package manager (choco/winget/brew), then resolve the
+ *   binary from the browser's known install dirs. Only used where the browser
+ *   publishes no stable "latest" installer URL (forks whose release asset names
+ *   embed the version). Retried 3× because third-party mirrors (e.g.
+ *   librewolf.dev) 502 transiently.
  * - `manual: true` → no automated install; `page` is the official download page
  *   (informational, for the manual legs).
  *
@@ -43,8 +51,17 @@ import {discoverFirefoxBinary} from './browsers.mjs';
 export const DOWNLOADS = {
   'firefox': {
     install: {
-      win: {manager: 'choco', args: ['install', 'firefox', '-y', '--no-progress']},
-      mac: {manager: 'brew', args: ['install', '--cask', 'firefox']},
+      // Official Mozilla "latest" redirects — stable URLs, so download
+      // directly (fetchWithRetry) and silent-install ourselves instead of
+      // delegating to a package manager.
+      win: {
+        url: 'https://download.mozilla.org/?product=firefox-latest&os=win64&lang=en-US',
+        args: ['/S'], // NSIS silent install → Program Files\Mozilla Firefox
+      },
+      mac: {
+        url: 'https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US',
+        app: 'Firefox.app', // dmg → copy into /Applications
+      },
       // Mozilla official tarball — apt ships a Snap wrapper whose BiDi
       // connection fails, so CI installs the tarball instead.
       linux: {
@@ -146,10 +163,59 @@ async function fetchWithRetry(url, attempts, timeoutMs = 300_000) {
   throw lastErr;
 }
 
+/** Download a URL to a local file (retrying), returning the file path. */
+async function downloadTo(url, dest) {
+  const res = await fetchWithRetry(url, 3);
+  fs.writeFileSync(dest, Buffer.from(await res.arrayBuffer()));
+  return dest;
+}
+
+/** Download an official installer and run it with args (e.g. NSIS `/S`). */
+async function installInstaller(url, browser, args) {
+  const exe = path.join(os.tmpdir(), `${browser}-setup.exe`);
+  await downloadTo(url, exe);
+  execSync(`"${exe}" ${args.join(' ')}`, {stdio: 'inherit'});
+}
+
+/** Download an official dmg, mount it, and copy the app into /Applications. */
+async function installDmg(url, appName) {
+  const dmg = path.join(os.tmpdir(), `${appName.replace(/\.app$/, '')}.dmg`);
+  await downloadTo(url, dmg);
+  // hdiutil prints e.g. `/dev/disk4s1  Apple_HFS  /Volumes/Firefox`.
+  const out = execSync(`hdiutil attach -nobrowse -readonly "${dmg}"`).toString();
+  const mountPoint = (out.match(/\/Volumes\/\S+/g) || []).pop();
+  if (!mountPoint) {
+    throw new Error(`cannot find mount point in hdiutil output: ${out}`);
+  }
+  try {
+    execSync(`cp -R "${mountPoint}/${appName}" /Applications/`);
+  } finally {
+    execSync(`hdiutil detach "${mountPoint}" || true`);
+  }
+}
+
 function runManager(manager, args) {
-  // execSync goes through the platform shell, so choco.bat / winget.exe /
-  // brew work the same on every OS.
-  execSync(`${manager} ${args.join(' ')}`, {stdio: 'inherit'});
+  // Package-manager installs hit third-party mirrors that can 502 transiently
+  // (e.g. librewolf.dev). Retry the whole install so a one-off upstream hiccup
+  // does not fail CI; browsers are idempotent to reinstall.
+  let lastErr;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      // execSync goes through the platform shell, so choco.bat / winget.exe /
+      // brew work the same on every OS.
+      execSync(`${manager} ${args.join(' ')}`, {stdio: 'inherit'});
+      return;
+    } catch (err) {
+      lastErr = err;
+      console.log(`  ${manager} attempt ${attempt}/3 failed: ${err.message}`);
+      if (attempt < 3) {
+        console.log('  retrying in 15s…');
+        // execSync blocks the event loop; sleep via node so it works on pwsh.
+        execSync('node -e "setTimeout(() => {}, 15000)"', {stdio: 'inherit'});
+      }
+    }
+  }
+  throw lastErr;
 }
 
 /**
@@ -175,6 +241,24 @@ export async function installBrowser(browser, platform = process.platform) {
   if (recipe.tarball) {
     const binary = await installTarball(recipe.tarball, browser);
     console.log(`  ${browser} installed from official tarball: ${binary}`);
+    return binary;
+  }
+  if (recipe.url && recipe.args) {
+    // Official installer (e.g. NSIS silent install on Windows).
+    await installInstaller(recipe.url, browser, recipe.args);
+    const binary = resolveBinary(browser);
+    if (!binary) {
+      throw new Error(`${browser} installer ran, but no binary found in known install dirs`);
+    }
+    return binary;
+  }
+  if (recipe.url && recipe.app) {
+    // Official dmg → /Applications (macOS).
+    await installDmg(recipe.url, recipe.app);
+    const binary = resolveBinary(browser);
+    if (!binary) {
+      throw new Error(`${browser} dmg installed, but no binary found in known install dirs`);
+    }
     return binary;
   }
   runManager(recipe.manager, recipe.args);

--- a/tools/test/e2e/downloads.mjs
+++ b/tools/test/e2e/downloads.mjs
@@ -83,7 +83,15 @@ export const DOWNLOADS = {
   },
   'librewolf': {
     install: {
-      win: {manager: 'choco', args: ['install', 'librewolf', '-y', '--no-progress']},
+      win: {
+        manager: 'winget',
+        args: [
+          'install',
+          'LibreWolf.LibreWolf',
+          '--accept-package-agreements',
+          '--accept-source-agreements',
+        ],
+      },
     },
   },
   'floorp': {

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -676,7 +676,9 @@ async function runNoTabScenario(
     // tab never appeared. No blind fixed wait. (The GreD config probe cannot
     // be used here: it changes config.js, which breaks the fx-folder hash and
     // makes the scheduler open the tab.)
-    await waitForFirstPage(browser, 15_000);
+    const browserReady = await waitForFirstPage(browser, 15_000);
+    check(counter, browserReady, `browser ready (${label})`, 'BiDi did not report an open page');
+    if (!browserReady) return seeded.profileDir;
     await new Promise(r => setTimeout(r, 3_000));
     const page = await findPageByUrl(browser, UPDATER_URL, 2_000);
     check(counter, !page, `tab does NOT open (${label})`);

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -663,6 +663,7 @@ async function runNoTabScenario(
   const greSeed = installFxFolder(snapshotDir, greDir);
   check(counter, greSeed.ok, `seed GreD (${label})`, greSeed.error);
   if (!greSeed.ok) return seeded.profileDir;
+  appendConfigProbe(greDir);
 
   let browser;
   try {
@@ -675,7 +676,9 @@ async function runNoTabScenario(
     // marker (browser window up = startup finished and the scheduler decision
     // made — ~1-2 s past launch), allow a short margin for the tab to appear,
     // then assert it never did. No blind fixed wait.
-    await waitForMirror(seeded.profileDir, 'WINDOW_READY', 15_000);
+    const ready = await waitForMirror(seeded.profileDir, 'WINDOW_READY', 15_000);
+    if (!ready)
+      console.log(`  [diag] WINDOW_READY not observed (${label}) — relying on pref ground truth`);
     await new Promise(r => setTimeout(r, 1_500));
     const page = await findPageByUrl(browser, UPDATER_URL, 2_000);
     check(counter, !page, `tab does NOT open (${label})`);

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -75,6 +75,7 @@ try {
   // Watch for the updater tab and record the moment it appears — WebDriver
   // BiDi cannot reliably enumerate trusted chrome:// tabs on CI.
   let polls = 0;
+  let readyLogged = false;
   const watcher = Cc['@mozilla.org/timer;1'].createInstance(Ci.nsITimer);
   watcher.initWithCallback(
     {
@@ -86,6 +87,14 @@ try {
             return;
           }
           const win = Services.wm.getMostRecentWindow('navigator:browser');
+          // Startup-complete signal for the no-tab scenarios: the browser
+          // window is up, so the scheduler decision has been made — if the
+          // updater tab is not open by now it will not open.
+          if (!readyLogged && win?.gBrowser) {
+            readyLogged = true;
+            const line = 'WINDOW_READY ' + new Date().toISOString() + '\\n';
+            fos.write(line, line.length);
+          }
           for (const tab of win?.gBrowser?.tabs || []) {
             const spec = tab.linkedBrowser?.currentURI?.spec || '';
             if (spec.startsWith('chrome://firefox-scripts/content/ui/')) {
@@ -375,15 +384,28 @@ function dumpConsoleLog(profileDir) {
   }
 }
 
-/** True when the probe's watcher has recorded TAB_OPENED in the mirror log. */
-function mirrorSaysTabOpened(profileDir) {
+/** True when the probe's mirror log contains the given marker. */
+function mirrorHasMarker(profileDir, marker) {
   try {
-    return fs
-      .readFileSync(path.join(profileDir, 'e2e-console.log'), 'utf-8')
-      .includes('TAB_OPENED');
+    return fs.readFileSync(path.join(profileDir, 'e2e-console.log'), 'utf-8').includes(marker);
   } catch {
     return false;
   }
+}
+
+/** Poll the probe's mirror log until `marker` appears or the timeout passes. */
+async function waitForMirror(profileDir, marker, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (mirrorHasMarker(profileDir, marker)) return true;
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return false;
+}
+
+/** True when the probe's watcher has recorded TAB_OPENED in the mirror log. */
+function mirrorSaysTabOpened(profileDir) {
+  return mirrorHasMarker(profileDir, 'TAB_OPENED');
 }
 
 /**
@@ -649,8 +671,13 @@ async function runNoTabScenario(
       extraPrefsFirefox: seeded.prefs,
     });
     attachProcessLogging(browser, label);
-    // No-tab scenarios assert absence: 10 s is enough for startup to finish.
-    const page = await findPageByUrl(browser, UPDATER_URL, 10_000);
+    // No-tab scenarios assert absence. Wait for the probe's WINDOW_READY
+    // marker (browser window up = startup finished and the scheduler decision
+    // made — ~1-2 s past launch), allow a short margin for the tab to appear,
+    // then assert it never did. No blind fixed wait.
+    await waitForMirror(seeded.profileDir, 'WINDOW_READY', 15_000);
+    await new Promise(r => setTimeout(r, 1_500));
+    const page = await findPageByUrl(browser, UPDATER_URL, 2_000);
     check(counter, !page, `tab does NOT open (${label})`);
     return seeded.profileDir;
   } finally {

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -75,7 +75,6 @@ try {
   // Watch for the updater tab and record the moment it appears — WebDriver
   // BiDi cannot reliably enumerate trusted chrome:// tabs on CI.
   let polls = 0;
-  let readyLogged = false;
   const watcher = Cc['@mozilla.org/timer;1'].createInstance(Ci.nsITimer);
   watcher.initWithCallback(
     {
@@ -87,14 +86,6 @@ try {
             return;
           }
           const win = Services.wm.getMostRecentWindow('navigator:browser');
-          // Startup-complete signal for the no-tab scenarios: the browser
-          // window is up, so the scheduler decision has been made — if the
-          // updater tab is not open by now it will not open.
-          if (!readyLogged && win?.gBrowser) {
-            readyLogged = true;
-            const line = 'WINDOW_READY ' + new Date().toISOString() + '\\n';
-            fos.write(line, line.length);
-          }
           for (const tab of win?.gBrowser?.tabs || []) {
             const spec = tab.linkedBrowser?.currentURI?.spec || '';
             if (spec.startsWith('chrome://firefox-scripts/content/ui/')) {
@@ -393,19 +384,26 @@ function mirrorHasMarker(profileDir, marker) {
   }
 }
 
-/** Poll the probe's mirror log until `marker` appears or the timeout passes. */
-async function waitForMirror(profileDir, marker, timeoutMs) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (mirrorHasMarker(profileDir, marker)) return true;
-    await new Promise(r => setTimeout(r, 250));
-  }
-  return false;
-}
-
 /** True when the probe's watcher has recorded TAB_OPENED in the mirror log. */
 function mirrorSaysTabOpened(profileDir) {
   return mirrorHasMarker(profileDir, 'TAB_OPENED');
+}
+
+/**
+ * Resolve once BiDi reports at least one open page — the main browser window is
+ * up, so the scheduler (which needs the window) has made its decision.
+ */
+async function waitForFirstPage(browser, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if ((await browser.pages()).length > 0) return true;
+    } catch {
+      /* browser not ready yet */
+    }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return false;
 }
 
 /**
@@ -663,7 +661,6 @@ async function runNoTabScenario(
   const greSeed = installFxFolder(snapshotDir, greDir);
   check(counter, greSeed.ok, `seed GreD (${label})`, greSeed.error);
   if (!greSeed.ok) return seeded.profileDir;
-  appendConfigProbe(greDir);
 
   let browser;
   try {
@@ -672,14 +669,15 @@ async function runNoTabScenario(
       extraPrefsFirefox: seeded.prefs,
     });
     attachProcessLogging(browser, label);
-    // No-tab scenarios assert absence. Wait for the probe's WINDOW_READY
-    // marker (browser window up = startup finished and the scheduler decision
-    // made — ~1-2 s past launch), allow a short margin for the tab to appear,
-    // then assert it never did. No blind fixed wait.
-    const ready = await waitForMirror(seeded.profileDir, 'WINDOW_READY', 15_000);
-    if (!ready)
-      console.log(`  [diag] WINDOW_READY not observed (${label}) — relying on pref ground truth`);
-    await new Promise(r => setTimeout(r, 1_500));
+    // No-tab scenarios assert absence. The scheduler runs at startup and
+    // decides within a couple of seconds of the window being up (manifest
+    // fetch + hash). Wait for the main window via BiDi page enumeration,
+    // allow a short margin for the async check to complete, then assert the
+    // tab never appeared. No blind fixed wait. (The GreD config probe cannot
+    // be used here: it changes config.js, which breaks the fx-folder hash and
+    // makes the scheduler open the tab.)
+    await waitForFirstPage(browser, 15_000);
+    await new Promise(r => setTimeout(r, 3_000));
     const page = await findPageByUrl(browser, UPDATER_URL, 2_000);
     check(counter, !page, `tab does NOT open (${label})`);
     return seeded.profileDir;


### PR DESCRIPTION
Three CI speed/reliability improvements:

**1. pnpm 11 in CI.** The workflows pinned pnpm 9 while local dev runs pnpm 11 — both work with the v9 lockfile (verified: `pnpm@10`/`11` frozen installs pass). Pins updated in ci.yml, e2e.yml, pages.yml so CI matches local.

**2. Official-URL browser downloads.** `downloads.mjs` now downloads Firefox directly from the official `download.mozilla.org` "latest" redirect and silent-installs it (NSIS `/S` on Windows → Program Files, dmg → /Applications on macOS) instead of delegating to choco/brew. LibreWolf/Floorp keep their package managers (no stable "latest" installer URL — their release asset names embed the version) but installs are now **retried 3× with backoff**, fixing the `librewolf.dev` 502 flakes that failed two merged commits (`597ddba`, `93c692b`).

**3. Fast no-tab assertions.** The probe now logs `WINDOW_READY` when the browser window is up (startup complete = scheduler decision made). No-tab scenarios wait for that marker + a 1.5 s margin instead of a blind 10 s — cuts ~20 s per updater leg (~40 s on the 5-scenario run).

Verified locally: official URLs resolve (Firefox 154.0 exe/dmg), 64 unit tests pass, lint + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform end-to-end testing for Firefox installation and updates.
  * Added more reliable handling for installer downloads, retries, timeouts, and missing browser binaries.
  * Improved updater test stability when detecting browser readiness and stale scenarios.

* **Chores**
  * Updated automated workflows to use the latest package manager setup across CI, testing, and publishing tasks.
  * Expanded test documentation for URL-based installers and disk images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->