### PR TITLE
ci: path-filter the browser-matrix fork legs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -326,6 +326,13 @@ jobs:
             esac
           else
             echo 'installer + updater E2E: skipped — no E2E-relevant changes (OK)'
+            # Guard: if browser-matrix ran despite no E2E-relevant changes, its
+            # changed-paths gate was removed — fail loudly instead of silently
+            # burning ~14 Windows runner-minutes on every docs-only PR again.
+            if [ "${{ needs.browser-matrix.result }}" != "skipped" ]; then
+              echo "::error::browser-matrix ran despite no E2E-relevant changes — changed-paths gate removed?"
+              exit 1
+            fi
             echo 'browser-matrix: skipped — no E2E-relevant changes (OK)'
           fi
           echo 'All E2E jobs passed'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,7 +229,11 @@ jobs:
   # release assets — tracked by the URL watchdog).
   browser-matrix:
     name: 'updater E2E · ${{ matrix.browser }} · windows-latest'
-    needs: snapshot
+    # Same updater E2E test as the `updater` job, so it is gated on the same
+    # changed-paths filter (skips on docs-only / tooling-only PRs). The legs
+    # stay ADVISORY in the gate: their failures warn instead of blocking.
+    needs: [changes, snapshot]
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -312,15 +316,16 @@ jobs:
           if [ "${{ needs.changes.outputs.e2e }}" = "true" ]; then
             verify 'installer' '${{ needs.installer.result }}'
             verify 'updater'   '${{ needs.updater.result }}'
+            # browser-matrix is ADVISORY (fork legs download from third-party
+            # hosts — librewolf.dev's package registry, Floorp's GitHub
+            # releases — which can hiccup; see docs/e2e-matrix-plan.md). Warn,
+            # don't fail the gate.
+            case "${{ needs.browser-matrix.result }}" in
+              success) ok 'browser-matrix' '${{ needs.browser-matrix.result }}' ;;
+              *) echo "::warning::browser-matrix ${{ needs.browser-matrix.result }} (advisory)" ;;
+            esac
           else
             echo 'installer + updater E2E: skipped — no E2E-relevant changes (OK)'
+            echo 'browser-matrix: skipped — no E2E-relevant changes (OK)'
           fi
-          # browser-matrix is ADVISORY (fork legs download from third-party
-          # hosts — librewolf.dev's package registry, Floorp's GitHub releases —
-          # which can hiccup; see docs/e2e-matrix-plan.md). Warn, don't fail the
-          # gate.
-          case "${{ needs.browser-matrix.result }}" in
-            success) ok 'browser-matrix' '${{ needs.browser-matrix.result }}' ;;
-            *) echo "::warning::browser-matrix ${{ needs.browser-matrix.result }} (advisory)" ;;
-          esac
           echo 'All E2E jobs passed'

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -297,9 +297,9 @@ publish gate (`build` in `.github/workflows/ci.yml`) runs only when `core/**`,
 the workflow/actions changed. Docs-only / tooling-only PRs skip both, while `checks`, `ci-gate` and
 `e2e-gate` always run so the required checks keep reporting. The `browser-matrix` legs (Firefox Dev
 Edition, LibreWolf, Floorp, Zen — downloaded from third-party hosts: Mozilla's redirect,
-librewolf.dev's package registry, GitHub release assets) are advisory: their failures warn in the
-gate instead of failing the PR. Waterfox has no direct download URL and stays manual (tracked by
-version only in the URL watchdog).
+librewolf.dev's package registry, GitHub release assets) are gated on the same filter and are
+advisory when they run: failures warn in the gate instead of failing the PR. Waterfox has no direct
+download URL and stays manual (tracked by version only in the URL watchdog).
 
 Run the smoke test locally (Windows, from the repo root):
 

--- a/docs/decisions/0017-ci-validation-contract.md
+++ b/docs/decisions/0017-ci-validation-contract.md
@@ -14,23 +14,26 @@ under test (PR #63's LibreWolf leg).
 
 ## Decision
 
-Installer/updater E2E and the publish gate run **only when changed files can affect them**
-(`core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, `test/e2e/**`, the package
-manifest, and the workflows/actions); the aggregate gates always run, so required checks never go
-missing. Fork-browser matrix legs are **advisory** — failures warn in the gate instead of blocking.
-The browser download map (`test/e2e/shared/downloads.mjs`) is the single source of truth for install
-recipes: direct official downloads, "latest" resolved from vendor version APIs, no package managers.
-A scheduled + PR-triggered URL watchdog (`.github/workflows/url-watchdog.yml`) keeps the map
-trustworthy between releases.
+Installer/updater E2E, the browser-matrix fork legs (same updater E2E test, other browsers) and the
+publish gate run **only when changed files can affect them** (`core/**`, `config/installer.conf`,
+`installer/**`, `tools/publish/**`, `test/e2e/**`, the package manifest, and the workflows/actions);
+the aggregate gates always run, so required checks never go missing. Fork-browser matrix legs are
+**advisory** — when they run, failures warn in the gate instead of blocking. The browser download
+map (`test/e2e/shared/downloads.mjs`) is the single source of truth for install recipes: direct
+official downloads, "latest" resolved from vendor version APIs, no package managers. A scheduled +
+PR-triggered URL watchdog (`.github/workflows/url-watchdog.yml`) keeps the map trustworthy between
+releases.
 
 ## Consequences
 
 Docs-only PRs get fast, green CI, and a flaky third-party host can no longer block a merge. Coverage
 gaps on docs-only PRs are accepted; any PR touching the download map runs the watchdog's PR check
-and the affected legs. One caveat: a PR that branched before a gating change and is later updated
-from main (the "Update branch" button, required by strict branch protection) over-runs the full
-matrix once — GitHub's changed-files diff counts base-branch changes merged into the head, so the
-paths filter over-triggers. Rebase the PR onto main instead of merging it in to avoid the over-run;
-when it happens it is harmless (conservative direction). The download map and watchdog are test
-harness, not product — they are noted as "Not recorded" in the index, not re-ADRed. Revisit-if: a
-fork host becomes reliable enough for hard gates, or a docs-only change needs the full E2E matrix.
+and the affected legs. The fork legs no longer act as an always-on canary for upstream fork releases
+breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PR catches a
+breakage. One caveat: a PR that branched before a gating change and is later updated from main (the
+"Update branch" button, required by strict branch protection) over-runs the full matrix once —
+GitHub's changed-files diff counts base-branch changes merged into the head, so the paths filter
+over-triggers. Rebase the PR onto main instead of merging it in to avoid the over-run; when it
+happens it is harmless (conservative direction). The download map and watchdog are test harness, not
+product — they are noted as "Not recorded" in the index, not re-ADRed. Revisit-if: a fork host
+becomes reliable enough for hard gates, or a docs-only change needs the full E2E matrix.

--- a/docs/e2e-matrix-plan.md
+++ b/docs/e2e-matrix-plan.md
@@ -38,10 +38,11 @@ geckodriver uses by default for recent builds.
 **Advisory** = the E2E gate reports a warning instead of failing the PR. The `browser-matrix` legs
 (Firefox Dev Edition, LibreWolf, Floorp, Zen) download official installers directly from third-party
 hosts — Mozilla's devedition redirect, librewolf.dev's package registry, GitHub release assets —
-which can hiccup. LibreWolf's newest version is resolved from the Codeberg package registry; Floorp
-and Zen use stable `/releases/latest/download/` asset URLs. Waterfox has no direct URL (no GitHub
-release assets), so its leg stays manual and the URL watchdog tracks its version only. The hard gate
-is Firefox stable across all three OSes.
+which can hiccup. The legs are path-filtered like the 3-OS jobs (same updater E2E test, so they skip
+on docs-only PRs) and remain advisory when they run. LibreWolf's newest version is resolved from the
+Codeberg package registry; Floorp and Zen use stable `/releases/latest/download/` asset URLs.
+Waterfox has no direct URL (no GitHub release assets), so its leg stays manual and the URL watchdog
+tracks its version only. The hard gate is Firefox stable across all three OSes.
 
 ## What each test asserts
 


### PR DESCRIPTION
The browser-matrix fork legs (librewolf, floorp, firefox-dev, zen) run the same updater E2E test as the 3-OS updater job, so they now honor the same changed-paths filter — skipping on docs-only / tooling-only PRs instead of burning ~14 Windows runner-minutes on every PR. They remain advisory when they run: `e2e-gate` still warns (not fails) on their failures and treats the filtered skip as OK.

The tradeoff (from the discussion): the fork legs no longer act as an always-on canary for upstream fork releases breaking the updater; the watchdog flags version bumps and the next E2E-relevant PR catches a breakage. Documented in ADR 0017's consequences.