### PR TITLE
ci: log the URL watchdog baseline's cache-hit status and age

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -285,9 +285,11 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
   LibreWolf, Floorp, Zen; Waterfox tracked by version only) from its vendor API and verifies the
   download endpoint with a 1 KB ranged GET. Each new release is downloaded once, SHA-256'd and
   recorded in the per-release watchdog issue (`label:url-watchdog`) — the durable ledger. Opens
-  issues on rot (404, HTML error page, changed API shape) and same-version binary size changes. The
-  PR mode (`--pr`) is stateless, always green, and surfaces findings as annotations. Run manually
-  via `workflow_dispatch`, or locally with `node tools/check-browser-downloads.mjs --dry-run`.
+  issues on rot (404, HTML error page, changed API shape) and same-version binary size changes. Each
+  run logs the baseline's cache-hit status and age, so a silently evicted Actions cache is visible
+  instead of masquerading as a first run. The PR mode (`--pr`) is stateless, always green, and
+  surfaces findings as annotations. Run manually via `workflow_dispatch`, or locally with
+  `node tools/check-browser-downloads.mjs --dry-run`.
 
 **PR path filtering** — the installer + updater E2E jobs (`.github/workflows/e2e.yml`) run only when
 a changed file can affect them (`core/**`, `config/installer.conf`, `installer/**`,

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -12,9 +12,8 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-downloads.mjs')).href;
-const {compareBaseline, issueBody, issueTitle, parseContentRange, sha256File} = await import(
-  scriptUrl
-);
+const {compareBaseline, formatAge, issueBody, issueTitle, parseContentRange, sha256File} =
+  await import(scriptUrl);
 
 test('compareBaseline: first run, new version, unchanged', () => {
   assert.equal(compareBaseline(null, {version: '154.0.1'}), 'first-run');
@@ -52,6 +51,14 @@ test('issueBody: new-version body carries the verified SHA-256 ledger', () => {
   assert.match(body, /Watchdog run: https:\/\/github\.com/);
   assert.match(body, /New librewolf release: 154\.0-2 → 154\.0\.1-2/);
   assert.match(body, /Verified SHA-256 \(153225824 bytes\): `ec27c770aa/);
+});
+
+test('formatAge: human-readable baseline age, clamped at 0', () => {
+  assert.equal(formatAge(0), '0m');
+  assert.equal(formatAge(8 * 60_000), '8m');
+  assert.equal(formatAge(5 * 3_600_000 + 12 * 60_000), '5h 12m');
+  assert.equal(formatAge(3 * 86_400_000 + 2 * 3_600_000), '3d 2h');
+  assert.equal(formatAge(-5_000), '0m'); // clock skew → clamp, no negative
 });
 
 test('parseContentRange: total size or null', () => {

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -19,7 +19,9 @@
  *        downloads the installer once, hashes it and records {version, size,
  *        sha256} in the baseline (.watchdog/baseline.json, stored in the
  *        Actions cache). Same-version runs re-check only the 1 KB range, but
- *        flag a size change (binary replaced without a bump).
+ *        flag a size change (binary replaced without a bump). Each run logs the
+ *        baseline's cache-hit status and age, so a silently evicted cache is
+ *        visible instead of masquerading as a first run.
  *   4. ISSUES — new versions, rot, and same-version size changes open a GitHub
  *        issue, deduped per browser (the exact issue title is matched against
  *        open issues carrying the `url-watchdog` label). New-release issues
@@ -207,6 +209,19 @@ export function compareBaseline(prev, curr) {
 }
 
 /**
+ * Human-readable age from a millisecond span — e.g. '3d 2h', '5h 12m', '8m'.
+ * Exported for unit tests; clamped to 0 so clock skew never prints negative.
+ */
+export function formatAge(ms) {
+  const min = Math.max(0, Math.floor(ms / 60_000));
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h ${min % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}
+
+/**
  * The dedup key for an issue: exact-title match against open issues carrying
  * the url-watchdog label, so a re-run never duplicates an open finding.
  */
@@ -310,8 +325,19 @@ export async function main() {
   const baselineFile = path.join(baselineDir, 'baseline.json');
 
   let baseline = {};
-  if (!prMode && fs.existsSync(baselineFile)) {
+  const baselineFound = !prMode && fs.existsSync(baselineFile);
+  if (baselineFound) {
     baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf-8'));
+    // Cache-hit telemetry: an evicted/expired Actions cache would otherwise
+    // masquerade as a first run or a version bump. The cache restore preserves
+    // the file mtime, so age = time since the previous run wrote the baseline.
+    const stat = fs.statSync(baselineFile);
+    console.log(
+      `baseline: cache hit — written ${new Date(stat.mtimeMs).toISOString()} ` +
+        `(${formatAge(Date.now() - stat.mtimeMs)} ago)`
+    );
+  } else if (!prMode) {
+    console.log('baseline: cache miss — first run, re-baselining all browsers');
   }
 
   const findings = [];


### PR DESCRIPTION
The watchdog baseline lives in the Actions cache, which evicts/expires silently (7-day TTL). An eviction previously looked identical to a first run or a version bump — the real cause was invisible in the log.

Each run now prints one line up front:
- `baseline: cache hit — written <ISO ts> (<age> ago)` (age from the restored file's mtime)
- `baseline: cache miss — first run, re-baselining all browsers`

`formatAge()` is exported + unit-tested (4 cases incl. negative clamp); both log lines smoke-verified live. Docs (DEVELOPING.md) updated.