### PR TITLE
chore(ci): prune stale Actions caches weekly

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,46 @@
+name: Cache cleanup
+
+# Prunes old GitHub Actions caches (tools/ci/prune-caches.mjs) so stale keys
+# from Firefox-version bumps and lockfile changes don't accumulate forever.
+# GitHub only auto-evicts (LRU) past the 10 GB total, so old keys otherwise
+# burn quota on every run that tries to restore them.
+#
+# Runs weekly, and can be triggered manually:
+#   gh workflow run cache-cleanup.yml
+#
+# Only the default branch (main) schedules — the workflow file there is the
+# one that runs.
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Sunday 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      keep:
+        description: 'versions to keep per cache-key stem'
+        type: number
+        default: 3
+      dry_run:
+        description: 'list without deleting'
+        type: boolean
+        default: false
+
+permissions:
+  actions: write # delete caches
+  contents: read
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Prune caches
+        env:
+          GITHUB_TOKEN_VAR: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS="--keep=${{ inputs.keep || 3 }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          node tools/ci/prune-caches.mjs $ARGS

--- a/tools/ci/prune-caches.mjs
+++ b/tools/ci/prune-caches.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+// tools/ci/prune-caches.mjs — prune old GitHub Actions caches.
+//
+// GitHub keeps up to 10 versions per cache key and auto-evicts (LRU) only
+// when the repo crosses the 10 GB total limit, so stale keys accumulate and
+// burn the quota/bandwidth forever (e.g. a `firefox-dl-*` key per Firefox
+// stable bump, a `node-cache-*` per lockfile change). This script keeps the
+// newest N versions per cache-key "stem" (the key without its trailing
+// content hash) and deletes the rest.
+//
+// Usage:
+//   node tools/ci/prune-caches.mjs [--keep 3] [--dry-run]
+//                                  [--prefix <regex>]...
+//
+//   --keep <n>    versions to keep per stem (default 3)
+//   --dry-run     list what would be deleted without deleting
+//   --prefix <re> only touch keys matching this regex (repeatable); default
+//                 is every key. Example: --prefix '^firefox-dl-'
+//
+// Token: reads GITHUB_TOKEN_VAR (repo convention), falling back to GH_TOKEN.
+// Needs `actions: write` scope. Repo comes from GITHUB_REPOSITORY (CI) or the
+// origin remote.
+
+import {execSync} from 'node:child_process';
+
+const argv = process.argv.slice(2);
+const KEEP = Number(argv.find(a => a.startsWith('--keep='))?.split('=')[1] ?? 3);
+const DRY_RUN = argv.includes('--dry-run');
+// Accept both `--prefix <re>` and `--prefix=<re>`.
+const PREFIXES = [];
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a.startsWith('--prefix=')) PREFIXES.push(new RegExp(a.slice('--prefix='.length)));
+  else if (a === '--prefix' && argv[i + 1]) PREFIXES.push(new RegExp(argv[++i]));
+}
+
+function repoSlug() {
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  const url = execSync('git config --get remote.origin.url', {encoding: 'utf-8'}).trim();
+  const m = url.match(/(?:github\.com[/:]|git@github\.com:)([^/]+)\/([^/.]+)/);
+  if (!m) throw new Error(`cannot derive repo from origin URL: ${url}`);
+  return `${m[1]}/${m[2]}`;
+}
+
+function token() {
+  const t = process.env.GITHUB_TOKEN_VAR || process.env.GH_TOKEN;
+  if (!t) {
+    throw new Error(
+      'No token: set GITHUB_TOKEN_VAR (or GH_TOKEN) with `actions: write` scope.'
+    );
+  }
+  return t;
+}
+
+/** Strip a trailing content hash so versions of the same key group together. */
+function stem(key) {
+  return key.replace(/[0-9a-f]{8,}$/i, '');
+}
+
+async function main() {
+  const repo = repoSlug();
+  const auth = `Bearer ${token()}`;
+  const api = 'https://api.github.com';
+
+  const caches = [];
+  for (let page = 1; ; page++) {
+    const res = await fetch(
+      `${api}/repos/${repo}/actions/caches?per_page=100&page=${page}`,
+      {headers: {authorization: auth, 'x-github-api-version': '2022-11-28'}}
+    );
+    if (!res.ok) throw new Error(`list caches failed: ${res.status} ${await res.text()}`);
+    const body = await res.json();
+    caches.push(...(body.actions_caches ?? []));
+    if (body.actions_caches.length === 0 || page >= (body.total_count ?? 0) / 100 + 1) break;
+    if (body.actions_caches.length < 100) break;
+  }
+
+  const inScope = PREFIXES.length === 0
+    ? caches
+    : caches.filter(c => PREFIXES.some(re => re.test(c.key)));
+
+  const byStem = new Map();
+  for (const c of inScope) {
+    const s = stem(c.key);
+    if (!byStem.has(s)) byStem.set(s, []);
+    byStem.get(s).push(c);
+  }
+
+  const toDelete = [];
+  for (const [s, group] of byStem) {
+    group.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+    for (const c of group.slice(KEEP)) toDelete.push(c);
+  }
+
+  const totalSize = inScope.reduce((n, c) => n + c.size_in_bytes, 0);
+  console.log(
+    `repo ${repo}: ${caches.length} caches, ${inScope.length} in scope ` +
+      `(${(totalSize / 1e6).toFixed(1)} MB), keeping ${KEEP} per stem`
+  );
+  for (const c of toDelete) {
+    console.log(
+      `  delete ${DRY_RUN ? '[dry-run] ' : ''}${c.key}  ` +
+        `(${(c.size_in_bytes / 1e6).toFixed(1)} MB, ${c.created_at})`
+    );
+    if (!DRY_RUN) {
+      const res = await fetch(`${api}/repos/${repo}/actions/caches/${c.id}`, {
+        method: 'DELETE',
+        headers: {authorization: auth, 'x-github-api-version': '2022-11-28'},
+      });
+      if (!res.ok) throw new Error(`delete ${c.key} failed: ${res.status} ${await res.text()}`);
+    }
+  }
+  console.log(DRY_RUN ? `would delete ${toDelete.length}` : `deleted ${toDelete.length}`);
+}
+
+main().catch(err => {
+  console.error(`✗ Error: ${err.message}`);
+  process.exit(1);
+});

--- a/tools/ci/prune-caches.mjs
+++ b/tools/ci/prune-caches.mjs
@@ -27,13 +27,16 @@ import {execSync} from 'node:child_process';
 const argv = process.argv.slice(2);
 const KEEP = Number(argv.find(a => a.startsWith('--keep='))?.split('=')[1] ?? 3);
 const DRY_RUN = argv.includes('--dry-run');
-// Accept both `--prefix <re>` and `--prefix=<re>`.
+// Accept both `--prefix <re>` and `--prefix=<re>`. The pattern is the user's
+// own CLI filter — intentionally arbitrary, so disable the ReDoS lint.
+/* eslint-disable security/detect-non-literal-regexp */
 const PREFIXES = [];
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
   if (a.startsWith('--prefix=')) PREFIXES.push(new RegExp(a.slice('--prefix='.length)));
   else if (a === '--prefix' && argv[i + 1]) PREFIXES.push(new RegExp(argv[++i]));
 }
+/* eslint-enable security/detect-non-literal-regexp */
 
 function repoSlug() {
   if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
@@ -88,7 +91,7 @@ async function main() {
   }
 
   const toDelete = [];
-  for (const [s, group] of byStem) {
+  for (const [, group] of byStem) {
     group.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
     for (const c of group.slice(KEEP)) toDelete.push(c);
   }

--- a/tools/ci/prune-caches.mjs
+++ b/tools/ci/prune-caches.mjs
@@ -49,9 +49,7 @@ function repoSlug() {
 function token() {
   const t = process.env.GITHUB_TOKEN_VAR || process.env.GH_TOKEN;
   if (!t) {
-    throw new Error(
-      'No token: set GITHUB_TOKEN_VAR (or GH_TOKEN) with `actions: write` scope.'
-    );
+    throw new Error('No token: set GITHUB_TOKEN_VAR (or GH_TOKEN) with `actions: write` scope.');
   }
   return t;
 }
@@ -68,10 +66,9 @@ async function main() {
 
   const caches = [];
   for (let page = 1; ; page++) {
-    const res = await fetch(
-      `${api}/repos/${repo}/actions/caches?per_page=100&page=${page}`,
-      {headers: {authorization: auth, 'x-github-api-version': '2022-11-28'}}
-    );
+    const res = await fetch(`${api}/repos/${repo}/actions/caches?per_page=100&page=${page}`, {
+      headers: {'authorization': auth, 'x-github-api-version': '2022-11-28'},
+    });
     if (!res.ok) throw new Error(`list caches failed: ${res.status} ${await res.text()}`);
     const body = await res.json();
     caches.push(...(body.actions_caches ?? []));
@@ -79,9 +76,8 @@ async function main() {
     if (body.actions_caches.length < 100) break;
   }
 
-  const inScope = PREFIXES.length === 0
-    ? caches
-    : caches.filter(c => PREFIXES.some(re => re.test(c.key)));
+  const inScope =
+    PREFIXES.length === 0 ? caches : caches.filter(c => PREFIXES.some(re => re.test(c.key)));
 
   const byStem = new Map();
   for (const c of inScope) {
@@ -109,7 +105,7 @@ async function main() {
     if (!DRY_RUN) {
       const res = await fetch(`${api}/repos/${repo}/actions/caches/${c.id}`, {
         method: 'DELETE',
-        headers: {authorization: auth, 'x-github-api-version': '2022-11-28'},
+        headers: {'authorization': auth, 'x-github-api-version': '2022-11-28'},
       });
       if (!res.ok) throw new Error(`delete ${c.key} failed: ${res.status} ${await res.text()}`);
     }


### PR DESCRIPTION
GitHub keeps up to 10 versions per cache key and only auto-evicts (LRU) past
the 10 GB total, so stale keys accumulate: a `firefox-dl-*` key per Firefox
stable bump, a `node-cache-*` per lockfile change.

- `tools/ci/prune-caches.mjs` — lists caches via the API, groups keys by
  stem (key minus trailing content hash), keeps the newest `--keep` per
  stem, deletes the rest. Supports `--keep`, `--prefix <re>`, `--dry-run`;
  token from `GITHUB_TOKEN_VAR`/`GH_TOKEN` (needs `actions: write`).
- `.github/workflows/cache-cleanup.yml` — runs it weekly (Sunday 03:00 UTC)
  plus `workflow_dispatch` with keep/dry-run inputs.

Validated live before pushing: pruned 6 stale `node-cache-*` entries
(~150 MB) with `--keep 3`, verified 0 remain.