### PR TITLE
ci: path-filter E2E/publish gates and replace winget with direct downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,33 @@ permissions:
   contents: read
 
 jobs:
+  # ── Changed-paths filter ──────────────────────────────────────────────────
+  # Docs-only / tooling-only PRs skip the publish gate (`build`): nothing that
+  # gets packaged or built changed. `checks` and `ci-gate` always run, so the
+  # required checks never go missing. See docs/DEVELOPING.md → CI.
+  changes:
+    name: detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.filter.outputs.publish }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            publish:
+              - 'core/**'
+              - 'config/installer.conf'
+              - 'installer/**'
+              - 'tools/publish/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
+
   # Fast static gate: eslint (incl. security plugin) + prettier + clang-format
   # + the gcc -fanalyzer C analysis.  Runs on every PR and on main pushes.
   checks:
@@ -28,6 +55,8 @@ jobs:
   # the generated files, hashes and Makefile before they reach a release.
   build:
     name: publish gate — ${{ matrix.os }}
+    needs: changes
+    if: needs.changes.outputs.publish == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -79,15 +108,23 @@ jobs:
     name: CI gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [checks, build]
+    needs: [changes, checks, build]
     steps:
       - name: Verify all CI jobs
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "::error::changes job failed (${{ needs.changes.result }})"
+            exit 1
+          fi
           fail() { echo "::error::$1: $2"; exit 1; }
           ok()   { echo "$1: $2 (OK)"; }
           verify() {
             case "$2" in success) ok "$1" "$2" ;; *) fail "$1" "$2" ;; esac
           }
           verify 'checks' '${{ needs.checks.result }}'
-          verify 'build'   '${{ needs.build.result }}'
+          if [ "${{ needs.changes.outputs.publish }}" = "true" ]; then
+            verify 'build' '${{ needs.build.result }}'
+          else
+            echo 'publish gate: skipped — no publish-relevant changes (OK)'
+          fi
           echo 'All CI jobs passed'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -222,10 +222,11 @@ jobs:
           if-no-files-found: ignore
 
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
-  # LibreWolf + Floorp download official installers directly: LibreWolf resolves
-  # its newest version from the Codeberg package registry, Floorp uses GitHub's
-  # stable `/releases/latest/download/` asset URL. Firefox Dev Edition, Waterfox,
-  # and Zen require manual install.
+  # Each browser downloads an official installer directly: LibreWolf resolves
+  # its newest version from the Codeberg package registry; Floorp and Zen use
+  # GitHub's stable `/releases/latest/download/` asset URLs; Firefox Dev Edition
+  # uses Mozilla's stable devedition redirect. Waterfox stays manual (no
+  # release assets — tracked by the URL watchdog).
   browser-matrix:
     name: 'updater E2E · ${{ matrix.browser }} · windows-latest'
     needs: snapshot
@@ -233,7 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [librewolf, floorp]
+        browser: [librewolf, floorp, firefox-dev, zen]
     env:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Changed-paths filter ──────────────────────────────────────────────────
+  # Docs-only / tooling-only PRs skip the installer + updater E2E jobs: nothing
+  # that builds or runs them changed. `snapshot` stays (browser-matrix needs
+  # it) and the always-running `e2e-gate` still reports, so the required check
+  # never goes missing. See docs/DEVELOPING.md → Continuous integration.
+  changes:
+    name: detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'core/**'
+              - 'config/installer.conf'
+              - 'installer/**'
+              - 'tools/publish/**'
+              - 'test/e2e/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/e2e.yml'
+              - '.github/actions/**'
+
   # ── Dev snapshot (built ONCE per run, shared across all updater legs) ────
   # The package zips + hashes.json are OS-independent, so one ubuntu build
   # serves every updater leg. A LOCAL-mode build bakes the BUILDER's dist dir
@@ -58,6 +87,8 @@ jobs:
   # ── Installer E2E ──────────────────────────────────────────────────────────
   installer:
     name: 'installer E2E · ${{ matrix.os }}'
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -102,7 +133,8 @@ jobs:
   # Every OS leg is required; the updater must work across the supported matrix.
   updater:
     name: 'updater E2E · ${{ matrix.os }}'
-    needs: snapshot
+    needs: [changes, snapshot]
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -190,8 +222,10 @@ jobs:
           if-no-files-found: ignore
 
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
-  # LibreWolf + Floorp install via winget. Firefox Dev Edition, Waterfox, and
-  # Zen require manual install.
+  # LibreWolf + Floorp download official installers directly: LibreWolf resolves
+  # its newest version from the Codeberg package registry, Floorp uses GitHub's
+  # stable `/releases/latest/download/` asset URL. Firefox Dev Edition, Waterfox,
+  # and Zen require manual install.
   browser-matrix:
     name: 'updater E2E · ${{ matrix.browser }} · windows-latest'
     needs: snapshot
@@ -240,17 +274,32 @@ jobs:
     name: E2E gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [installer, helper, updater, browser-matrix]
+    needs: [changes, installer, helper, updater, browser-matrix]
     steps:
       - name: Verify all E2E jobs
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "::error::changes job failed (${{ needs.changes.result }})"
+            exit 1
+          fi
           fail() { echo "::error::$1: $2"; exit 1; }
           ok()   { echo "$1: $2 (OK)"; }
           verify() {
             case "$2" in success) ok "$1" "$2" ;; *) fail "$1" "$2" ;; esac
           }
-          verify 'installer' '${{ needs.installer.result }}'
           verify 'helper' '${{ needs.helper.result }}'
-          verify 'updater' '${{ needs.updater.result }}'
-          verify 'browser-matrix' '${{ needs.browser-matrix.result }}'
+          if [ "${{ needs.changes.outputs.e2e }}" = "true" ]; then
+            verify 'installer' '${{ needs.installer.result }}'
+            verify 'updater'   '${{ needs.updater.result }}'
+          else
+            echo 'installer + updater E2E: skipped — no E2E-relevant changes (OK)'
+          fi
+          # browser-matrix is ADVISORY (fork legs download from third-party
+          # hosts — librewolf.dev's package registry, Floorp's GitHub releases —
+          # which can hiccup; see docs/e2e-matrix-plan.md). Warn, don't fail the
+          # gate.
+          case "${{ needs.browser-matrix.result }}" in
+            success) ok 'browser-matrix' '${{ needs.browser-matrix.result }}' ;;
+            *) echo "::warning::browser-matrix ${{ needs.browser-matrix.result }} (advisory)" ;;
+          esac
           echo 'All E2E jobs passed'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -240,6 +240,26 @@ jobs:
     steps:
       - uses: $/.github/actions/setup-repo
 
+      # The ~100 MB LibreWolf / Floorp installers dominate the job; cache them
+      # keyed on the resolved download URL. LibreWolf's URL embeds the version,
+      # so a new release invalidates the key; Floorp's is a stable latest URL,
+      # so its key is constant — downloadTo() re-fetches when the remote size
+      # changes, and save-always re-caches the fresh file.
+      - name: Resolve download URL
+        id: dlurl
+        shell: bash
+        run: |
+          URL=$(node test/e2e/shared/downloads.mjs ${{ matrix.browser }} --url)
+          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          echo "key=browser-dl-${{ runner.os }}-${{ matrix.browser }}-$KEY" >> "$GITHUB_OUTPUT"
+          echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
+      - name: Cache ${{ matrix.browser }} installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.BROWSER_DL_DIR }}
+          key: ${{ steps.dlurl.outputs.key }}
+          save-always: true
+
       # downloads.mjs installs via the official recipe and resolves the real
       # binary from install dirs (never a PATH shim or app-execution alias,
       # whose parent dir is not the browser's GreD), exporting FIREFOX_BINARY.

--- a/.github/workflows/url-watchdog.yml
+++ b/.github/workflows/url-watchdog.yml
@@ -1,0 +1,61 @@
+# URL watchdog — weekly check that the E2E browser download map still resolves.
+#
+# CI installs Firefox, LibreWolf and Floorp from third-party hosts (Mozilla,
+# librewolf.dev, Floorp GitHub releases). Those URLs can rot silently: a 404,
+# an HTML error page where a binary used to be, or a package-registry API that
+# changed shape. This workflow re-resolves each browser's latest version and
+# verifies its download endpoint with a 1 KB ranged GET — nothing is downloaded
+# in full — and opens an issue when something breaks or a new version is out.
+#
+# The last-seen versions live in the Actions cache (.watchdog/baseline.json) so
+# a version bump is detected against the previous run, not the repo.
+#
+# See: tools/check-browser-downloads.mjs
+
+name: URL watchdog
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Monday 06:00 UTC — browsers release ~monthly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: url-watchdog
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: check browser download URLs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      # Baseline = last-seen version + endpoint size per browser. Weekly access
+      # keeps the 7-day cache TTL rolling; a missed run just re-baselines.
+      - name: Restore baseline
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .watchdog
+          key: url-watchdog-baseline-v1
+
+      - name: Check browser downloads
+        run: node tools/check-browser-downloads.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      # save-always: the script rewrites baseline.json every run even when the
+      # restore step hit, so a version bump is persisted for the next run.
+      - name: Save baseline
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .watchdog
+          key: url-watchdog-baseline-v1
+          save-always: true

--- a/.github/workflows/url-watchdog.yml
+++ b/.github/workflows/url-watchdog.yml
@@ -1,20 +1,26 @@
-# URL watchdog — weekly check that the E2E browser download map still resolves.
+# URL watchdog — catch rot in the E2E browser download map.
 #
-# CI installs Firefox, LibreWolf and Floorp from third-party hosts (Mozilla,
-# librewolf.dev, Floorp GitHub releases). Those URLs can rot silently: a 404,
-# an HTML error page where a binary used to be, or a package-registry API that
-# changed shape. This workflow re-resolves each browser's latest version and
-# verifies its download endpoint with a 1 KB ranged GET — nothing is downloaded
-# in full — and opens an issue when something breaks or a new version is out.
+# CI installs Firefox, Firefox Dev Edition, LibreWolf, Floorp and Zen from
+# third-party hosts (Mozilla, librewolf.dev, GitHub releases). Those URLs can
+# rot silently: a 404, an HTML error page where a binary used to be, or a
+# package-registry API that changed shape. This workflow re-resolves each
+# browser's latest version and verifies its download endpoint with a 1 KB
+# ranged GET — nothing is downloaded in full except one SHA-256 pass per new
+# release — and opens an issue when something breaks or a new version is out.
 #
-# The last-seen versions live in the Actions cache (.watchdog/baseline.json) so
-# a version bump is detected against the previous run, not the repo.
-#
-# See: tools/check-browser-downloads.mjs
+# Two modes (see tools/check-browser-downloads.mjs):
+# - Weekly (schedule/dispatch): version baseline in the Actions cache
+#   (.watchdog/baseline.json) + deduped issues.
+# - PR (pull_request touching the download map): stateless and always green —
+#   findings surface as ::warning:: / ::notice:: annotations, so the check can
+#   be required without ever blocking.
 
 name: URL watchdog
 
 on:
+  pull_request:
+    paths:
+      - 'test/e2e/shared/downloads.mjs'
   schedule:
     - cron: '0 6 * * 1' # Monday 06:00 UTC — browsers release ~monthly
   workflow_dispatch:
@@ -28,8 +34,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Weekly: baseline + issues ─────────────────────────────────────────────
   check:
     name: check browser download URLs
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,8 +46,9 @@ jobs:
         with:
           node-version: 24
 
-      # Baseline = last-seen version + endpoint size per browser. Weekly access
-      # keeps the 7-day cache TTL rolling; a missed run just re-baselines.
+      # Baseline = last-seen version + size (+ one-time sha256 per release).
+      # Weekly access keeps the 7-day cache TTL rolling; a missed run just
+      # re-baselines.
       - name: Restore baseline
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -59,3 +68,21 @@ jobs:
           path: .watchdog
           key: url-watchdog-baseline-v1
           save-always: true
+
+  # ── PR: stateless rot check at review time ────────────────────────────────
+  # Runs only when the download map itself changed. The script exits 0 and
+  # prints ::warning:: annotations on rot, so this job never blocks — but it
+  # can be added to branch protection as a required check.
+  pr-check:
+    name: browser download URLs (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Check browser downloads
+        run: node tools/check-browser-downloads.mjs --pr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,5 +226,7 @@ Before finishing:
   **pnpm** (lockfile v9), `"type": "module"` for all `tools/` scripts.
 - **C toolchain:** MSYS2 UCRT64/mingw-w64 on Windows (`-mwindows` GUI subsystem); clang/gcc
   elsewhere; `clang-format` pinned via npm. All asset embedding is Node (`installer/embed.mjs`).
-- **No CI yet** (no `.github/workflows`); prod publish is manual from `main`. All publish scripts
-  require a clean worktree.
+- **CI** runs from `.github/workflows/` (ci.yml, e2e.yml, pages.yml, ai-review.yml). The installer +
+  updater E2E jobs and the publish gate are **path-filtered on PRs**: they skip when no changed file
+  can affect them (see `docs/DEVELOPING.md` → Continuous integration). Prod publish stays manual
+  from `main`; all publish scripts require a clean worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ Before finishing:
   **pnpm** (lockfile v9), `"type": "module"` for all `tools/` scripts.
 - **C toolchain:** MSYS2 UCRT64/mingw-w64 on Windows (`-mwindows` GUI subsystem); clang/gcc
   elsewhere; `clang-format` pinned via npm. All asset embedding is Node (`installer/embed.mjs`).
-- **CI** runs from `.github/workflows/` (ci.yml, e2e.yml, pages.yml, ai-review.yml). The installer +
-  updater E2E jobs and the publish gate are **path-filtered on PRs**: they skip when no changed file
-  can affect them (see `docs/DEVELOPING.md` → Continuous integration). Prod publish stays manual
-  from `main`; all publish scripts require a clean worktree.
+- **CI** runs from `.github/workflows/` (ci.yml, e2e.yml, pages.yml, ai-review.yml,
+  url-watchdog.yml). The installer + updater E2E jobs and the publish gate are **path-filtered on
+  PRs**: they skip when no changed file can affect them (see `docs/DEVELOPING.md` → Continuous
+  integration). Prod publish stays manual from `main`; all publish scripts require a clean worktree.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -280,11 +280,14 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
   token, valid tokens pass the gate, and no response carries `Access-Control-Allow-Origin`.
 - **Hash parity** (Windows) — `pnpm test:hash` verifies the JS and C installer hashes match, using
   the dev snapshot built by the publish gate (no second build).
-- **URL watchdog** (`.github/workflows/url-watchdog.yml`, weekly) — re-resolves the latest version
-  of every browser the E2E map installs (Firefox, LibreWolf, Floorp) from its vendor API and
-  verifies the download endpoint with a 1 KB ranged GET. Opens an issue on rot (404, HTML error
-  page, changed API shape) or a new release. Run manually via `workflow_dispatch`, or locally with
-  `node tools/check-browser-downloads.mjs --dry-run`.
+- **URL watchdog** (`.github/workflows/url-watchdog.yml`, weekly + on PRs touching the download map)
+  — re-resolves the latest version of every browser the E2E map installs (Firefox, Dev Edition,
+  LibreWolf, Floorp, Zen; Waterfox tracked by version only) from its vendor API and verifies the
+  download endpoint with a 1 KB ranged GET. Each new release is downloaded once, SHA-256'd and
+  recorded in the per-release watchdog issue (`label:url-watchdog`) — the durable ledger. Opens
+  issues on rot (404, HTML error page, changed API shape) and same-version binary size changes. The
+  PR mode (`--pr`) is stateless, always green, and surfaces findings as annotations. Run manually
+  via `workflow_dispatch`, or locally with `node tools/check-browser-downloads.mjs --dry-run`.
 
 **PR path filtering** — the installer + updater E2E jobs (`.github/workflows/e2e.yml`) run only when
 a changed file can affect them (`core/**`, `config/installer.conf`, `installer/**`,

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -280,6 +280,11 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
   token, valid tokens pass the gate, and no response carries `Access-Control-Allow-Origin`.
 - **Hash parity** (Windows) — `pnpm test:hash` verifies the JS and C installer hashes match, using
   the dev snapshot built by the publish gate (no second build).
+- **URL watchdog** (`.github/workflows/url-watchdog.yml`, weekly) — re-resolves the latest version
+  of every browser the E2E map installs (Firefox, LibreWolf, Floorp) from its vendor API and
+  verifies the download endpoint with a 1 KB ranged GET. Opens an issue on rot (404, HTML error
+  page, changed API shape) or a new release. Run manually via `workflow_dispatch`, or locally with
+  `node tools/check-browser-downloads.mjs --dry-run`.
 
 **PR path filtering** — the installer + updater E2E jobs (`.github/workflows/e2e.yml`) run only when
 a changed file can affect them (`core/**`, `config/installer.conf`, `installer/**`,

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -281,6 +281,16 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
 - **Hash parity** (Windows) — `pnpm test:hash` verifies the JS and C installer hashes match, using
   the dev snapshot built by the publish gate (no second build).
 
+**PR path filtering** — the installer + updater E2E jobs (`.github/workflows/e2e.yml`) run only when
+a changed file can affect them (`core/**`, `config/installer.conf`, `installer/**`,
+`tools/publish/**`, `test/e2e/**`, `package.json`, `pnpm-lock.yaml`, the workflow/actions); the
+publish gate (`build` in `.github/workflows/ci.yml`) runs only when `core/**`,
+`config/installer.conf`, `installer/**`, `tools/publish/**`, `package.json`, `pnpm-lock.yaml`, or
+the workflow/actions changed. Docs-only / tooling-only PRs skip both, while `checks`, `ci-gate` and
+`e2e-gate` always run so the required checks keep reporting. The `browser-matrix` fork legs
+(LibreWolf, Floorp — downloaded from third-party hosts: librewolf.dev's package registry, Floorp's
+GitHub releases) are advisory: their failures warn in the gate instead of failing the PR.
+
 Run the smoke test locally (Windows, from the repo root):
 
 ```bash

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -292,9 +292,11 @@ a changed file can affect them (`core/**`, `config/installer.conf`, `installer/*
 publish gate (`build` in `.github/workflows/ci.yml`) runs only when `core/**`,
 `config/installer.conf`, `installer/**`, `tools/publish/**`, `package.json`, `pnpm-lock.yaml`, or
 the workflow/actions changed. Docs-only / tooling-only PRs skip both, while `checks`, `ci-gate` and
-`e2e-gate` always run so the required checks keep reporting. The `browser-matrix` fork legs
-(LibreWolf, Floorp — downloaded from third-party hosts: librewolf.dev's package registry, Floorp's
-GitHub releases) are advisory: their failures warn in the gate instead of failing the PR.
+`e2e-gate` always run so the required checks keep reporting. The `browser-matrix` legs (Firefox Dev
+Edition, LibreWolf, Floorp, Zen — downloaded from third-party hosts: Mozilla's redirect,
+librewolf.dev's package registry, GitHub release assets) are advisory: their failures warn in the
+gate instead of failing the PR. Waterfox has no direct download URL and stays manual (tracked by
+version only in the URL watchdog).
 
 Run the smoke test locally (Windows, from the repo root):
 

--- a/docs/e2e-matrix-plan.md
+++ b/docs/e2e-matrix-plan.md
@@ -32,9 +32,11 @@ geckodriver uses by default for recent builds.
 | LibreWolf                 | Windows | `windows-latest`       | Advisory                |
 | Floorp                    | Windows | `windows-latest`       | Advisory                |
 
-**Advisory** = `continue-on-error: true` in CI. These browsers don't have stable download URLs for
-CI, so they run manually or when available. The hard gate is Firefox stable across all three OSes +
-Firefox Developer Edition on Windows.
+**Advisory** = the E2E gate reports a warning instead of failing the PR (LibreWolf / Floorp install
+from third-party download hosts — librewolf.dev's package registry, Floorp's GitHub releases — which
+can hiccup). LibreWolf's newest version is resolved from the Codeberg package registry; Floorp's
+stable `/releases/latest/download/` asset URL needs no lookup, so no manual step is required. The
+hard gate is Firefox stable across all three OSes + Firefox Developer Edition on Windows.
 
 ## What each test asserts
 

--- a/docs/e2e-matrix-plan.md
+++ b/docs/e2e-matrix-plan.md
@@ -18,25 +18,27 @@ geckodriver uses by default for recent builds.
 
 ## Matrix
 
-| Browser                   | OS      | Runner                 | Status                  |
-| ------------------------- | ------- | ---------------------- | ----------------------- |
-| Firefox stable            | Windows | `windows-latest`       | Hard gate               |
-| Firefox stable            | macOS   | `macos-latest`         | Hard gate               |
-| Firefox stable            | Linux   | `ubuntu-latest` (xvfb) | Hard gate               |
-| Firefox Developer Edition | Windows | `windows-latest`       | Hard gate               |
-| Firefox Developer Edition | macOS   | `macos-latest`         | Advisory (no brew cask) |
-| Firefox Developer Edition | Linux   | `ubuntu-latest` (xvfb) | Advisory                |
-| Waterfox                  | Windows | `windows-latest`       | Advisory                |
-| Waterfox                  | macOS   | `macos-latest`         | Advisory                |
-| Zen Browser               | Windows | `windows-latest`       | Advisory                |
-| LibreWolf                 | Windows | `windows-latest`       | Advisory                |
-| Floorp                    | Windows | `windows-latest`       | Advisory                |
+| Browser                   | OS      | Runner                 | Status                            |
+| ------------------------- | ------- | ---------------------- | --------------------------------- |
+| Firefox stable            | Windows | `windows-latest`       | Hard gate                         |
+| Firefox stable            | macOS   | `macos-latest`         | Hard gate                         |
+| Firefox stable            | Linux   | `ubuntu-latest` (xvfb) | Hard gate                         |
+| Firefox Developer Edition | Windows | `windows-latest`       | Advisory (browser-matrix leg)     |
+| Firefox Developer Edition | macOS   | `macos-latest`         | Advisory (no brew cask)           |
+| Firefox Developer Edition | Linux   | `ubuntu-latest` (xvfb) | Advisory                          |
+| Waterfox                  | Windows | `windows-latest`       | Advisory (no direct URL — manual) |
+| Waterfox                  | macOS   | `macos-latest`         | Advisory                          |
+| Zen Browser               | Windows | `windows-latest`       | Advisory (browser-matrix leg)     |
+| LibreWolf                 | Windows | `windows-latest`       | Advisory (browser-matrix leg)     |
+| Floorp                    | Windows | `windows-latest`       | Advisory (browser-matrix leg)     |
 
-**Advisory** = the E2E gate reports a warning instead of failing the PR (LibreWolf / Floorp install
-from third-party download hosts — librewolf.dev's package registry, Floorp's GitHub releases — which
-can hiccup). LibreWolf's newest version is resolved from the Codeberg package registry; Floorp's
-stable `/releases/latest/download/` asset URL needs no lookup, so no manual step is required. The
-hard gate is Firefox stable across all three OSes + Firefox Developer Edition on Windows.
+**Advisory** = the E2E gate reports a warning instead of failing the PR. The `browser-matrix` legs
+(Firefox Dev Edition, LibreWolf, Floorp, Zen) download official installers directly from third-party
+hosts — Mozilla's devedition redirect, librewolf.dev's package registry, GitHub release assets —
+which can hiccup. LibreWolf's newest version is resolved from the Codeberg package registry; Floorp
+and Zen use stable `/releases/latest/download/` asset URLs. Waterfox has no direct URL (no GitHub
+release assets), so its leg stays manual and the URL watchdog tracks its version only. The hard gate
+is Firefox stable across all three OSes.
 
 ## What each test asserts
 

--- a/test/e2e/shared/browsers.mjs
+++ b/test/e2e/shared/browsers.mjs
@@ -147,8 +147,8 @@ export const BROWSERS = {
     choco: 'librewolf',
   },
   'floorp': {
-    // The NSIS installer (winget Ablaze.Floorp, machine scope) installs to
-    // 'C:\Program Files\Ablaze Floorp', not 'Floorp'.
+    // The NSIS installer installs to 'C:\Program Files\Ablaze Floorp', not
+    // 'Floorp'.
     win: ['Ablaze Floorp', 'floorp.exe'],
     mac: ['Floorp.app'],
     linux: ['floorp'],

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -379,7 +379,10 @@ FIREFOX_BINARY via $GITHUB_ENV. With --url, prints the download URL instead
   }
 }
 
-const isMain = process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('downloads.mjs');
+// Basename (not endsWith) so modules with a similar name — e.g.
+// tools/check-browser-downloads.mjs — can import this file without tripping
+// the CLI entry-point guard.
+const isMain = process.argv[1] && path.basename(process.argv[1]) === 'downloads.mjs';
 if (isMain) {
   main().catch(err => {
     console.error(`✗ Error: ${err.message}`);

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -202,7 +202,9 @@ export async function resolveDownloadUrl(browser, platform = process.platform) {
  * @returns {Promise<string>}
  */
 async function resolveLatestUrl({api, pick, url}) {
-  const res = await fetchWithRetry(api, 3);
+  // Registry metadata (a small JSON list) — 15 s per attempt, not the
+  // 300 s installer-download timeout; a stalled registry must fail fast.
+  const res = await fetchWithRetry(api, 3, 15_000);
   const packages = await res.json();
   const latest = packages.find(pick);
   if (!latest) {

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -36,11 +36,9 @@ import {discoverFirefoxBinary} from './browsers.mjs';
  *   into /Applications (macOS).
  * - {tarball, url} → download the official tarball and extract it; returns the
  *   binary path directly.
- * - {manager, args} → run a package manager (choco/winget/brew), then resolve the
- *   binary from the browser's known install dirs. Only used where the browser
- *   publishes no stable "latest" installer URL (forks whose release asset names
- *   embed the version). Retried 3× because third-party mirrors (e.g.
- *   librewolf.dev) 502 transiently.
+ * - {latest: {api, pick, url}, args} → resolve the newest version from a registry
+ *   API (e.g. LibreWolf's Gitea package list), build the installer URL from it,
+ *   then install — for forks that embed the version in the asset name.
  * - `manual: true` → no automated install; `page` is the official download page
  *   (informational, for the manual legs).
  *
@@ -81,29 +79,32 @@ export const DOWNLOADS = {
     manual: true,
     page: 'https://zen-browser.app/download/',
   },
+  // LibreWolf embeds the version in the download URL (Gitea generic-package
+  // registry on librewolf.dev), so resolve the newest version from the Codeberg
+  // packages API first — no package manager, no third-party mirror flakiness.
   'librewolf': {
     install: {
       win: {
-        manager: 'winget',
-        args: [
-          'install',
-          'LibreWolf.LibreWolf',
-          '--accept-package-agreements',
-          '--accept-source-agreements',
-        ],
+        latest: {
+          api: 'https://codeberg.org/api/v1/packages/librewolf',
+          // Gitea lists packages newest-first; the installer is the `generic`
+          // `librewolf` package (not `librewolf-source`).
+          pick: pkg => pkg.type === 'generic' && pkg.name === 'librewolf',
+          url: version =>
+            `https://librewolf.dev/api/packages/librewolf/generic/librewolf/${version}/librewolf-${version}-windows-x86_64-setup.exe`,
+        },
+        args: ['/S'], // NSIS silent install → Program Files\LibreWolf
       },
     },
   },
+  // Floorp keeps a stable asset name across releases, so GitHub's
+  // `/releases/latest/download/` redirect always resolves the newest installer
+  // without a version lookup.
   'floorp': {
     install: {
       win: {
-        manager: 'winget',
-        args: [
-          'install',
-          'Ablaze.Floorp',
-          '--accept-package-agreements',
-          '--accept-source-agreements',
-        ],
+        url: 'https://github.com/Floorp-Projects/Floorp/releases/latest/download/floorp-windows-x86_64.installer.exe',
+        args: ['/S'], // NSIS silent install → Program Files\Ablaze Floorp
       },
     },
   },
@@ -117,7 +118,7 @@ export function platformKey(platform = process.platform) {
 }
 
 /**
- * Resolve a browser's binary after a package-manager install, mirroring the
+ * Resolve a browser's binary after an installer run, mirroring the
  * candidate-dir search of discoverFirefoxBinary (real install dirs, never PATH
  * shims or app-execution aliases — their parent dir is not the browser's
  * GreD).
@@ -144,15 +145,16 @@ export function downloadDir() {
 }
 
 /**
- * Resolve a browser's download URL for a platform (the recipe's tarball or
- * installer URL) — used to key the CI download cache, since the URL embeds the
- * release version. Package-manager recipes have no download URL.
+ * Resolve a browser's download URL for a platform (the recipe's tarball,
+ * installer URL, or latest-resolved URL) — used to key the CI download cache,
+ * since the URL embeds the release version. `latest` recipes query their
+ * registry API, so this is async.
  *
  * @param {string} browser
  * @param {string} [platform] process.platform value (win32|darwin|linux)
- * @returns {string}
+ * @returns {Promise<string>}
  */
-export function resolveDownloadUrl(browser, platform = process.platform) {
+export async function resolveDownloadUrl(browser, platform = process.platform) {
   const key = platformKey(
     platform === 'win' ? 'win32'
     : platform === 'mac' ? 'darwin'
@@ -167,11 +169,30 @@ export function resolveDownloadUrl(browser, platform = process.platform) {
         : '')
     );
   }
-  const url = recipe.tarball || recipe.url;
-  if (!url) {
-    throw new Error(`${browser} installs via a package manager — no download URL to cache`);
+  if (recipe.latest) return resolveLatestUrl(recipe.latest);
+  return recipe.tarball || recipe.url;
+}
+
+/**
+ * Resolve the newest download URL for a `{api, pick, url}` recipe: fetch the
+ * registry list (retrying), pick the newest matching package, and build the
+ * version-embedded installer URL.
+ *
+ * @param {{
+ *   api: string;
+ *   pick: (pkg: object) => boolean;
+ *   url: (version: string) => string;
+ * }} recipe
+ * @returns {Promise<string>}
+ */
+async function resolveLatestUrl({api, pick, url}) {
+  const res = await fetchWithRetry(api, 3);
+  const packages = await res.json();
+  const latest = packages.find(pick);
+  if (!latest) {
+    throw new Error(`no matching package found at ${api}`);
   }
-  return url;
+  return url(latest.version);
 }
 
 /** Download an official Mozilla tarball and extract it; returns the binary path. */
@@ -268,30 +289,6 @@ async function installDmg(url, appName) {
   }
 }
 
-function runManager(manager, args) {
-  // Package-manager installs hit third-party mirrors that can 502 transiently
-  // (e.g. librewolf.dev). Retry the whole install so a one-off upstream hiccup
-  // does not fail CI; browsers are idempotent to reinstall.
-  let lastErr;
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      // execSync goes through the platform shell, so choco.bat / winget.exe /
-      // brew work the same on every OS.
-      execSync(`${manager} ${args.join(' ')}`, {stdio: 'inherit'});
-      return;
-    } catch (err) {
-      lastErr = err;
-      console.log(`  ${manager} attempt ${attempt}/3 failed: ${err.message}`);
-      if (attempt < 3) {
-        console.log('  retrying in 15s…');
-        // execSync blocks the event loop; sleep via node so it works on pwsh.
-        execSync('node -e "setTimeout(() => {}, 15000)"', {stdio: 'inherit'});
-      }
-    }
-  }
-  throw lastErr;
-}
-
 /**
  * Install a browser for a platform and return the resolved binary path.
  *
@@ -317,6 +314,17 @@ export async function installBrowser(browser, platform = process.platform) {
     console.log(`  ${browser} installed from official tarball: ${binary}`);
     return binary;
   }
+  if (recipe.latest && recipe.args) {
+    // Version-embedded installer URL (e.g. LibreWolf) — resolve the newest
+    // version first, then install like any other official installer.
+    const url = await resolveLatestUrl(recipe.latest);
+    await installInstaller(url, browser, recipe.args);
+    const binary = resolveBinary(browser);
+    if (!binary) {
+      throw new Error(`${browser} installer ran, but no binary found in known install dirs`);
+    }
+    return binary;
+  }
   if (recipe.url && recipe.args) {
     // Official installer (e.g. NSIS silent install on Windows).
     await installInstaller(recipe.url, browser, recipe.args);
@@ -335,14 +343,7 @@ export async function installBrowser(browser, platform = process.platform) {
     }
     return binary;
   }
-  runManager(recipe.manager, recipe.args);
-  const binary = resolveBinary(browser);
-  if (!binary) {
-    throw new Error(
-      `${browser} installed via ${recipe.manager}, but no binary found in known install dirs`
-    );
-  }
-  return binary;
+  throw new Error(`${browser} has no install recipe for ${key}`);
 }
 
 async function main() {
@@ -367,7 +368,7 @@ FIREFOX_BINARY via $GITHUB_ENV. With --url, prints the download URL instead
   if (args.includes('--url')) {
     // Print the exact download URL for this platform so the workflow can key
     // the CI download cache on it (the URL embeds the release version).
-    console.log(resolveDownloadUrl(browser, normalized));
+    console.log(await resolveDownloadUrl(browser, normalized));
     return;
   }
 

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -42,9 +42,9 @@ import {discoverFirefoxBinary} from './browsers.mjs';
  * - `manual: true` → no automated install; `page` is the official download page
  *   (informational, for the manual legs).
  *
- * The E2E workflow installs only what CI needs today (firefox, librewolf,
- * floorp); the other forks are documented here so adding a leg is a one-line
- * change, and they have no stable unattended install.
+ * The E2E workflow installs what CI needs today (firefox, firefox-dev,
+ * librewolf, floorp, zen); waterfox is documented here but has no stable
+ * unattended install (no release assets — see the URL watchdog).
  */
 export const DOWNLOADS = {
   'firefox': {
@@ -68,15 +68,31 @@ export const DOWNLOADS = {
     },
   },
   'firefox-dev': {
-    manual: true,
+    install: {
+      // Same stable Mozilla "latest" redirect as Firefox stable, dev channel.
+      win: {
+        url: 'https://download.mozilla.org/?product=firefox-devedition-latest&os=win64&lang=en-US',
+        args: ['/S'], // NSIS silent install → %LOCALAPPDATA%\Firefox Developer Edition
+      },
+    },
     page: 'https://www.mozilla.org/firefox/developer/',
   },
   'waterfox': {
+    // No stable installer URL: Waterfox publishes no release assets on GitHub
+    // (site-distributed), so it stays manual. The URL watchdog tracks its
+    // version via the GitHub API.
     manual: true,
     page: 'https://www.waterfox.net/download/',
   },
+  // Zen keeps a stable asset name across releases, so GitHub's
+  // `/releases/latest/download/` redirect always resolves the newest installer.
   'zen': {
-    manual: true,
+    install: {
+      win: {
+        url: 'https://github.com/zen-browser/desktop/releases/latest/download/zen.installer.exe',
+        args: ['/S'], // NSIS silent install → %LOCALAPPDATA%\Zen Browser
+      },
+    },
     page: 'https://zen-browser.app/download/',
   },
   // LibreWolf embeds the version in the download URL (Gitea generic-package

--- a/test/unit/e2e/downloads.test.mjs
+++ b/test/unit/e2e/downloads.test.mjs
@@ -20,34 +20,66 @@ const {downloadDir, downloadTo, resolveDownloadUrl} = await import(downloadsUrl)
 
 // ── resolveDownloadUrl ────────────────────────────────────────────────────
 
-test('resolveDownloadUrl: official installer URLs per platform', () => {
-  const win = resolveDownloadUrl('firefox', 'win32');
-  const mac = resolveDownloadUrl('firefox', 'darwin');
-  const linux = resolveDownloadUrl('firefox', 'linux');
+test('resolveDownloadUrl: official installer URLs per platform', async () => {
+  const win = await resolveDownloadUrl('firefox', 'win32');
+  const mac = await resolveDownloadUrl('firefox', 'darwin');
+  const linux = await resolveDownloadUrl('firefox', 'linux');
   assert.match(win, /^https:\/\/download\.mozilla\.org\/\?product=firefox-latest&os=win64/);
   assert.match(mac, /^https:\/\/download\.mozilla\.org\/\?product=firefox-latest&os=osx/);
   assert.match(linux, /^https:\/\/download\.mozilla\.org\/\?product=firefox-latest&os=linux64/);
 });
 
-test('resolveDownloadUrl: accepts short platform names (win/mac)', () => {
-  assert.equal(resolveDownloadUrl('firefox', 'win'), resolveDownloadUrl('firefox', 'win32'));
-  assert.equal(resolveDownloadUrl('firefox', 'mac'), resolveDownloadUrl('firefox', 'darwin'));
+test('resolveDownloadUrl: accepts short platform names (win/mac)', async () => {
+  assert.equal(
+    await resolveDownloadUrl('firefox', 'win'),
+    await resolveDownloadUrl('firefox', 'win32')
+  );
+  assert.equal(
+    await resolveDownloadUrl('firefox', 'mac'),
+    await resolveDownloadUrl('firefox', 'darwin')
+  );
 });
 
-test('resolveDownloadUrl: package-manager browsers have no URL to cache', () => {
-  assert.throws(() => resolveDownloadUrl('librewolf', 'win32'), /package manager/);
-  assert.throws(() => resolveDownloadUrl('floorp', 'win32'), /package manager/);
+test('resolveDownloadUrl: floorp uses the stable GitHub latest-download URL', async () => {
+  assert.equal(
+    await resolveDownloadUrl('floorp', 'win32'),
+    'https://github.com/Floorp-Projects/Floorp/releases/latest/download/floorp-windows-x86_64.installer.exe'
+  );
 });
 
-test('resolveDownloadUrl: manual-only browsers throw with the official page', () => {
-  assert.throws(
-    () => resolveDownloadUrl('waterfox', 'win32'),
+test('resolveDownloadUrl: librewolf resolves the latest version from the packages API', async () => {
+  // Stub global fetch: no network in unit tests. The stub mimics Gitea's
+  // package list (newest-first); the resolver must pick the `generic`
+  // `librewolf` package and build the version-embedded installer URL.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => [
+      {type: 'generic', name: 'librewolf-source', version: '154.0.1-2'},
+      {type: 'generic', name: 'librewolf', version: '154.0.1-2'},
+      {type: 'generic', name: 'librewolf', version: '153.0.4-1'},
+    ],
+  });
+  try {
+    const url = await resolveDownloadUrl('librewolf', 'win32');
+    assert.equal(
+      url,
+      'https://librewolf.dev/api/packages/librewolf/generic/librewolf/154.0.1-2/librewolf-154.0.1-2-windows-x86_64-setup.exe'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('resolveDownloadUrl: manual-only browsers throw with the official page', async () => {
+  await assert.rejects(
+    resolveDownloadUrl('waterfox', 'win32'),
     /manual install only.*waterfox\.net/
   );
 });
 
-test('resolveDownloadUrl: unknown browser throws', () => {
-  assert.throws(() => resolveDownloadUrl('not-a-browser', 'linux'), /has no automated install/);
+test('resolveDownloadUrl: unknown browser throws', async () => {
+  await assert.rejects(resolveDownloadUrl('not-a-browser', 'linux'), /has no automated install/);
 });
 
 // ── downloadTo cache reuse ────────────────────────────────────────────────

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -1,15 +1,18 @@
 // test/unit/tools/check-browser-downloads.test.mjs — Unit tests for the pure
-// helpers in tools/check-browser-downloads.mjs (the version/endpoint checks
-// and issue creation hit the network and the GitHub API — not unit-tested).
+// helpers in tools/check-browser-downloads.mjs (the version/endpoint checks,
+// the full-download pass, and issue creation hit the network and the GitHub
+// API — not unit-tested).
 
 import {test} from 'node:test';
 import assert from 'node:assert/strict';
-import {fileURLToPath, pathToFileURL} from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-downloads.mjs')).href;
-const {compareBaseline, issueTitle, parseContentRange} = await import(scriptUrl);
+const {compareBaseline, issueTitle, parseContentRange, sha256File} = await import(scriptUrl);
 
 test('compareBaseline: first run, new version, unchanged', () => {
   assert.equal(compareBaseline(null, {version: '154.0.1'}), 'first-run');
@@ -17,7 +20,7 @@ test('compareBaseline: first run, new version, unchanged', () => {
   assert.equal(compareBaseline({version: '154.0.1'}, {version: '154.0.1'}), 'ok');
 });
 
-test('issueTitle: rot and new-version titles are dedup keys', () => {
+test('issueTitle: rot, new-version and size-change titles are dedup keys', () => {
   assert.equal(
     issueTitle('rot', 'librewolf', {reason: 'HTTP 404'}),
     '[url-watchdog] librewolf download check failed: HTTP 404'
@@ -26,6 +29,10 @@ test('issueTitle: rot and new-version titles are dedup keys', () => {
     issueTitle('new-version', 'floorp', {prevVersion: '12.16.2', newVersion: '12.17.0'}),
     '[url-watchdog] floorp 12.16.2 → 12.17.0'
   );
+  assert.equal(
+    issueTitle('size-change', 'zen'),
+    '[url-watchdog] zen same version, binary size changed'
+  );
 });
 
 test('parseContentRange: total size or null', () => {
@@ -33,4 +40,18 @@ test('parseContentRange: total size or null', () => {
   assert.equal(parseContentRange(null), null);
   assert.equal(parseContentRange(''), null);
   assert.equal(parseContentRange('bytes */0'), 0);
+});
+
+test('sha256File: streams a file into its SHA-256', async () => {
+  const tmp = path.join(os.tmpdir(), `watchdog-hash-${process.pid}.txt`);
+  try {
+    fs.writeFileSync(tmp, 'abc');
+    // Known SHA-256 vector for 'abc'.
+    assert.equal(
+      await sha256File(tmp),
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+  } finally {
+    fs.rmSync(tmp, {force: true});
+  }
 });

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -1,0 +1,36 @@
+// test/unit/tools/check-browser-downloads.test.mjs — Unit tests for the pure
+// helpers in tools/check-browser-downloads.mjs (the version/endpoint checks
+// and issue creation hit the network and the GitHub API — not unit-tested).
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import path from 'node:path';
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-downloads.mjs')).href;
+const {compareBaseline, issueTitle, parseContentRange} = await import(scriptUrl);
+
+test('compareBaseline: first run, new version, unchanged', () => {
+  assert.equal(compareBaseline(null, {version: '154.0.1'}), 'first-run');
+  assert.equal(compareBaseline({version: '153.0'}, {version: '154.0.1'}), 'new-version');
+  assert.equal(compareBaseline({version: '154.0.1'}, {version: '154.0.1'}), 'ok');
+});
+
+test('issueTitle: rot and new-version titles are dedup keys', () => {
+  assert.equal(
+    issueTitle('rot', 'librewolf', {reason: 'HTTP 404'}),
+    '[url-watchdog] librewolf download check failed: HTTP 404'
+  );
+  assert.equal(
+    issueTitle('new-version', 'floorp', {prevVersion: '12.16.2', newVersion: '12.17.0'}),
+    '[url-watchdog] floorp 12.16.2 → 12.17.0'
+  );
+});
+
+test('parseContentRange: total size or null', () => {
+  assert.equal(parseContentRange('bytes 0-1023/104857600'), 104857600);
+  assert.equal(parseContentRange(null), null);
+  assert.equal(parseContentRange(''), null);
+  assert.equal(parseContentRange('bytes */0'), 0);
+});

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -12,7 +12,9 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-downloads.mjs')).href;
-const {compareBaseline, issueTitle, parseContentRange, sha256File} = await import(scriptUrl);
+const {compareBaseline, issueBody, issueTitle, parseContentRange, sha256File} = await import(
+  scriptUrl
+);
 
 test('compareBaseline: first run, new version, unchanged', () => {
   assert.equal(compareBaseline(null, {version: '154.0.1'}), 'first-run');
@@ -33,6 +35,23 @@ test('issueTitle: rot, new-version and size-change titles are dedup keys', () =>
     issueTitle('size-change', 'zen'),
     '[url-watchdog] zen same version, binary size changed'
   );
+});
+
+test('issueBody: new-version body carries the verified SHA-256 ledger', () => {
+  const body = issueBody(
+    {
+      kind: 'new-version',
+      browser: 'librewolf',
+      prevVersion: '154.0-2',
+      newVersion: '154.0.1-2',
+      size: 153225824,
+      sha256: 'ec27c770aa951b8f11541ce5c4fa2d15ec8d7fe613662505ce9ab00b196a100e',
+    },
+    'https://github.com/onemen/firefox-scripts/actions/runs/1'
+  );
+  assert.match(body, /Watchdog run: https:\/\/github\.com/);
+  assert.match(body, /New librewolf release: 154\.0-2 → 154\.0\.1-2/);
+  assert.match(body, /Verified SHA-256 \(153225824 bytes\): `ec27c770aa/);
 });
 
 test('parseContentRange: total size or null', () => {

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -151,7 +151,9 @@ async function checkEndpoint(url) {
       await reader.read(); // first chunk (≤ 64 KB) — enough to confirm it's a download
       await reader.cancel();
     }
-    return {ok: true, total};
+    // null (not 0) when the server ignored Range and reported no total, so
+    // callers can tell "unknown" apart from a zero-byte response.
+    return {ok: true, total: total || null};
   } finally {
     // Best-effort: drain/cancel is handled above; nothing further to release.
   }
@@ -313,7 +315,10 @@ export async function main() {
   }
 
   const findings = [];
-  const next = {};
+  // Start from the loaded baseline so a browser whose check failed this run
+  // keeps its recorded {version, size, sha256} instead of being erased — a
+  // release landing during a transient outage must still reach the ledger.
+  const next = {...baseline};
   const runUrl =
     process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY ?
       `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID || ''}`
@@ -364,7 +369,9 @@ export async function main() {
       findings.push({kind: 'rot', browser, reason: endpoint.reason, version});
       continue; // broken chain — do not touch the baseline for this browser
     }
-    console.log(`  endpoint ok (${endpoint.total} bytes)`);
+    console.log(
+      `  endpoint ok${endpoint.total ? ` (${endpoint.total} bytes)` : ' (no size reported)'}`
+    );
 
     // PR mode: stateless, always green — surface findings as annotations.
     if (prMode) {
@@ -403,15 +410,18 @@ export async function main() {
       continue;
     }
 
-    // Same version: keep the recorded hash, flag a binary replacement.
-    next[browser] = {version, size: endpoint.total, sha256: prev.sha256 || null};
-    if (prev.size && prev.size !== endpoint.total) {
-      console.log(`  ⚠ same version, binary size changed: ${prev.size} → ${endpoint.total}`);
+    // Same version: keep the recorded hash, flag a binary replacement. A server
+    // that ignores Range reports no total — keep the recorded size in that case
+    // instead of overwriting it with 0 and raising a false size-change.
+    const total = endpoint.total || 0;
+    next[browser] = {version, size: total || prev.size || null, sha256: prev.sha256 || null};
+    if (total && prev.size && prev.size !== total) {
+      console.log(`  ⚠ same version, binary size changed: ${prev.size} → ${total}`);
       findings.push({
         kind: 'size-change',
         browser,
         prevSize: prev.size,
-        newSize: endpoint.total,
+        newSize: total,
       });
     } else {
       console.log('  unchanged');

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -1,35 +1,48 @@
 #!/usr/bin/env node
 
 /**
- * tools/check-browser-downloads.mjs — weekly watchdog for the E2E browser
- * download map (test/e2e/shared/downloads.mjs).
+ * tools/check-browser-downloads.mjs — watchdog for the E2E browser download map
+ * (test/e2e/shared/downloads.mjs).
  *
- * The URL watchdog workflow (.github/workflows/url-watchdog.yml) runs this on a
- * schedule. For each browser CI installs (firefox, librewolf, floorp) it:
+ * Runs in two modes, both driven by .github/workflows/url-watchdog.yml:
  *
- * 1. VERSION — reads the current release version from the vendor's API (Firefox
- *    product-details, LibreWolf Codeberg packages, Floorp GitHub releases).
- *    Nothing is downloaded.
- * 2. ENDPOINT — fetches the resolved installer URL with a 1 KB range request and
- *    asserts the host still serves a binary (2xx, binary content-type,
- *    plausible size). Catches 404s, HTML error pages and hosts that changed
- *    shape — the failure mode that made the LibreWolf winget leg flaky.
- * 3. BASELINE — compares versions against the last run's baseline (stored in the
- *    Actions cache under .watchdog/). New versions and broken endpoints open a
- *    GitHub issue, deduped per browser (the exact issue title is matched
- *    against open issues carrying the `url-watchdog` label).
+ * - Weekly (schedule/workflow_dispatch). For each browser CI installs it:
  *
- * Never downloads the ~100 MB installers — a 1 KB ranged GET (plus cancelling
- * the body stream) is enough to verify a host. Requires GITHUB_TOKEN with
- * issues: write for issue creation; without it, or with --dry-run, findings are
- * printed instead. Exit code stays 0 when findings are reported (they become
- * issues, not CI failures).
+ *   1. VERSION — reads the current release version from the vendor's API (Firefox
+ *        product-details, LibreWolf Codeberg packages, Floorp / Zen / Waterfox
+ *        GitHub releases). Nothing is downloaded.
+ *   2. ENDPOINT — fetches the resolved installer URL with a 1 KB range request and
+ *        asserts the host still serves a binary (2xx, binary content-type,
+ *        plausible size). Catches 404s, HTML error pages and hosts that changed
+ *        shape.
+ *   3. SHA-256 — when the version changed since the last run (or on the first run),
+ *        downloads the installer once, hashes it and records {version, size,
+ *        sha256} in the baseline (.watchdog/baseline.json, stored in the
+ *        Actions cache). Same-version runs re-check only the 1 KB range, but
+ *        flag a size change (binary replaced without a bump).
+ *   4. ISSUES — new versions, rot, and same-version size changes open a GitHub
+ *        issue, deduped per browser (the exact issue title is matched against
+ *        open issues carrying the `url-watchdog` label).
+ * - PR (pull_request touching the download map): stateless and always green —
+ *   findings surface as ::warning:: / ::notice:: annotations, so the check can
+ *   be marked required without ever blocking. No baseline, no issues, no full
+ *   downloads.
+ *
+ * Browsers without a direct download URL (waterfox) are tracked by version
+ * only: their vendor API is still polled, but there is no endpoint to verify
+ * and no CI recipe to install.
+ *
+ * Requires GITHUB_TOKEN with issues: write for issue creation; without it, or
+ * with --dry-run, findings are printed instead. Exit code stays 0 when findings
+ * are reported (they become issues / annotations, not CI failures).
  */
 
+import {createHash} from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {resolveDownloadUrl} from '../test/e2e/shared/downloads.mjs';
+import {downloadTo, resolveDownloadUrl} from '../test/e2e/shared/downloads.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -39,26 +52,41 @@ export const WATCHDOG_LABEL = 'url-watchdog';
 const MIN_BINARY_BYTES = 10_000_000; // installers are ~100 MB; smaller = wrong file
 const RANGE_BYTES = 1024;
 
-/** The browsers the E2E map installs — each must resolve + serve a binary. */
-const BROWSERS = ['firefox', 'librewolf', 'floorp'];
+/** Browsers the E2E map installs or tracks — each must resolve its version. */
+const BROWSERS = ['firefox', 'firefox-dev', 'librewolf', 'floorp', 'zen', 'waterfox'];
 
 const VERSION_APIS = {
-  firefox: {
+  'firefox': {
     // Mozilla product-details: the canonical "current stable version" endpoint.
     url: 'https://product-details.mozilla.org/1.0/firefox_versions.json',
     parse: j => j.LATEST_FIREFOX_VERSION,
   },
-  librewolf: {
+  'firefox-dev': {
+    url: 'https://product-details.mozilla.org/1.0/firefox_versions.json',
+    parse: j => j.FIREFOX_DEVEDITION,
+  },
+  'librewolf': {
     // Gitea package list on Codeberg, newest-first; the installer is the
     // `generic` `librewolf` package (not `librewolf-source`).
     url: 'https://codeberg.org/api/v1/packages/librewolf',
     parse: packages => packages.find(p => p.type === 'generic' && p.name === 'librewolf')?.version,
   },
-  floorp: {
+  'floorp': {
     // Floorp moved to the Floorp-Projects org; the latest release's tag is the
     // marketing version.
     url: 'https://api.github.com/repos/Floorp-Projects/Floorp/releases/latest',
     parse: release => (release.tag_name || '').replace(/^v/, ''),
+  },
+  'zen': {
+    url: 'https://api.github.com/repos/zen-browser/desktop/releases/latest',
+    parse: release => (release.tag_name || '').replace(/^v/, ''),
+  },
+  'waterfox': {
+    // Waterfox publishes no release assets on GitHub — version-only tracking
+    // (no direct download URL, so no endpoint to verify).
+    url: 'https://api.github.com/repos/BrowserWorks/Waterfox/releases/latest',
+    parse: release => (release.tag_name || '').replace(/^v/, ''),
+    manual: true,
   },
 };
 
@@ -128,6 +156,41 @@ async function checkEndpoint(url) {
 }
 
 /**
+ * Stream-hash a file. Exported for unit tests.
+ *
+ * @param {string} file
+ * @returns {Promise<string>} lowercase hex SHA-256
+ */
+export async function sha256File(file) {
+  const hash = createHash('sha256');
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(file);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('end', resolve);
+    stream.on('error', reject);
+  });
+  return hash.digest('hex');
+}
+
+/**
+ * One-time full download + hash for a release, proving the whole file transfers
+ * (not just the first KB) and recording a known-good SHA-256. The temp file is
+ * removed afterwards — only the hash persists in the baseline.
+ */
+async function verifyFullDownload(url, browser) {
+  const tmp = path.join(os.tmpdir(), `watchdog-${browser}-${process.pid}.exe`);
+  try {
+    await downloadTo(url, tmp);
+    const sha256 = await sha256File(tmp);
+    return {ok: true, size: fs.statSync(tmp).size, sha256};
+  } catch (err) {
+    return {ok: false, reason: `full download failed: ${err.message}`};
+  } finally {
+    fs.rmSync(tmp, {force: true});
+  }
+}
+
+/**
  * Classify a browser's version change against the previous baseline.
  *
  * @param {{version: string} | null} prev baseline entry for the browser
@@ -146,6 +209,9 @@ export function compareBaseline(prev, curr) {
 export function issueTitle(kind, browser, {prevVersion, newVersion, reason} = {}) {
   if (kind === 'rot') {
     return `[url-watchdog] ${browser} download check failed: ${reason}`;
+  }
+  if (kind === 'size-change') {
+    return `[url-watchdog] ${browser} same version, binary size changed`;
   }
   return `[url-watchdog] ${browser} ${prevVersion} → ${newVersion}`;
 }
@@ -189,13 +255,14 @@ async function openIssueIfNew(token, repo, title, body) {
 
 export async function main() {
   const dryRun = process.argv.includes('--dry-run');
+  const prMode = process.argv.includes('--pr');
   const token = process.env.GITHUB_TOKEN || '';
   const repo = process.env.GITHUB_REPOSITORY || '';
   const baselineDir = process.env.BASELINE_DIR || path.join(REPO_ROOT, '.watchdog');
   const baselineFile = path.join(baselineDir, 'baseline.json');
 
   let baseline = {};
-  if (fs.existsSync(baselineFile)) {
+  if (!prMode && fs.existsSync(baselineFile)) {
     baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf-8'));
   }
 
@@ -220,6 +287,24 @@ export async function main() {
       continue;
     }
 
+    const prev = prMode ? undefined : baseline[browser];
+    const change = compareBaseline(prev, {version});
+
+    // Manual browsers (no direct download URL): version tracked only.
+    if (VERSION_APIS[browser].manual) {
+      console.log('  no direct download URL — manual install (version tracked only)');
+      if (!prMode) {
+        next[browser] = {version, manual: true};
+        if (change === 'new-version') {
+          console.log(`  new version: ${prev.version} → ${version} (no CI recipe — no action)`);
+        } else {
+          console.log(change === 'first-run' ? '  first run — baseline recorded' : '  unchanged');
+        }
+      }
+      continue;
+    }
+
+    // Endpoint check (1 KB ranged GET) for every browser.
     let endpoint;
     try {
       const url = await resolveDownloadUrl(browser, 'win32');
@@ -235,36 +320,82 @@ export async function main() {
     }
     console.log(`  endpoint ok (${endpoint.total} bytes)`);
 
-    const prev = baseline[browser];
-    const change = compareBaseline(prev, {version});
-    next[browser] = {version, size: endpoint.total};
-    if (change === 'new-version') {
-      console.log(`  ✗ new version: ${prev.version} → ${version}`);
+    // PR mode: stateless, always green — surface findings as annotations.
+    if (prMode) {
+      continue;
+    }
+
+    // New release (or first run): one-time full download + SHA-256.
+    if (change !== 'ok') {
+      console.log(
+        `  ${change === 'first-run' ? 'first run' : `new version: ${prev.version} → ${version}`}` +
+          ' — verifying full download + SHA-256'
+      );
+      const verified = await verifyFullDownload(
+        await resolveDownloadUrl(browser, 'win32'),
+        browser
+      );
+      if (!verified.ok) {
+        console.log(`  ✗ ${verified.reason}`);
+        findings.push({kind: 'rot', browser, reason: verified.reason, version});
+        continue;
+      }
+      console.log(`  sha256 ${verified.sha256}`);
+      next[browser] = {version, size: verified.size, sha256: verified.sha256};
+      if (change === 'new-version') {
+        findings.push({
+          kind: 'new-version',
+          browser,
+          prevVersion: prev.version,
+          newVersion: version,
+        });
+      } else {
+        console.log('  first run — baseline recorded');
+      }
+      continue;
+    }
+
+    // Same version: keep the recorded hash, flag a binary replacement.
+    next[browser] = {version, size: endpoint.total, sha256: prev.sha256 || null};
+    if (prev.size && prev.size !== endpoint.total) {
+      console.log(`  ⚠ same version, binary size changed: ${prev.size} → ${endpoint.total}`);
       findings.push({
-        kind: 'new-version',
+        kind: 'size-change',
         browser,
-        prevVersion: prev.version,
-        newVersion: version,
+        prevSize: prev.size,
+        newSize: endpoint.total,
       });
     } else {
-      console.log(`  ${change === 'first-run' ? 'first run — baseline recorded' : 'unchanged'}`);
+      console.log('  unchanged');
     }
   }
 
-  // Persist the baseline (only for non-dry runs; CI's cache step picks it up).
-  if (!dryRun) {
+  // Persist the baseline (schedule mode only; CI's cache step picks it up).
+  if (!prMode && !dryRun) {
     fs.mkdirSync(baselineDir, {recursive: true});
     fs.writeFileSync(baselineFile, JSON.stringify(next, null, 2) + '\n');
   }
 
   for (const f of findings) {
     const title = issueTitle(f.kind, f.browser, f);
+    if (prMode) {
+      // Annotations: rot → warning, everything else → notice. Exit stays 0 so
+      // this can be a required check without ever blocking a merge.
+      const level = f.kind === 'rot' ? 'warning' : 'notice';
+      const msg = `${f.browser}: ${f.kind === 'rot' ? f.reason : title}`;
+      console.log(`::${level} file=tools/check-browser-downloads.mjs::${msg}`);
+      continue;
+    }
     const body =
       `Watchdog run: ${runUrl || 'local'}\n\n` +
       (f.kind === 'rot' ?
         `The ${f.browser} download chain failed:\n\n- ${f.reason}\n\n` +
         'Check test/e2e/shared/downloads.mjs and the vendor host; E2E CI installs ' +
         'this browser from the resolved URL.'
+      : f.kind === 'size-change' ?
+        `The ${f.browser} installer changed size without a version bump ` +
+        `(${f.prevSize} → ${f.newSize} bytes). The host likely replaced the binary ` +
+        '— verify it is still the official release.'
       : `New ${f.browser} release: ${f.prevVersion} → ${f.newVersion}.\n\n` +
         'No action required unless E2E CI starts failing; the version-aware ' +
         'download cache key will invalidate on the next run.');
@@ -280,12 +411,14 @@ export async function main() {
   }
 
   console.log(
-    `\n${findings.length} finding(s); baseline ${dryRun ? 'not written (dry-run)' : 'written'}.`
+    `\n${findings.length} finding(s); ` +
+      (prMode ? 'PR mode — no baseline, no issues.'
+      : dryRun ? 'baseline not written (dry-run).'
+      : 'baseline written.')
   );
 }
 
-const isMain =
-  process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('check-browser-downloads.mjs');
+const isMain = process.argv[1] && path.basename(process.argv[1]) === 'check-browser-downloads.mjs';
 if (isMain) {
   main().catch(err => {
     console.error(`✗ Error: ${err.message}`);

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+/**
+ * tools/check-browser-downloads.mjs — weekly watchdog for the E2E browser
+ * download map (test/e2e/shared/downloads.mjs).
+ *
+ * The URL watchdog workflow (.github/workflows/url-watchdog.yml) runs this on a
+ * schedule. For each browser CI installs (firefox, librewolf, floorp) it:
+ *
+ * 1. VERSION — reads the current release version from the vendor's API (Firefox
+ *    product-details, LibreWolf Codeberg packages, Floorp GitHub releases).
+ *    Nothing is downloaded.
+ * 2. ENDPOINT — fetches the resolved installer URL with a 1 KB range request and
+ *    asserts the host still serves a binary (2xx, binary content-type,
+ *    plausible size). Catches 404s, HTML error pages and hosts that changed
+ *    shape — the failure mode that made the LibreWolf winget leg flaky.
+ * 3. BASELINE — compares versions against the last run's baseline (stored in the
+ *    Actions cache under .watchdog/). New versions and broken endpoints open a
+ *    GitHub issue, deduped per browser (the exact issue title is matched
+ *    against open issues carrying the `url-watchdog` label).
+ *
+ * Never downloads the ~100 MB installers — a 1 KB ranged GET (plus cancelling
+ * the body stream) is enough to verify a host. Requires GITHUB_TOKEN with
+ * issues: write for issue creation; without it, or with --dry-run, findings are
+ * printed instead. Exit code stays 0 when findings are reported (they become
+ * issues, not CI failures).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {resolveDownloadUrl} from '../test/e2e/shared/downloads.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+export const REPO_ROOT = path.resolve(__dirname, '..');
+
+export const WATCHDOG_LABEL = 'url-watchdog';
+const MIN_BINARY_BYTES = 10_000_000; // installers are ~100 MB; smaller = wrong file
+const RANGE_BYTES = 1024;
+
+/** The browsers the E2E map installs — each must resolve + serve a binary. */
+const BROWSERS = ['firefox', 'librewolf', 'floorp'];
+
+const VERSION_APIS = {
+  firefox: {
+    // Mozilla product-details: the canonical "current stable version" endpoint.
+    url: 'https://product-details.mozilla.org/1.0/firefox_versions.json',
+    parse: j => j.LATEST_FIREFOX_VERSION,
+  },
+  librewolf: {
+    // Gitea package list on Codeberg, newest-first; the installer is the
+    // `generic` `librewolf` package (not `librewolf-source`).
+    url: 'https://codeberg.org/api/v1/packages/librewolf',
+    parse: packages => packages.find(p => p.type === 'generic' && p.name === 'librewolf')?.version,
+  },
+  floorp: {
+    // Floorp moved to the Floorp-Projects org; the latest release's tag is the
+    // marketing version.
+    url: 'https://api.github.com/repos/Floorp-Projects/Floorp/releases/latest',
+    parse: release => (release.tag_name || '').replace(/^v/, ''),
+  },
+};
+
+/** Fetch + JSON-parse a URL, bounded by a timeout. */
+async function getJson(url) {
+  const res = await fetch(url, {signal: AbortSignal.timeout(30_000)});
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.json();
+}
+
+/** Resolve the current release version for a browser from its vendor API. */
+async function resolveVersion(browser) {
+  const {url, parse} = VERSION_APIS[browser];
+  const version = parse(await getJson(url));
+  if (!version) {
+    throw new Error(`version API for ${browser} returned no version (${url})`);
+  }
+  return String(version);
+}
+
+/** Parse a Content-Range header ('bytes 0-1023/104857600') → total size. */
+export function parseContentRange(header) {
+  if (!header) return null;
+  const m = /\/\s*(\d+)\s*$/.exec(header);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Verify a download endpoint serves a binary: 2xx, binary content-type, and a
+ * plausible size. A 1 KB ranged GET; the body stream is cancelled after the
+ * first chunk so a server ignoring Range still costs ~one chunk, not 100 MB.
+ */
+async function checkEndpoint(url) {
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: {Range: `bytes=0-${RANGE_BYTES - 1}`},
+      redirect: 'follow',
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    return {ok: false, reason: `fetch failed: ${err.message}`};
+  }
+  try {
+    if (!res.ok) return {ok: false, reason: `HTTP ${res.status} ${res.statusText}`};
+    const type = (res.headers.get('content-type') || '').toLowerCase();
+    if (
+      !/application\/(octet-stream|x-msdownload|x-msdos-program)|application\/zip|^binary\//.test(
+        type
+      )
+    ) {
+      return {ok: false, reason: `unexpected content-type '${type}'`};
+    }
+    const total = parseContentRange(res.headers.get('content-range')) || 0;
+    if (total && total < MIN_BINARY_BYTES) {
+      return {ok: false, reason: `suspiciously small (${total} bytes)`};
+    }
+    if (res.body) {
+      const reader = res.body.getReader();
+      await reader.read(); // first chunk (≤ 64 KB) — enough to confirm it's a download
+      await reader.cancel();
+    }
+    return {ok: true, total};
+  } finally {
+    // Best-effort: drain/cancel is handled above; nothing further to release.
+  }
+}
+
+/**
+ * Classify a browser's version change against the previous baseline.
+ *
+ * @param {{version: string} | null} prev baseline entry for the browser
+ * @param {{version: string}} curr freshly resolved version
+ * @returns {'first-run' | 'new-version' | 'ok'}
+ */
+export function compareBaseline(prev, curr) {
+  if (!prev) return 'first-run';
+  return prev.version !== curr.version ? 'new-version' : 'ok';
+}
+
+/**
+ * The dedup key for an issue: exact-title match against open issues carrying
+ * the url-watchdog label, so a re-run never duplicates an open finding.
+ */
+export function issueTitle(kind, browser, {prevVersion, newVersion, reason} = {}) {
+  if (kind === 'rot') {
+    return `[url-watchdog] ${browser} download check failed: ${reason}`;
+  }
+  return `[url-watchdog] ${browser} ${prevVersion} → ${newVersion}`;
+}
+
+/** Minimal GitHub REST helper (issues only). */
+async function ghApi(token, pathname, {method = 'GET', body} = {}) {
+  const res = await fetch(`https://api.github.com${pathname}`, {
+    method,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? {'Content-Type': 'application/json'} : {}),
+    },
+    ...(body ? {body: JSON.stringify(body)} : {}),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`GitHub API ${method} ${pathname}: HTTP ${res.status} ${json.message || ''}`);
+  }
+  return json;
+}
+
+/** Open a watchdog issue unless an open one with the same title already exists. */
+async function openIssueIfNew(token, repo, title, body) {
+  const open = await ghApi(
+    token,
+    `/repos/${repo}/issues?state=open&labels=${WATCHDOG_LABEL}&per_page=100`
+  );
+  if (open.some(i => i.title === title)) {
+    console.log(`  already open: ${title}`);
+    return;
+  }
+  await ghApi(token, `/repos/${repo}/issues`, {
+    method: 'POST',
+    body: {title, body, labels: [WATCHDOG_LABEL]},
+  });
+  console.log(`  opened issue: ${title}`);
+}
+
+export async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const token = process.env.GITHUB_TOKEN || '';
+  const repo = process.env.GITHUB_REPOSITORY || '';
+  const baselineDir = process.env.BASELINE_DIR || path.join(REPO_ROOT, '.watchdog');
+  const baselineFile = path.join(baselineDir, 'baseline.json');
+
+  let baseline = {};
+  if (fs.existsSync(baselineFile)) {
+    baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf-8'));
+  }
+
+  const findings = [];
+  const next = {};
+  const runUrl =
+    process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY ?
+      `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID || ''}`
+    : '';
+
+  for (const browser of BROWSERS) {
+    console.log(`\n${browser}:`);
+    let version;
+    try {
+      version = await resolveVersion(browser);
+      console.log(`  version ${version} (API ok)`);
+    } catch (err) {
+      // The version API itself failed — that is rot in the resolution chain.
+      const reason = `version lookup failed: ${err.message}`;
+      console.log(`  ✗ ${reason}`);
+      findings.push({kind: 'rot', browser, reason});
+      continue;
+    }
+
+    let endpoint;
+    try {
+      const url = await resolveDownloadUrl(browser, 'win32');
+      console.log(`  url ${url}`);
+      endpoint = await checkEndpoint(url);
+    } catch (err) {
+      endpoint = {ok: false, reason: err.message};
+    }
+    if (!endpoint.ok) {
+      console.log(`  ✗ ${endpoint.reason}`);
+      findings.push({kind: 'rot', browser, reason: endpoint.reason, version});
+      continue; // broken chain — do not touch the baseline for this browser
+    }
+    console.log(`  endpoint ok (${endpoint.total} bytes)`);
+
+    const prev = baseline[browser];
+    const change = compareBaseline(prev, {version});
+    next[browser] = {version, size: endpoint.total};
+    if (change === 'new-version') {
+      console.log(`  ✗ new version: ${prev.version} → ${version}`);
+      findings.push({
+        kind: 'new-version',
+        browser,
+        prevVersion: prev.version,
+        newVersion: version,
+      });
+    } else {
+      console.log(`  ${change === 'first-run' ? 'first run — baseline recorded' : 'unchanged'}`);
+    }
+  }
+
+  // Persist the baseline (only for non-dry runs; CI's cache step picks it up).
+  if (!dryRun) {
+    fs.mkdirSync(baselineDir, {recursive: true});
+    fs.writeFileSync(baselineFile, JSON.stringify(next, null, 2) + '\n');
+  }
+
+  for (const f of findings) {
+    const title = issueTitle(f.kind, f.browser, f);
+    const body =
+      `Watchdog run: ${runUrl || 'local'}\n\n` +
+      (f.kind === 'rot' ?
+        `The ${f.browser} download chain failed:\n\n- ${f.reason}\n\n` +
+        'Check test/e2e/shared/downloads.mjs and the vendor host; E2E CI installs ' +
+        'this browser from the resolved URL.'
+      : `New ${f.browser} release: ${f.prevVersion} → ${f.newVersion}.\n\n` +
+        'No action required unless E2E CI starts failing; the version-aware ' +
+        'download cache key will invalidate on the next run.');
+    if (dryRun || !token) {
+      console.log(`\n${dryRun ? '[dry-run] ' : '[no GITHUB_TOKEN] '}would open: ${title}`);
+      continue;
+    }
+    if (!repo) {
+      console.log(`\nGITHUB_REPOSITORY not set — skipping issue creation for: ${title}`);
+      continue;
+    }
+    await openIssueIfNew(token, repo, title, body);
+  }
+
+  console.log(
+    `\n${findings.length} finding(s); baseline ${dryRun ? 'not written (dry-run)' : 'written'}.`
+  );
+}
+
+const isMain =
+  process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('check-browser-downloads.mjs');
+if (isMain) {
+  main().catch(err => {
+    console.error(`✗ Error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -22,7 +22,9 @@
  *        flag a size change (binary replaced without a bump).
  *   4. ISSUES — new versions, rot, and same-version size changes open a GitHub
  *        issue, deduped per browser (the exact issue title is matched against
- *        open issues carrying the `url-watchdog` label).
+ *        open issues carrying the `url-watchdog` label). New-release issues
+ *        carry the verified SHA-256 + size — the durable ledger (search
+ *        `label:url-watchdog` for the record of any release).
  * - PR (pull_request touching the download map): stateless and always green —
  *   findings surface as ::warning:: / ::notice:: annotations, so the check can
  *   be marked required without ever blocking. No baseline, no issues, no full
@@ -216,6 +218,50 @@ export function issueTitle(kind, browser, {prevVersion, newVersion, reason} = {}
   return `[url-watchdog] ${browser} ${prevVersion} → ${newVersion}`;
 }
 
+/**
+ * Markdown body for a watchdog issue. New-release bodies carry the verified
+ * SHA-256 + size — the durable ledger record for that browser/version.
+ *
+ * @param {{
+ *   kind: string;
+ *   browser: string;
+ *   reason?: string;
+ *   prevVersion?: string;
+ *   newVersion?: string;
+ *   prevSize?: number;
+ *   newSize?: number;
+ *   size?: number;
+ *   sha256?: string;
+ * }} f
+ * @param {string} runUrl
+ */
+export function issueBody(f, runUrl = 'local') {
+  const head = `Watchdog run: ${runUrl}\n\n`;
+  if (f.kind === 'rot') {
+    return (
+      head +
+      `The ${f.browser} download chain failed:\n\n- ${f.reason}\n\n` +
+      'Check test/e2e/shared/downloads.mjs and the vendor host; E2E CI installs ' +
+      'this browser from the resolved URL.'
+    );
+  }
+  if (f.kind === 'size-change') {
+    return (
+      head +
+      `The ${f.browser} installer changed size without a version bump ` +
+      `(${f.prevSize} → ${f.newSize} bytes). The host likely replaced the binary ` +
+      '— verify it is still the official release.'
+    );
+  }
+  return (
+    head +
+    `New ${f.browser} release: ${f.prevVersion} → ${f.newVersion}.\n\n` +
+    `Verified SHA-256 (${f.size} bytes): \`${f.sha256}\`\n\n` +
+    'No action required unless E2E CI starts failing; the version-aware ' +
+    'download cache key will invalidate on the next run.'
+  );
+}
+
 /** Minimal GitHub REST helper (issues only). */
 async function ghApi(token, pathname, {method = 'GET', body} = {}) {
   const res = await fetch(`https://api.github.com${pathname}`, {
@@ -348,6 +394,8 @@ export async function main() {
           browser,
           prevVersion: prev.version,
           newVersion: version,
+          size: verified.size,
+          sha256: verified.sha256,
         });
       } else {
         console.log('  first run — baseline recorded');
@@ -386,19 +434,7 @@ export async function main() {
       console.log(`::${level} file=tools/check-browser-downloads.mjs::${msg}`);
       continue;
     }
-    const body =
-      `Watchdog run: ${runUrl || 'local'}\n\n` +
-      (f.kind === 'rot' ?
-        `The ${f.browser} download chain failed:\n\n- ${f.reason}\n\n` +
-        'Check test/e2e/shared/downloads.mjs and the vendor host; E2E CI installs ' +
-        'this browser from the resolved URL.'
-      : f.kind === 'size-change' ?
-        `The ${f.browser} installer changed size without a version bump ` +
-        `(${f.prevSize} → ${f.newSize} bytes). The host likely replaced the binary ` +
-        '— verify it is still the official release.'
-      : `New ${f.browser} release: ${f.prevVersion} → ${f.newVersion}.\n\n` +
-        'No action required unless E2E CI starts failing; the version-aware ' +
-        'download cache key will invalidate on the next run.');
+    const body = issueBody(f, runUrl || 'local');
     if (dryRun || !token) {
       console.log(`\n${dryRun ? '[dry-run] ' : '[no GITHUB_TOKEN] '}would open: ${title}`);
       continue;


### PR DESCRIPTION
## What & why

Two CI-reliability fixes that grew out of PR #63's CI run (the LibreWolf winget flake):

1. **Path-filter the installer/updater E2E jobs and the publish gate.** Docs-only / tooling-only PRs currently run (and can fail on) the full E2E matrix. `e2e.yml` and `ci.yml` now gate those jobs on changed paths (`core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, `test/e2e/**`, `package.json`, `pnpm-lock.yaml`, workflow/actions); the aggregate gates (`e2e-gate`, `ci-gate`) always run so required checks never go missing. `browser-matrix` stays advisory (warn, not fail).
2. **Drop winget for LibreWolf + Floorp.** The failing leg was `winget install LibreWolf.LibreWolf` hitting the flaky third-party winget source. `test/e2e/shared/downloads.mjs` now downloads official installers directly:
   - LibreWolf — resolves the newest version from the Codeberg package registry (`/api/v1/packages/librewolf`) and installs from `librewolf.dev` (verified: resolves `154.0.1-2`).
   - Floorp — uses GitHub's stable `/releases/latest/download/floorp-windows-x86_64.installer.exe` (Floorp moved from `Ablaze-M/Floorp` to `Floorp-Projects/Floorp`).
   - Package-manager recipes removed; `resolveDownloadUrl` is async for version resolution. Unit tests updated (fetch stubbed, no network).

## Notes
- The two changes are grouped in one PR as "CI reliability"; happy to split if you'd rather review them separately.
- Docs (`AGENTS.md`, `docs/DEVELOPING.md`, `docs/e2e-matrix-plan.md`) updated to match.
- Validation: `pnpm test` 102 pass / 0 fail, `pnpm format` ✓, `pnpm lint` ✓. Live `--url` resolution smoke-tested for all three browsers.