### PR TITLE
ci: extend the e2e-gate skip guard to installer + updater

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -326,13 +326,21 @@ jobs:
             esac
           else
             echo 'installer + updater E2E: skipped — no E2E-relevant changes (OK)'
-            # Guard: if browser-matrix ran despite no E2E-relevant changes, its
-            # changed-paths gate was removed — fail loudly instead of silently
-            # burning ~14 Windows runner-minutes on every docs-only PR again.
-            if [ "${{ needs.browser-matrix.result }}" != "skipped" ]; then
-              echo "::error::browser-matrix ran despite no E2E-relevant changes — changed-paths gate removed?"
-              exit 1
-            fi
-            echo 'browser-matrix: skipped — no E2E-relevant changes (OK)'
+            # Guard: if any gated E2E job ran despite no E2E-relevant changes,
+            # its changed-paths gate was removed — fail loudly instead of
+            # silently burning runner-minutes on every docs-only PR again.
+            # (`helper` is deliberately unfiltered and always runs.)
+            for spec in \
+              "installer:${{ needs.installer.result }}" \
+              "updater:${{ needs.updater.result }}" \
+              "browser-matrix:${{ needs.browser-matrix.result }}"; do
+              job="${spec%%:*}"
+              result="${spec#*:}"
+              if [ "$result" != "skipped" ]; then
+                echo "::error::$job ran despite no E2E-relevant changes (result: $result) — changed-paths gate removed?"
+                exit 1
+              fi
+            done
+            echo 'installer + updater + browser-matrix: skipped — no E2E-relevant changes (OK)'
           fi
           echo 'All E2E jobs passed'


### PR DESCRIPTION
Extends the runtime gate-removal guard from #66 from browser-matrix to **all three** gated E2E jobs (installer, updater, browser-matrix), one loop that names the regressed job.

Shell logic verified locally for all 8 gate cases: legit ×2 exit 0; each removed gate ×3 exit 1; installer/updater failure exit 1; browser-matrix failure stays advisory (warning, exit 0).