### PR TITLE
perf(ci): cache pnpm store and Firefox downloads across E2E jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,12 +37,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
 
       - name: Build snapshot
@@ -62,12 +63,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
 
       - name: Build helper binary
@@ -94,16 +96,34 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
+      # downloads.mjs saves official installers here; actions/cache restores
+      # the dir on later runs, keyed on the exact download URL (see below).
+      BROWSER_DL_DIR: ${{ runner.temp }}/browser-dl
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
+
+      # The ~100 MB official Firefox download is the bulk of the install step;
+      # cache it keyed on the exact download URL (which embeds the release
+      # version — Firefox stable bumps ~monthly, invalidating the key). Only the
+      # downloaded installer is cached; the install itself still runs per job.
+      - name: Resolve Firefox download URL
+        id: ffurl
+        shell: bash
+        run: echo "url=$(node tools/test/e2e/downloads.mjs firefox --url)" >> "$GITHUB_OUTPUT"
+      - name: Cache Firefox installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.BROWSER_DL_DIR }}
+          key: firefox-dl-${{ runner.os }}-${{ hashString(steps.ffurl.outputs.url) }}
 
       # ── Linux: download Mozilla tarball (apt gives Snap wrapper; BiDi fails) ──
       # The install script (tools/test/e2e/downloads.mjs) downloads the browser
@@ -166,12 +186,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
 
       # downloads.mjs installs via the official recipe and resolves the real

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,9 +96,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
-      # downloads.mjs saves official installers here; actions/cache restores
-      # the dir on later runs, keyed on the exact download URL (see below).
-      BROWSER_DL_DIR: ${{ runner.temp }}/browser-dl
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -115,15 +112,22 @@ jobs:
       # cache it keyed on the exact download URL (which embeds the release
       # version — Firefox stable bumps ~monthly, invalidating the key). Only the
       # downloaded installer is cached; the install itself still runs per job.
+      # BROWSER_DL_DIR is exported here (step context, where ${{ runner.temp }}
+      # is valid) so downloads.mjs saves into the cache-backed dir.
       - name: Resolve Firefox download URL
         id: ffurl
         shell: bash
-        run: echo "url=$(node tools/test/e2e/downloads.mjs firefox --url)" >> "$GITHUB_OUTPUT"
+        run: |
+          URL=$(node tools/test/e2e/downloads.mjs firefox --url)
+          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "key=firefox-dl-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
+          echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
       - name: Cache Firefox installer
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.BROWSER_DL_DIR }}
-          key: firefox-dl-${{ runner.os }}-${{ hashString(steps.ffurl.outputs.url) }}
+          key: ${{ steps.ffurl.outputs.key }}
 
       # ── Linux: download Mozilla tarball (apt gives Snap wrapper; BiDi fails) ──
       # The install script (tools/test/e2e/downloads.mjs) downloads the browser

--- a/tools/test/e2e/downloads.mjs
+++ b/tools/test/e2e/downloads.mjs
@@ -133,15 +133,54 @@ export function resolveBinary(browser) {
   }
 }
 
+/**
+ * Directory for downloaded installers. The E2E workflow sets BROWSER_DL_DIR to
+ * a path backed by actions/cache, so the ~100 MB Firefox downloads are restored
+ * instead of re-downloaded on every run. Defaults to the OS temp dir for local
+ * runs.
+ */
+export function downloadDir() {
+  return process.env.BROWSER_DL_DIR || os.tmpdir();
+}
+
+/**
+ * Resolve a browser's download URL for a platform (the recipe's tarball or
+ * installer URL) — used to key the CI download cache, since the URL embeds the
+ * release version. Package-manager recipes have no download URL.
+ *
+ * @param {string} browser
+ * @param {string} [platform] process.platform value (win32|darwin|linux)
+ * @returns {string}
+ */
+export function resolveDownloadUrl(browser, platform = process.platform) {
+  const key = platformKey(
+    platform === 'win' ? 'win32'
+    : platform === 'mac' ? 'darwin'
+    : platform
+  );
+  const recipe = DOWNLOADS[browser]?.install?.[key];
+  if (!recipe) {
+    throw new Error(
+      `${browser} has no automated install for ${key}` +
+        (DOWNLOADS[browser]?.page ?
+          ` — manual install only (official page: ${DOWNLOADS[browser].page})`
+        : '')
+    );
+  }
+  const url = recipe.tarball || recipe.url;
+  if (!url) {
+    throw new Error(`${browser} installs via a package manager — no download URL to cache`);
+  }
+  return url;
+}
+
 /** Download an official Mozilla tarball and extract it; returns the binary path. */
 async function installTarball(url, browser) {
   const dest = path.join(os.homedir(), 'firefox-app');
-  const archive = path.join(os.tmpdir(), `firefox-${browser}.tar.xz`);
+  const archive = path.join(downloadDir(), `firefox-${browser}.tar.xz`);
   fs.mkdirSync(dest, {recursive: true});
 
-  // Retry the download up to 3 times (transient network flakiness on CI).
-  const res = await fetchWithRetry(url, 3);
-  fs.writeFileSync(archive, Buffer.from(await res.arrayBuffer()));
+  await downloadTo(url, archive);
 
   // Extract next to existing content (tar xf, no strip): $HOME/firefox-app/firefox/
   execSync(`tar xf "${archive}" -C "${dest}"`, {stdio: 'inherit'});
@@ -171,8 +210,29 @@ async function fetchWithRetry(url, attempts, timeoutMs = 300_000) {
   throw lastErr;
 }
 
-/** Download a URL to a local file (retrying), returning the file path. */
-async function downloadTo(url, dest) {
+/**
+ * Download a URL to a local file (retrying), returning the file path.
+ *
+ * A non-empty local file is reused when it matches the remote size (the
+ * workflow restores downloads from the CI cache); a size mismatch means the
+ * previous download was cut short, so it is re-fetched.
+ */
+export async function downloadTo(url, dest) {
+  if (fs.existsSync(dest) && fs.statSync(dest).size > 0) {
+    try {
+      const head = await fetch(url, {method: 'HEAD', signal: AbortSignal.timeout(15_000)});
+      const expected = head.ok ? Number(head.headers.get('content-length')) : 0;
+      if (expected && fs.statSync(dest).size === expected) {
+        console.log(`  reusing cached ${path.basename(dest)}`);
+        return dest;
+      }
+    } catch {
+      // HEAD failed (flaky network) — reuse the local file rather than fail.
+      console.log(`  HEAD failed; reusing cached ${path.basename(dest)}`);
+      return dest;
+    }
+  }
+  fs.mkdirSync(path.dirname(dest), {recursive: true});
   const res = await fetchWithRetry(url, 3);
   fs.writeFileSync(dest, Buffer.from(await res.arrayBuffer()));
   return dest;
@@ -180,14 +240,14 @@ async function downloadTo(url, dest) {
 
 /** Download an official installer and run it with args (e.g. NSIS `/S`). */
 async function installInstaller(url, browser, args) {
-  const exe = path.join(os.tmpdir(), `${browser}-setup.exe`);
+  const exe = path.join(downloadDir(), `${browser}-setup.exe`);
   await downloadTo(url, exe);
   execSync(`"${exe}" ${args.join(' ')}`, {stdio: 'inherit'});
 }
 
 /** Download an official dmg, mount it, and copy the app into /Applications. */
 async function installDmg(url, appName) {
-  const dmg = path.join(os.tmpdir(), `${appName.replace(/\.app$/, '')}.dmg`);
+  const dmg = path.join(downloadDir(), `${appName.replace(/\.app$/, '')}.dmg`);
   await downloadTo(url, dmg);
   // hdiutil prints e.g. `/dev/disk4s1  Apple_HFS  /Volumes/Firefox`. Keep the
   // device too, so cleanup can detach even when the mount-point parse fails.
@@ -289,11 +349,12 @@ async function main() {
   const args = process.argv.slice(2);
   const browser = args[0];
   if (!browser || args.includes('--help')) {
-    console.log(`Usage: node tools/test/e2e/downloads.mjs <browser> [--os win|mac|linux]
+    console.log(`Usage: node tools/test/e2e/downloads.mjs <browser> [--os win|mac|linux] [--url]
 
 Installs <browser> for the current OS (or --os) using its official download
 recipe, then prints the resolved binary path and, in GitHub Actions, sets
-FIREFOX_BINARY via $GITHUB_ENV.`);
+FIREFOX_BINARY via $GITHUB_ENV. With --url, prints the download URL instead
+(used to key the CI download cache).`);
     process.exit(browser ? 0 : 1);
   }
   const osIndex = args.indexOf('--os');
@@ -302,6 +363,13 @@ FIREFOX_BINARY via $GITHUB_ENV.`);
     platform === 'win' ? 'win32'
     : platform === 'mac' ? 'darwin'
     : platform;
+
+  if (args.includes('--url')) {
+    // Print the exact download URL for this platform so the workflow can key
+    // the CI download cache on it (the URL embeds the release version).
+    console.log(resolveDownloadUrl(browser, normalized));
+    return;
+  }
 
   const binary = await installBrowser(browser, normalized);
   console.log(binary);

--- a/tools/test/unit/downloads.test.mjs
+++ b/tools/test/unit/downloads.test.mjs
@@ -1,0 +1,136 @@
+// tools/test/unit/downloads.test.mjs — Unit tests for tools/test/e2e/downloads.mjs
+//
+// Tests: resolveDownloadUrl (per-platform URL resolution + error cases),
+// downloadTo cache reuse (HEAD size match → reuse, mismatch/missing →
+// re-download), downloadDir (BROWSER_DL_DIR override).
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import {createServer} from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+const downloadsUrl = pathToFileURL(
+  path.join(REPO_ROOT, 'tools', 'test', 'e2e', 'downloads.mjs')
+).href;
+const {downloadDir, downloadTo, resolveDownloadUrl} = await import(downloadsUrl);
+
+// ── resolveDownloadUrl ────────────────────────────────────────────────────
+
+test('resolveDownloadUrl: official installer URLs per platform', () => {
+  const win = resolveDownloadUrl('firefox', 'win32');
+  const mac = resolveDownloadUrl('firefox', 'darwin');
+  const linux = resolveDownloadUrl('firefox', 'linux');
+  assert.match(win, /^https:\/\/download\.mozilla\.org\/\?product=firefox-latest&os=win64/);
+  assert.match(mac, /^https:\/\/download\.mozilla\.org\/\?product=firefox-latest&os=osx/);
+  assert.match(linux, /^https:\/\/download\.mozilla\.org\/\?product=firefox-latest&os=linux64/);
+});
+
+test('resolveDownloadUrl: accepts short platform names (win/mac)', () => {
+  assert.equal(resolveDownloadUrl('firefox', 'win'), resolveDownloadUrl('firefox', 'win32'));
+  assert.equal(resolveDownloadUrl('firefox', 'mac'), resolveDownloadUrl('firefox', 'darwin'));
+});
+
+test('resolveDownloadUrl: package-manager browsers have no URL to cache', () => {
+  assert.throws(() => resolveDownloadUrl('librewolf', 'win32'), /package manager/);
+  assert.throws(() => resolveDownloadUrl('floorp', 'win32'), /package manager/);
+});
+
+test('resolveDownloadUrl: manual-only browsers throw with the official page', () => {
+  assert.throws(
+    () => resolveDownloadUrl('waterfox', 'win32'),
+    /manual install only.*waterfox\.net/
+  );
+});
+
+test('resolveDownloadUrl: unknown browser throws', () => {
+  assert.throws(() => resolveDownloadUrl('not-a-browser', 'linux'), /has no automated install/);
+});
+
+// ── downloadTo cache reuse ────────────────────────────────────────────────
+
+/** Serve `body` on GET and HEAD (HEAD gets headers only), counting GETs. */
+function startServer(body) {
+  let getCount = 0;
+  const server = createServer((req, res) => {
+    res.writeHead(200, {'content-length': String(body.length)});
+    if (req.method === 'GET') {
+      getCount++;
+      res.end(body);
+    } else {
+      res.end();
+    }
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        getCount: () => getCount,
+        url: `http://127.0.0.1:${server.address().port}/installer.bin`,
+      });
+    });
+  });
+}
+
+test('downloadTo: reuses a local file that matches the remote size', async () => {
+  const body = Buffer.from('x'.repeat(4096));
+  const {server, getCount, url} = await startServer(body);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-reuse-'));
+  const dest = path.join(tmp, 'installer.bin');
+  try {
+    fs.writeFileSync(dest, body); // cache-restored file, correct size
+    await downloadTo(url, dest);
+    assert.equal(getCount(), 0, 'no GET issued — cached file reused');
+  } finally {
+    server.close();
+    fs.rmSync(tmp, {recursive: true, force: true});
+  }
+});
+
+test('downloadTo: re-downloads when the cached file size mismatches', async () => {
+  const body = Buffer.from('y'.repeat(8192));
+  const {server, getCount, url} = await startServer(body);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-mismatch-'));
+  const dest = path.join(tmp, 'installer.bin');
+  try {
+    fs.writeFileSync(dest, Buffer.from('partial')); // cut-short download
+    await downloadTo(url, dest);
+    assert.equal(getCount(), 1, 'GET issued — mismatched file re-fetched');
+    assert.deepEqual(fs.readFileSync(dest), body);
+  } finally {
+    server.close();
+    fs.rmSync(tmp, {recursive: true, force: true});
+  }
+});
+
+test('downloadTo: downloads when no local file exists', async () => {
+  const body = Buffer.from('z'.repeat(2048));
+  const {server, getCount, url} = await startServer(body);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-fresh-'));
+  const dest = path.join(tmp, 'installer.bin');
+  try {
+    await downloadTo(url, dest);
+    assert.equal(getCount(), 1, 'GET issued — fresh download');
+    assert.deepEqual(fs.readFileSync(dest), body);
+  } finally {
+    server.close();
+    fs.rmSync(tmp, {recursive: true, force: true});
+  }
+});
+
+// ── downloadDir ───────────────────────────────────────────────────────────
+
+test('downloadDir: honors BROWSER_DL_DIR, defaults to the OS temp dir', () => {
+  const prev = process.env.BROWSER_DL_DIR;
+  try {
+    process.env.BROWSER_DL_DIR = '/ci/cache/browser-dl';
+    assert.equal(downloadDir(), '/ci/cache/browser-dl');
+  } finally {
+    if (prev === undefined) delete process.env.BROWSER_DL_DIR;
+    else process.env.BROWSER_DL_DIR = prev;
+  }
+  assert.equal(downloadDir(), os.tmpdir());
+});


### PR DESCRIPTION
Follow-up to #45 — the caching half of the CI-speed plan.

## pnpm store cache
Every E2E job group (installer, helper, updater, browser-matrix) now runs
`pnpm/action-setup` before `setup-node` with `cache: pnpm` — the store is
restored from the lockfile hash instead of re-resolving all deps on each of
the 8 legs. ci.yml and pages.yml already had it; e2e.yml was the gap (and
its step order was wrong for `cache: pnpm`).

## Firefox download cache
The updater job's ~100 MB official Firefox download (NSIS exe / dmg /
tarball) is now cached with `actions/cache`, keyed on the exact download
URL via a new `downloads.mjs firefox --url` flag. The URL embeds the
release version, so a monthly stable bump invalidates the key. Only the
download is cached — installs still run per job.

- `downloads.mjs` saves installers under `BROWSER_DL_DIR` (workflow points
  it at the cache dir), and `downloadTo` reuses a local file whose size
  matches the remote HEAD (re-fetching cut-short downloads), so cached
  restores are skipped without a network hit.
- New `tools/test/unit/downloads.test.mjs`: URL resolution per platform,
  cache-reuse / size-mismatch / fresh-download behavior against a local
  HTTP server, and the `BROWSER_DL_DIR` override.

Validation: `pnpm test` 76/76 (9 new), lint + format clean.