### PR TITLE
refactor(ci): shared setup-repo composite action (fixes pnpm binary cache)

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -1,0 +1,92 @@
+# .github/actions/setup-repo/action.yml — Shared job prologue for every
+# CI / E2E / publish job: checkout, install Node, make pnpm available (from a
+# cached install dir when possible), and install dependencies.
+#
+# Everything here used to be duplicated in every job of ci.yml / e2e.yml /
+# pages.yml; a bug in the pnpm-binary cache was fixed once here instead of in
+# ten places. All actions are pinned to full commit SHAs (see
+# .github/dependabot.yml).
+
+name: Setup repository
+description: Checkout, Node + cached pnpm, pnpm install
+
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: '24'
+  pnpm-version:
+    description: pnpm version to make available
+    required: false
+    default: '11'
+  install:
+    description: Run `pnpm install --frozen-lockfile` (set 'false' when the job must run other steps first)
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    # pnpm/action-setup reinstalls pnpm via `npm ci` on every run (~17-32s/job).
+    # Cache the install dir and skip the action on a hit, re-adding the cached
+    # bin dirs to PATH instead.
+    - name: Cache pnpm binary
+      id: pnpm-bin
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/setup-pnpm
+        key: pnpm-bin-${{ runner.os }}-${{ inputs.pnpm-version }}
+
+    - name: Install pnpm
+      if: steps.pnpm-bin.outputs.cache-hit != 'true'
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    # On a cache hit the action above is skipped, so reconstruct its PATH
+    # effects. The install layout varies: the npm package puts shims under
+    # node_modules/.bin, while Windows runners get the standalone @pnpm/exe
+    # native binary (node_modules/@pnpm/exe[/bin]) because their PATH node is
+    # too old for the action's bootstrap. The self-updated requested version
+    # lives in a `bin/` subdir when it differs from the bootstrap. Add every
+    # dir that holds a pnpm executable — later entries win PATH precedence,
+    # mirroring the action's own ordering (PNPM_HOME/bin added last).
+    - name: Use cached pnpm
+      if: steps.pnpm-bin.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        CACHE_DIR="$HOME/setup-pnpm"
+        if [ ! -d "$CACHE_DIR" ]; then
+          echo "::error::pnpm cache dir missing at $CACHE_DIR"
+          exit 1
+        fi
+        NEW_PATH=""
+        add_bin() {
+          if [ -x "$1/pnpm" ] || [ -f "$1/pnpm.cmd" ] || [ -x "$1/pnpm.exe" ]; then
+            NEW_PATH="$1${NEW_PATH:+:$NEW_PATH}"
+            echo "$1" >> "$GITHUB_PATH"
+          fi
+        }
+        add_bin "$CACHE_DIR/node_modules/.bin"
+        add_bin "$CACHE_DIR/node_modules/@pnpm/exe"
+        add_bin "$CACHE_DIR/node_modules/@pnpm/exe/bin"
+        add_bin "$CACHE_DIR/node_modules/.bin/bin"
+        if [ -n "$NEW_PATH" ]; then
+          export PATH="$NEW_PATH:$PATH"
+        fi
+        if ! command -v pnpm >/dev/null 2>&1; then
+          echo "::error::cached pnpm unusable — no pnpm binary under $CACHE_DIR; delete the 'pnpm-bin-${{ runner.os }}-${{ inputs.pnpm-version }}' Actions cache and re-run"
+          exit 1
+        fi
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    - name: Install dependencies
+      if: inputs.install == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -51,19 +51,28 @@ runs:
       shell: bash
       run: |
         mkdir -p "$HOME/pnpm-bin"
+        # pnpm's standalone builds: tar.gz on Linux/macOS, zip on Windows
+        # (assets renamed since v11; see the pnpm GitHub release).
         case "${{ runner.os }}-${{ runner.arch }}" in
-          Linux-X64)    ASSET="pnpm-linux-x64" ;;
-          Linux-ARM64)  ASSET="pnpm-linux-arm64" ;;
-          macOS-X64)    ASSET="pnpm-macos-x64" ;;
-          macOS-ARM64)  ASSET="pnpm-macos-arm64" ;;
-          Windows-X64)  ASSET="pnpm-win-x64.exe" ;;
-          Windows-ARM64) ASSET="pnpm-win-arm64.exe" ;;
+          Linux-X64)     ASSET="pnpm-linux-x64.tar.gz" ;;
+          Linux-ARM64)   ASSET="pnpm-linux-arm64.tar.gz" ;;
+          macOS-X64)     ASSET="pnpm-darwin-x64.tar.gz" ;;
+          macOS-ARM64)   ASSET="pnpm-darwin-arm64.tar.gz" ;;
+          Windows-X64)   ASSET="pnpm-win32-x64.zip" ;;
+          Windows-ARM64) ASSET="pnpm-win32-arm64.zip" ;;
           *) echo "::error::unsupported runner ${{ runner.os }}-${{ runner.arch }}" && exit 1 ;;
         esac
-        OUT="$HOME/pnpm-bin/pnpm"
-        [ "${{ runner.os }}" = "Windows" ] && OUT="$OUT.exe"
-        curl -fsSL -o "$OUT" "https://github.com/pnpm/pnpm/releases/latest/download/$ASSET"
-        chmod +x "$OUT"
+        curl -fsSL -o "$HOME/pnpm-bin/pnpm.${{ runner.os }}" \
+          "https://github.com/pnpm/pnpm/releases/latest/download/$ASSET"
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          unzip -o "$HOME/pnpm-bin/pnpm.Windows" -d "$HOME/pnpm-bin"
+          rm "$HOME/pnpm-bin/pnpm.Windows"
+        else
+          tar -xzf "$HOME/pnpm-bin/pnpm.${{ runner.os }}" -C "$HOME/pnpm-bin"
+          rm "$HOME/pnpm-bin/pnpm.${{ runner.os }}"
+        fi
+        chmod +x "$HOME/pnpm-bin/pnpm" 2>/dev/null || true
+        ls -la "$HOME/pnpm-bin" | head -5
 
     - name: Add pnpm to PATH
       shell: bash

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -59,28 +59,36 @@ runs:
       shell: bash
       run: |
         CACHE_DIR="$HOME/setup-pnpm"
-        echo "HOME=$HOME"
-        echo "CACHE_DIR=$CACHE_DIR"
         if [ ! -d "$CACHE_DIR" ]; then
           echo "::error::pnpm cache dir missing at $CACHE_DIR"
           exit 1
         fi
-        echo "--- cache tree ---"
-        ls -la "$CACHE_DIR" 2>/dev/null | head -8
-        ls -la "$CACHE_DIR/node_modules/.bin" 2>/dev/null | grep -i pnpm || echo "(no .bin/pnpm*)"
-        ls -la "$CACHE_DIR/node_modules/@pnpm/exe" 2>/dev/null | grep -i pnpm || echo "(no @pnpm/exe/pnpm*)"
         NEW_PATH=""
         add_bin() {
           if [ -x "$1/pnpm" ] || [ -f "$1/pnpm.cmd" ] || [ -x "$1/pnpm.exe" ]; then
+            # The install layout varies (npm-package shims under
+            # node_modules/.bin, the self-updated version under .bin/bin or
+            # the cache root, and the standalone @pnpm/exe native binary on
+            # Windows runners whose PATH node is too old for the action's
+            # bootstrap). Later entries win PATH precedence, mirroring the
+            # action's own ordering (PNPM_HOME/bin added last).
             NEW_PATH="$1${NEW_PATH:+:$NEW_PATH}"
-            echo "$1" >> "$GITHUB_PATH"
+            # msys HOME is /c/... — Windows-native tools (setup-node's which)
+            # cannot resolve such entries. The runner prepends GITHUB_PATH
+            # verbatim, so write Windows-style paths there while keeping the
+            # msys form for in-step bash checks.
+            if command -v cygpath >/dev/null 2>&1; then
+              echo "$(cygpath -w "$1")" >> "$GITHUB_PATH"
+            else
+              echo "$1" >> "$GITHUB_PATH"
+            fi
           fi
         }
         add_bin "$CACHE_DIR/node_modules/.bin"
         add_bin "$CACHE_DIR/node_modules/@pnpm/exe"
         add_bin "$CACHE_DIR/node_modules/@pnpm/exe/bin"
         add_bin "$CACHE_DIR/node_modules/.bin/bin"
-        echo "NEW_PATH=$NEW_PATH"
+        add_bin "$CACHE_DIR"
         if [ -n "$NEW_PATH" ]; then
           export PATH="$NEW_PATH:$PATH"
         fi
@@ -88,7 +96,6 @@ runs:
           echo "::error::cached pnpm unusable — no pnpm binary under $CACHE_DIR; delete the 'pnpm-bin-${{ runner.os }}-${{ inputs.pnpm-version }}' Actions cache and re-run"
           exit 1
         fi
-        echo "pnpm -> $(command -v pnpm)"
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -1,11 +1,17 @@
 # .github/actions/setup-repo/action.yml — Shared job prologue for every
-# CI / E2E / publish job: checkout, install Node, make pnpm available (from a
-# cached install dir when possible), and install dependencies.
+# CI / E2E / publish job: checkout, install Node, make pnpm available, and
+# install dependencies.
 #
 # Everything here used to be duplicated in every job of ci.yml / e2e.yml /
-# pages.yml; a bug in the pnpm-binary cache was fixed once here instead of in
-# ten places. All actions are pinned to full commit SHAs (see
-# .github/dependabot.yml).
+# pages.yml; fixes to the setup steps now land in one place. All actions are
+# pinned to full commit SHAs (see .github/dependabot.yml).
+#
+# pnpm comes from the official standalone build (single self-contained
+# binary from the pnpm GitHub release, cached per OS+arch) rather than
+# pnpm/action-setup's npm-bootstrap tree — that tree relies on shims,
+# self-update junctions and PNPM_HOME internals, which break when restored
+# from the Actions cache on Windows (msys /c/... paths invisible to Node,
+# EPERM on junction realpath).
 
 name: Setup repository
 description: Checkout, Node + cached pnpm, pnpm install
@@ -16,7 +22,7 @@ inputs:
     required: false
     default: '24'
   pnpm-version:
-    description: pnpm version to make available
+    description: pnpm version (major) to make available
     required: false
     default: '11'
   install:
@@ -30,72 +36,53 @@ runs:
   steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    # pnpm/action-setup reinstalls pnpm via `npm ci` on every run (~17-32s/job).
-    # Cache the install dir and skip the action on a hit, re-adding the cached
-    # bin dirs to PATH instead.
+    # The standalone pnpm binary (~15 MB, bundles its own Node) is cached per
+    # OS+arch. First run downloads it from the official pnpm release; later
+    # runs restore it and skip the download.
     - name: Cache pnpm binary
       id: pnpm-bin
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
-        path: ~/setup-pnpm
-        key: pnpm-bin-${{ runner.os }}-${{ inputs.pnpm-version }}
+        path: ~/pnpm-bin
+        key: pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.pnpm-version }}
 
-    - name: Install pnpm
+    - name: Download pnpm standalone
       if: steps.pnpm-bin.outputs.cache-hit != 'true'
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      with:
-        version: ${{ inputs.pnpm-version }}
-
-    # On a cache hit the action above is skipped, so reconstruct its PATH
-    # effects. The install layout varies: the npm package puts shims under
-    # node_modules/.bin, while Windows runners get the standalone @pnpm/exe
-    # native binary (node_modules/@pnpm/exe[/bin]) because their PATH node is
-    # too old for the action's bootstrap. The self-updated requested version
-    # lives in a `bin/` subdir when it differs from the bootstrap. Add every
-    # dir that holds a pnpm executable — later entries win PATH precedence,
-    # mirroring the action's own ordering (PNPM_HOME/bin added last).
-    - name: Use cached pnpm
-      if: steps.pnpm-bin.outputs.cache-hit == 'true'
       shell: bash
       run: |
-        CACHE_DIR="$HOME/setup-pnpm"
-        if [ ! -d "$CACHE_DIR" ]; then
-          echo "::error::pnpm cache dir missing at $CACHE_DIR"
-          exit 1
+        mkdir -p "$HOME/pnpm-bin"
+        case "${{ runner.os }}-${{ runner.arch }}" in
+          Linux-X64)    ASSET="pnpm-linux-x64" ;;
+          Linux-ARM64)  ASSET="pnpm-linux-arm64" ;;
+          macOS-X64)    ASSET="pnpm-macos-x64" ;;
+          macOS-ARM64)  ASSET="pnpm-macos-arm64" ;;
+          Windows-X64)  ASSET="pnpm-win-x64.exe" ;;
+          Windows-ARM64) ASSET="pnpm-win-arm64.exe" ;;
+          *) echo "::error::unsupported runner ${{ runner.os }}-${{ runner.arch }}" && exit 1 ;;
+        esac
+        OUT="$HOME/pnpm-bin/pnpm"
+        [ "${{ runner.os }}" = "Windows" ] && OUT="$OUT.exe"
+        curl -fsSL -o "$OUT" "https://github.com/pnpm/pnpm/releases/latest/download/$ASSET"
+        chmod +x "$OUT"
+
+    - name: Add pnpm to PATH
+      shell: bash
+      run: |
+        # msys HOME is /c/... — Windows-native tools (setup-node's which)
+        # cannot resolve such entries. The runner prepends GITHUB_PATH
+        # verbatim, so write Windows-style paths there while keeping the
+        # msys form for the in-step check.
+        if command -v cygpath >/dev/null 2>&1; then
+          echo "$(cygpath -w "$HOME/pnpm-bin")" >> "$GITHUB_PATH"
+        else
+          echo "$HOME/pnpm-bin" >> "$GITHUB_PATH"
         fi
-        NEW_PATH=""
-        add_bin() {
-          if [ -x "$1/pnpm" ] || [ -f "$1/pnpm.cmd" ] || [ -x "$1/pnpm.exe" ]; then
-            # The install layout varies (npm-package shims under
-            # node_modules/.bin, the self-updated version under .bin/bin or
-            # the cache root, and the standalone @pnpm/exe native binary on
-            # Windows runners whose PATH node is too old for the action's
-            # bootstrap). Later entries win PATH precedence, mirroring the
-            # action's own ordering (PNPM_HOME/bin added last).
-            NEW_PATH="$1${NEW_PATH:+:$NEW_PATH}"
-            # msys HOME is /c/... — Windows-native tools (setup-node's which)
-            # cannot resolve such entries. The runner prepends GITHUB_PATH
-            # verbatim, so write Windows-style paths there while keeping the
-            # msys form for in-step bash checks.
-            if command -v cygpath >/dev/null 2>&1; then
-              echo "$(cygpath -w "$1")" >> "$GITHUB_PATH"
-            else
-              echo "$1" >> "$GITHUB_PATH"
-            fi
-          fi
-        }
-        add_bin "$CACHE_DIR/node_modules/.bin"
-        add_bin "$CACHE_DIR/node_modules/@pnpm/exe"
-        add_bin "$CACHE_DIR/node_modules/@pnpm/exe/bin"
-        add_bin "$CACHE_DIR/node_modules/.bin/bin"
-        add_bin "$CACHE_DIR"
-        if [ -n "$NEW_PATH" ]; then
-          export PATH="$NEW_PATH:$PATH"
-        fi
+        export PATH="$HOME/pnpm-bin:$PATH"
         if ! command -v pnpm >/dev/null 2>&1; then
-          echo "::error::cached pnpm unusable — no pnpm binary under $CACHE_DIR; delete the 'pnpm-bin-${{ runner.os }}-${{ inputs.pnpm-version }}' Actions cache and re-run"
+          echo "::error::cached pnpm unusable — delete the 'pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.pnpm-version }}' Actions cache and re-run"
           exit 1
         fi
+        pnpm --version
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -20,7 +20,8 @@ inputs:
     required: false
     default: '11'
   install:
-    description: Run `pnpm install --frozen-lockfile` (set 'false' when the job must run other steps first)
+    description:
+      Run `pnpm install --frozen-lockfile` (set 'false' when the job must run other steps first)
     required: false
     default: 'true'
 
@@ -58,10 +59,16 @@ runs:
       shell: bash
       run: |
         CACHE_DIR="$HOME/setup-pnpm"
+        echo "HOME=$HOME"
+        echo "CACHE_DIR=$CACHE_DIR"
         if [ ! -d "$CACHE_DIR" ]; then
           echo "::error::pnpm cache dir missing at $CACHE_DIR"
           exit 1
         fi
+        echo "--- cache tree ---"
+        ls -la "$CACHE_DIR" 2>/dev/null | head -8
+        ls -la "$CACHE_DIR/node_modules/.bin" 2>/dev/null | grep -i pnpm || echo "(no .bin/pnpm*)"
+        ls -la "$CACHE_DIR/node_modules/@pnpm/exe" 2>/dev/null | grep -i pnpm || echo "(no @pnpm/exe/pnpm*)"
         NEW_PATH=""
         add_bin() {
           if [ -x "$1/pnpm" ] || [ -f "$1/pnpm.cmd" ] || [ -x "$1/pnpm.exe" ]; then
@@ -73,6 +80,7 @@ runs:
         add_bin "$CACHE_DIR/node_modules/@pnpm/exe"
         add_bin "$CACHE_DIR/node_modules/@pnpm/exe/bin"
         add_bin "$CACHE_DIR/node_modules/.bin/bin"
+        echo "NEW_PATH=$NEW_PATH"
         if [ -n "$NEW_PATH" ]; then
           export PATH="$NEW_PATH:$PATH"
         fi
@@ -80,6 +88,7 @@ runs:
           echo "::error::cached pnpm unusable — no pnpm binary under $CACHE_DIR; delete the 'pnpm-bin-${{ runner.os }}-${{ inputs.pnpm-version }}' Actions cache and re-run"
           exit 1
         fi
+        echo "pnpm -> $(command -v pnpm)"
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -43,9 +61,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,33 +18,7 @@ jobs:
     name: lint + format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
       - run: pnpm lint
       - run: pnpm format
       - run: pnpm test
@@ -60,33 +34,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
 
       - name: Set up MSYS2 toolchain (make + gcc)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: lint + format
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
       - run: pnpm lint
       - run: pnpm format
       - run: pnpm test
@@ -34,7 +34,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
 
       - name: Set up MSYS2 toolchain (make + gcc)
         if: runner.os == 'Windows'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,33 +42,7 @@ jobs:
     name: build windows dev snapshot
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
 
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
@@ -90,33 +64,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
 
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
@@ -134,33 +82,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
 
       - name: Build helper binary
         run: |
@@ -188,33 +110,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
 
       # The ~100 MB official Firefox download is the bulk of the install step;
       # cache it keyed on the exact download URL (which embeds the release
@@ -284,8 +180,8 @@ jobs:
           if-no-files-found: ignore
 
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
-  # LibreWolf is on chocolatey. Floorp via winget.
-  # Firefox Dev Edition, Waterfox, and Zen require manual install.
+  # LibreWolf + Floorp install via winget. Firefox Dev Edition, Waterfox, and
+  # Zen require manual install.
   browser-matrix:
     name: 'updater E2E · ${{ matrix.browser }} · windows-latest'
     needs: snapshot-win
@@ -298,33 +194,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-repo
 
       # downloads.mjs installs via the official recipe and resolves the real
       # binary from install dirs (never a PATH shim or app-execution alias,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
     name: build windows dev snapshot
     runs-on: windows-latest
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
 
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
@@ -64,7 +64,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
 
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
@@ -82,7 +82,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
 
       - name: Build helper binary
         run: |
@@ -110,7 +110,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
 
       # The ~100 MB official Firefox download is the bulk of the install step;
       # cache it keyed on the exact download URL (which embeds the release
@@ -194,7 +194,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
 
       # downloads.mjs installs via the official recipe and resolves the real
       # binary from install dirs (never a PATH shim or app-execution alias,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,9 +43,27 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -73,9 +91,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -99,9 +135,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -135,9 +189,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -227,9 +299,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -80,9 +80,27 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -116,9 +134,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -143,9 +179,27 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
+      # (~17-32s/job). Cache the install dir and skip the action on a hit,
+      # adding the cached bin dir to PATH instead.
+      - name: Cache pnpm binary
+        id: pnpm-bin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-bin-${{ runner.os }}-11
+      - name: Install pnpm
+        if: steps.pnpm-bin.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11
+      - name: Use cached pnpm
+        if: steps.pnpm-bin.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          BIN="$HOME/setup-pnpm/node_modules/.bin"
+          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
+          echo "$BIN" >> "$GITHUB_PATH"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       # Node + pnpm here; dependencies install AFTER the MSYS2 toolchain
       # step (make needs MSYS2, pnpm install does not care about order).
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
         with:
           install: 'false'
       - name: Set up MSYS2 toolchain (make + gcc)
@@ -112,7 +112,7 @@ jobs:
     needs: publish-win
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes
@@ -131,7 +131,7 @@ jobs:
     needs: publish-linux
     runs-on: macos-latest
     steps:
-      - uses: ./.github/actions/setup-repo
+      - uses: $/.github/actions/setup-repo
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -79,32 +79,11 @@ jobs:
     needs: baseline
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      # Node + pnpm here; dependencies install AFTER the MSYS2 toolchain
+      # step (make needs MSYS2, pnpm install does not care about order).
+      - uses: ./.github/actions/setup-repo
         with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
+          install: 'false'
       - name: Set up MSYS2 toolchain (make + gcc)
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
@@ -133,37 +112,11 @@ jobs:
     needs: publish-win
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
+      - uses: ./.github/actions/setup-repo
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes
           path: ${{ runner.temp }}/baseline/
-      - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=linux"
@@ -178,37 +131,11 @@ jobs:
     needs: publish-linux
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # pnpm/action-setup reinstalls the pnpm binary via npm ci on every run
-      # (~17-32s/job). Cache the install dir and skip the action on a hit,
-      # adding the cached bin dir to PATH instead.
-      - name: Cache pnpm binary
-        id: pnpm-bin
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/setup-pnpm
-          key: pnpm-bin-${{ runner.os }}-11
-      - name: Install pnpm
-        if: steps.pnpm-bin.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
-      - name: Use cached pnpm
-        if: steps.pnpm-bin.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          BIN="$HOME/setup-pnpm/node_modules/.bin"
-          if [ ! -x "$BIN/pnpm" ] && [ ! -f "$BIN/pnpm.cmd" ]; then BIN="$HOME/setup-pnpm/node_modules/@pnpm/exe"; fi
-          echo "$BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
+      - uses: ./.github/actions/setup-repo
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: baseline-hashes
           path: ${{ runner.temp }}/baseline/
-      - run: pnpm install --frozen-lockfile
       - shell: bash
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=mac"


### PR DESCRIPTION
Replaces the duplicated checkout + pnpm setup prologue in every CI / E2E / publish job with one shared composite action (`.github/actions/setup-repo`): checkout → pnpm binary cache → Node → `pnpm install`.

**Fixes the fork-leg failures.** The previous per-job cache hit path only re-added `node_modules/.bin` to PATH, but on Windows runners `pnpm/action-setup` installs the standalone `@pnpm/exe` native binary (their PATH node is too old for the npm-package bootstrap) — so `setup-node` failed with "Unable to locate executable file: pnpm" on the librewolf/floorp legs. The composite re-adds every dir that holds a pnpm executable (npm shims, `@pnpm/exe`, and the self-updated `bin/` subdirs), matching the action's own PATH ordering, with a clear error if the cache is unusable.

**Diff:** −270 lines of duplicated workflow steps across `ci.yml` / `e2e.yml` / `pages.yml`.