### PR TITLE
ci: guard the publish gate always-report design in ci-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,5 +137,14 @@ jobs:
             verify 'build' '${{ needs.build.result }}'
           else
             echo 'publish gate: skipped — no publish-relevant changes (OK)'
+            # Guard: `build` deliberately has NO job-level `if:` — it always
+            # runs and reports success, with the heavy steps gated inside. A
+            # job-level `if:` would skip it on docs-only PRs and make the
+            # required check go missing, blocking strict branch protection
+            # (the #65 regression). Fail loudly if that design is undone.
+            if [ "${{ needs.build.result }}" != "success" ]; then
+              echo "::error::publish gate did not report success (${{ needs.build.result }}) — always-run design undone?"
+              exit 1
+            fi
           fi
           echo 'All CI jobs passed'


### PR DESCRIPTION
Mirror of the e2e-gate browser-matrix assertion from #66.

`ci-gate` now verifies, in the no-publish-relevant branch, that the publish gate job reported **success** — the always-run no-op it's designed for. If the gate ever gains a job-level `if:` (a plausible 'cleanup'), it would skip on docs-only PRs and make the required check go missing, blocking strict branch protection — the exact #65 regression. The guard turns that silent regression into a loud CI failure.

Shell logic verified locally for all five cases (legit ×2, regression ×3).