### PR TITLE
feat(updater): pref-based URL overrides — true cross-OS snapshot sharing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,16 +31,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Windows dev snapshot (shared by the fork legs) ───────────────────────
-  # The browser-matrix legs (librewolf, floorp) run on windows-latest with an
-  # identical workspace path, so one Windows snapshot is hash-consistent for
-  # all three: LOCAL-mode URLs baked into utils.zip point at the same dist dir
-  # on every job. Sharing across OSes is impossible — the baked path is part
-  # of the hashed utils file set, so a repointed config flips the package hash
-  # and the updater sees a false "update available".
-  snapshot-win:
-    name: build windows dev snapshot
-    runs-on: windows-latest
+  # ── Dev snapshot (built ONCE per run, shared across all updater legs) ────
+  # The package zips + hashes.json are OS-independent, so one ubuntu build
+  # serves every updater leg. A LOCAL-mode build bakes the BUILDER's dist dir
+  # into utils.zip's generated config (part of the hashed file set), so on a
+  # different OS the test repoints the updater at its own copy via
+  # extensions.firefox-scripts.override.<KEY> prefs (localConfigOverrides in
+  # tools/test/e2e/helpers.mjs) — never by rewriting the config, which would
+  # flip the package hash and break the staleness check.
+  snapshot:
+    name: build dev snapshot
+    runs-on: ubuntu-latest
     steps:
       - uses: $/.github/actions/setup-repo
 
@@ -50,7 +51,7 @@ jobs:
       - name: Upload dev snapshot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dev-snapshot-win
+          name: dev-snapshot
           path: dist/
           if-no-files-found: error
 
@@ -101,6 +102,7 @@ jobs:
   # Every OS leg is required; the updater must work across the supported matrix.
   updater:
     name: 'updater E2E · ${{ matrix.os }}'
+    needs: snapshot
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -151,8 +153,15 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: node tools/test/e2e/downloads.mjs firefox
 
-      - name: Build snapshot
-        run: pnpm upload:local --mode=dev
+      # Restores dist/dev-<branch>-<sha>/ built once by the `snapshot` job.
+      # On non-ubuntu legs the baked LOCAL_DIST_PATH differs from this
+      # runner's, so the test sets the override prefs (localConfigOverrides)
+      # to point the updater at this copy.
+      - name: Download dev snapshot
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: dev-snapshot
+          path: dist/
 
       # The test builds its own fresh temp profile from the dev snapshot, so no
       # profile-seed step is needed. It reads FIREFOX_BINARY (set by the install
@@ -184,7 +193,7 @@ jobs:
   # Zen require manual install.
   browser-matrix:
     name: 'updater E2E · ${{ matrix.browser }} · windows-latest'
-    needs: snapshot-win
+    needs: snapshot
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -202,14 +211,14 @@ jobs:
       - name: Install ${{ matrix.browser }}
         run: node tools/test/e2e/downloads.mjs ${{ matrix.browser }}
 
-      # Restores dist/dev-<branch>-<sha>/ built by snapshot-win. `needs`
-      # already waits for that job, so the artifact always exists here. The
-      # Windows snapshot's baked LOCAL_DIST_PATH matches this runner's path,
-      # so the hash check stays consistent.
+      # Restores dist/dev-<branch>-<sha>/ built by the `snapshot` job. The
+      # ubuntu snapshot's baked LOCAL_DIST_PATH differs from this Windows
+      # runner's, so the test sets the override prefs (localConfigOverrides)
+      # to point the updater at this copy.
       - name: Download dev snapshot
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: dev-snapshot-win
+          name: dev-snapshot
           path: dist/
 
       - name: Run updater E2E

--- a/core/chrome/utils/updater/scriptsUpdater.sys.mjs
+++ b/core/chrome/utils/updater/scriptsUpdater.sys.mjs
@@ -36,6 +36,39 @@ const {CONFIG} = ChromeUtils.importESModule(
   'chrome://firefox-scripts/content/updater-config.sys.mjs'
 );
 
+// Test/local override prefs: a string pref
+// extensions.firefox-scripts.override.<KEY> (HASHES_URL, ZIP_BASE_URL,
+// HELPER_BASE_URL) wins over the generated CONFIG value.  This lets tests
+// point the updater at any local snapshot (e.g. one built on another OS)
+// WITHOUT touching the config file — it ships inside utils.zip and is part of
+// the hashed file set, so rewriting it would flip the package hash and break
+// the staleness check.
+const PREF_OVERRIDE_PREFIX = 'extensions.firefox-scripts.override.';
+
+function configValue(key) {
+  try {
+    const override = Services.prefs.getStringPref(PREF_OVERRIDE_PREFIX + key, '');
+    if (override) {
+      return override;
+    }
+  } catch (_) {
+    // unreadable pref → fall back to the generated CONFIG value
+  }
+  return CONFIG[key];
+}
+
+export function getHashesUrl() {
+  return configValue('HASHES_URL');
+}
+
+export function getZipBaseUrl() {
+  return configValue('ZIP_BASE_URL');
+}
+
+export function getHelperBaseUrl() {
+  return configValue('HELPER_BASE_URL');
+}
+
 const {Downloads} = ChromeUtils.importESModule('resource://gre/modules/Downloads.sys.mjs');
 
 // The actual update tab (updater-ui.zip) — a privileged chrome:// page.
@@ -191,7 +224,7 @@ export async function checkScriptsUpdateNeeded() {
   try {
     // Never hang on a dead/stalled manifest host: the daily check must fail
     // fast and leave the tab closed rather than spin.
-    const responseText = await withTimeout(fetchText(CONFIG.HASHES_URL), MANIFEST_TIMEOUT_MS);
+    const responseText = await withTimeout(fetchText(getHashesUrl()), MANIFEST_TIMEOUT_MS);
     const remoteInfo = JSON.parse(responseText);
 
     const greDir = Services.dirsvc.get('GreD', Ci.nsIFile).path;
@@ -266,7 +299,7 @@ export async function ensureUpdaterUi(info) {
 
   const tmpDir = PathUtils.join(PathUtils.tempDir, `fxs-updater-ui-${Date.now()}`);
   try {
-    const zipUrl = `${CONFIG.ZIP_BASE_URL}/updater-ui${CONFIG.ASSET_SUFFIX || ''}.zip`;
+    const zipUrl = `${getZipBaseUrl()}/updater-ui${CONFIG.ASSET_SUFFIX || ''}.zip`;
     const zipPath = PathUtils.join(tmpDir, 'updater-ui.zip');
     await Downloads.fetch(zipUrl, zipPath);
 

--- a/tools/publish/remote-ui/updater.js
+++ b/tools/publish/remote-ui/updater.js
@@ -37,8 +37,15 @@ const {Downloads} = ChromeUtils.importESModule('resource://gre/modules/Downloads
 const {Subprocess} = ChromeUtils.importESModule('resource://gre/modules/Subprocess.sys.mjs');
 const {AppConstants} = ChromeUtils.importESModule('resource://gre/modules/AppConstants.sys.mjs');
 
-const {computeFilesHash, checkScriptsUpdateNeeded, extractZipFlatten, copyFileList, fetchBytes} =
-  ChromeUtils.importESModule('chrome://firefox-scripts/content/scriptsUpdater.sys.mjs');
+const {
+  computeFilesHash,
+  checkScriptsUpdateNeeded,
+  extractZipFlatten,
+  copyFileList,
+  fetchBytes,
+  getZipBaseUrl,
+  getHelperBaseUrl,
+} = ChromeUtils.importESModule('chrome://firefox-scripts/content/scriptsUpdater.sys.mjs');
 
 // URL/path configuration — generated from config/installer.conf at publish
 // time (tools/publish/generateUpdaterConfig.mjs).  Single source of truth.
@@ -46,7 +53,10 @@ const {CONFIG} = ChromeUtils.importESModule(
   'chrome://firefox-scripts/content/updater-config.sys.mjs'
 );
 
-const ZIP_BASE_URL = CONFIG.ZIP_BASE_URL;
+// Resolved through scriptsUpdater.sys.mjs so tests can override the URLs via
+// extensions.firefox-scripts.override.<KEY> prefs without touching hashed
+// files (the config ships inside utils.zip).
+const ZIP_BASE_URL = getZipBaseUrl();
 // Asset-name suffix ('' prod / '-dev' dev): dev zips and helpers are
 // published as utils-dev.zip / helper_win-dev.exe etc.
 const ASSET_SUFFIX = CONFIG.ASSET_SUFFIX || '';
@@ -55,7 +65,7 @@ const UTILS_URL = `${ZIP_BASE_URL}/utils${ASSET_SUFFIX}.zip`;
 
 // Standalone elevated-copy helper — source of the binary is config-driven too
 // (installer.conf HELPER_BASE_URL, generated into updater-config.sys.mjs).
-const HELPER_BASE_URL = CONFIG.HELPER_BASE_URL;
+const HELPER_BASE_URL = getHelperBaseUrl();
 const HELPER_FILENAMES = {
   win: `helper_win${ASSET_SUFFIX}.exe`,
   macosx: `helper_mac${ASSET_SUFFIX}`,

--- a/tools/test/e2e/helpers.mjs
+++ b/tools/test/e2e/helpers.mjs
@@ -4,9 +4,46 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 
 export const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+
+const OVERRIDE_PREFIX = 'extensions.firefox-scripts.override.';
+
+/**
+ * When the dev snapshot was built on another machine (cross-OS sharing), its
+ * baked updater config points at the BUILDER's dist dir (file:// URLs), which
+ * is unreachable here. Rather than rewrite the config — it ships inside
+ * utils.zip and is part of the hashed file set, so rewriting it would flip the
+ * package hash and break the staleness check — point the updater at THIS
+ * machine's snapshot via pref overrides (scriptsUpdater.sys.mjs checks
+ * extensions.firefox-scripts.override.<KEY> before the generated CONFIG).
+ *
+ * @param {string} chromeUtils profile's chrome/utils dir (post-extract)
+ * @param {string} snapshotDir this machine's local snapshot dir
+ * @returns {Record<string, string>} extra prefs, or {} when already consistent
+ */
+export function localConfigOverrides(chromeUtils, snapshotDir) {
+  const cfg = path.join(chromeUtils, 'updater', 'updater-config.sys.mjs');
+  if (!fs.existsSync(cfg)) {
+    return {};
+  }
+  const text = fs.readFileSync(cfg, 'utf-8');
+  const baked = text.match(/LOCAL_DIST_PATH:\s*'([^']*)'/)?.[1];
+  if (!baked) {
+    return {};
+  }
+  const local = snapshotDir.replace(/\\/g, '/');
+  if (baked === local) {
+    return {};
+  }
+  const base = pathToFileURL(local).href.replace(/\/$/, '');
+  return {
+    [OVERRIDE_PREFIX + 'HASHES_URL']: `${base}/hashes.json`,
+    [OVERRIDE_PREFIX + 'ZIP_BASE_URL']: base,
+    [OVERRIDE_PREFIX + 'HELPER_BASE_URL']: base,
+  };
+}
 
 // ── Assertion counters ────────────────────────────────────────────────────
 

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -173,17 +173,19 @@ function seedProfile(
     'extensions.firefox-scripts.lastScriptsCheckDate': '',
   };
   const chromeUtils = path.join(profileDir, 'chrome', 'utils');
-  // Cross-OS snapshot sharing: when the snapshot was built elsewhere its baked
-  // file:// URLs point at the builder's dist dir. Repoint them at THIS
-  // machine's snapshot via pref overrides (never by rewriting the config — it
-  // is part of the hashed utils file set). No-op when the paths already match.
-  Object.assign(prefs, localConfigOverrides(chromeUtils, snapshotDir));
 
   // Extract utils
   const utilsZip = findZip(snapshotDir, ['utils-dev.zip', 'utils.zip']);
   if (utilsZip) {
     extractZip(utilsZip, chromeUtils);
   }
+
+  // Cross-OS snapshot sharing: when the snapshot was built elsewhere its baked
+  // file:// URLs point at the builder's dist dir. Repoint them at THIS
+  // machine's snapshot via pref overrides (never by rewriting the config — it
+  // is part of the hashed utils file set). No-op when the paths already match.
+  // Runs after the utils extract so the generated config file exists.
+  Object.assign(prefs, localConfigOverrides(chromeUtils, snapshotDir));
 
   // Force utils stale by changing a valid, non-startup module. Deleting a
   // shipped module can prevent the scheduler from running at all, which would

--- a/tools/test/e2e/updater-e2e.mjs
+++ b/tools/test/e2e/updater-e2e.mjs
@@ -34,6 +34,7 @@ import {
   tempDir,
   rmDir,
   summary,
+  localConfigOverrides,
 } from './helpers.mjs';
 import {findSnapshot, findZip, extractZip, discoverFirefoxBinary, findGreDir} from './browsers.mjs';
 
@@ -172,6 +173,11 @@ function seedProfile(
     'extensions.firefox-scripts.lastScriptsCheckDate': '',
   };
   const chromeUtils = path.join(profileDir, 'chrome', 'utils');
+  // Cross-OS snapshot sharing: when the snapshot was built elsewhere its baked
+  // file:// URLs point at the builder's dist dir. Repoint them at THIS
+  // machine's snapshot via pref overrides (never by rewriting the config — it
+  // is part of the hashed utils file set). No-op when the paths already match.
+  Object.assign(prefs, localConfigOverrides(chromeUtils, snapshotDir));
 
   // Extract utils
   const utilsZip = findZip(snapshotDir, ['utils-dev.zip', 'utils.zip']);

--- a/tools/test/unit/localConfigOverrides.test.mjs
+++ b/tools/test/unit/localConfigOverrides.test.mjs
@@ -1,0 +1,91 @@
+// tools/test/unit/localConfigOverrides.test.mjs — Unit tests for
+// tools/test/e2e/helpers.mjs localConfigOverrides().
+//
+// Tests: cross-OS snapshot (baked LOCAL_DIST_PATH ≠ local snapshot dir) →
+// override prefs pointing at the local snapshot; same path → no-op; missing
+// config / missing LOCAL_DIST_PATH → no-op.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+const helpersUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'test', 'e2e', 'helpers.mjs')).href;
+const {localConfigOverrides} = await import(helpersUrl);
+
+const OVERRIDE = 'extensions.firefox-scripts.override.';
+
+/** Write a minimal generated updater-config.sys.mjs with the given dist path. */
+function writeConfig(chromeUtils, distPath) {
+  const cfg = path.join(chromeUtils, 'updater', 'updater-config.sys.mjs');
+  fs.mkdirSync(path.dirname(cfg), {recursive: true});
+  fs.writeFileSync(
+    cfg,
+    `export const CONFIG = {\n  HASHES_URL: 'file:///x/hashes.json',\n  LOCAL_DIST_PATH: '${distPath}',\n};\n`
+  );
+}
+
+function makeProfile() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fxs-override-'));
+}
+
+test('localConfigOverrides: foreign snapshot path → override prefs at local dist', () => {
+  const profile = makeProfile();
+  try {
+    const chromeUtils = path.join(profile, 'chrome', 'utils');
+    const snapshotDir = path.join(profile, 'dist', 'dev-HEAD-abc123');
+    // Snapshot built on another machine (e.g. the ubuntu CI snapshot).
+    writeConfig(chromeUtils, '/home/runner/work/firefox-scripts/firefox-scripts/dist/dev-HEAD-abc123');
+
+    const prefs = localConfigOverrides(chromeUtils, snapshotDir);
+    const base = pathToFileURL(snapshotDir.replace(/\\/g, '/')).href.replace(/\/$/, '');
+    assert.deepEqual(prefs, {
+      [OVERRIDE + 'HASHES_URL']: `${base}/hashes.json`,
+      [OVERRIDE + 'ZIP_BASE_URL']: base,
+      [OVERRIDE + 'HELPER_BASE_URL']: base,
+    });
+  } finally {
+    fs.rmSync(profile, {recursive: true, force: true});
+  }
+});
+
+test('localConfigOverrides: same machine path → no overrides', () => {
+  const profile = makeProfile();
+  try {
+    const chromeUtils = path.join(profile, 'chrome', 'utils');
+    const snapshotDir = path.join(profile, 'dist', 'dev-HEAD-abc123');
+    const local = snapshotDir.replace(/\\/g, '/');
+    writeConfig(chromeUtils, local);
+
+    assert.deepEqual(localConfigOverrides(chromeUtils, snapshotDir), {});
+  } finally {
+    fs.rmSync(profile, {recursive: true, force: true});
+  }
+});
+
+test('localConfigOverrides: missing config file → no overrides', () => {
+  const profile = makeProfile();
+  try {
+    const chromeUtils = path.join(profile, 'chrome', 'utils');
+    assert.deepEqual(localConfigOverrides(chromeUtils, path.join(profile, 'dist')), {});
+  } finally {
+    fs.rmSync(profile, {recursive: true, force: true});
+  }
+});
+
+test('localConfigOverrides: config without LOCAL_DIST_PATH → no overrides', () => {
+  const profile = makeProfile();
+  try {
+    const chromeUtils = path.join(profile, 'chrome', 'utils');
+    const cfg = path.join(chromeUtils, 'updater', 'updater-config.sys.mjs');
+    fs.mkdirSync(path.dirname(cfg), {recursive: true});
+    fs.writeFileSync(cfg, 'export const CONFIG = {HASHES_URL: "https://x/hashes.json"};\n');
+
+    assert.deepEqual(localConfigOverrides(chromeUtils, path.join(profile, 'dist')), {});
+  } finally {
+    fs.rmSync(profile, {recursive: true, force: true});
+  }
+});


### PR DESCRIPTION
**Core change:** `scriptsUpdater.sys.mjs` (and the updater tab) now resolve `HASHES_URL` / `ZIP_BASE_URL` / `HELPER_BASE_URL` through override prefs `extensions.firefox-scripts.override.<KEY>` before falling back to the generated `CONFIG`. Tests can point the updater at any local snapshot **without touching hashed files** — the config ships inside `utils.zip` and is part of the hashed file set, so rewriting it (the earlier #48 approach) flips the package hash and makes "up-to-date" look stale.

**Automatic test support:** `localConfigOverrides()` in `tools/test/e2e/helpers.mjs` compares the baked `LOCAL_DIST_PATH` against the runner's snapshot dir and, when they differ (snapshot built on another OS), seeds the three override prefs pointing at the local copy. No-op when paths match (same-OS). 4 new unit tests.

**E2E payoff:** the Windows-only `snapshot-win` job becomes a single ubuntu `snapshot` job serving **all** updater legs (ubuntu/mac/windows) + both fork legs — true cross-OS sharing. Each leg previously ran its own `upload:local --mode=dev` (~20-35s × 5 builds/PR); installer legs keep per-OS builds (native binary).