### PR TITLE
ci: consolidate gate guards into one shared action + static contract

### DIFF
--- a/.github/actions/verify-gate/action.yml
+++ b/.github/actions/verify-gate/action.yml
@@ -52,4 +52,6 @@ runs:
         ADVISORY: ${{ inputs.advisory }}
         SKIP_GUARD: ${{ inputs.skip-guard }}
         ALWAYS_REPORT: ${{ inputs.always-report }}
-      run: ${{ github.action_path }}/verify.sh
+      # `bash <script>` (not a bare path): the exec bit is not stored for
+      # files added from Windows, so a direct run would get Permission denied.
+      run: bash ${{ github.action_path }}/verify.sh

--- a/.github/actions/verify-gate/action.yml
+++ b/.github/actions/verify-gate/action.yml
@@ -1,0 +1,50 @@
+name: Verify gate
+description: >-
+  Shared engine for the aggregate CI/E2E branch-protection checks. Verifies the changes
+  (paths-filter) job, then the branch-conditional gated jobs (required / advisory), then the
+  no-change guards (skipped-jobs and always-report). This is the shell logic that used to live
+  inline in ci-gate and e2e-gate.
+inputs:
+  changes-result:
+    description: result of the changes (paths-filter) job — must be success
+    required: true
+  branch:
+    description: "'true' when gated work is active (the filter output), else 'false'"
+    required: true
+  branch-label:
+    description: human label for the branch, e.g. 'E2E-relevant changes'
+    required: true
+  results:
+    description: 'space-separated name:result pairs for every tracked job'
+    required: true
+  required:
+    description: 'space-separated job names that must be success when branch=true'
+    required: false
+    default: ''
+  advisory:
+    description: 'space-separated job names warned (not failed) when branch=true'
+    required: false
+    default: ''
+  skip-guard:
+    description: 'space-separated job names that must be skipped when branch=false'
+    required: false
+    default: ''
+  always-report:
+    description: 'space-separated job names that must report success when branch=false'
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Verify gate results
+      shell: bash
+      env:
+        CHANGES_RESULT: ${{ inputs.changes-result }}
+        BRANCH: ${{ inputs.branch }}
+        BRANCH_LABEL: ${{ inputs.branch-label }}
+        RESULTS: ${{ inputs.results }}
+        REQUIRED: ${{ inputs.required }}
+        ADVISORY: ${{ inputs.advisory }}
+        SKIP_GUARD: ${{ inputs.skip-guard }}
+        ALWAYS_REPORT: ${{ inputs.always-report }}
+      run: ${{ github.action_path }}/verify.sh

--- a/.github/actions/verify-gate/action.yml
+++ b/.github/actions/verify-gate/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'space-separated job names that must be success when branch=true'
     required: false
     default: ''
+  always-verify:
+    description: 'space-separated job names that must be success in BOTH branches (always-run jobs)'
+    required: false
+    default: ''
   advisory:
     description: 'space-separated job names warned (not failed) when branch=true'
     required: false
@@ -44,6 +48,7 @@ runs:
         BRANCH_LABEL: ${{ inputs.branch-label }}
         RESULTS: ${{ inputs.results }}
         REQUIRED: ${{ inputs.required }}
+        ALWAYS_VERIFY: ${{ inputs.always-verify }}
         ADVISORY: ${{ inputs.advisory }}
         SKIP_GUARD: ${{ inputs.skip-guard }}
         ALWAYS_REPORT: ${{ inputs.always-report }}

--- a/.github/actions/verify-gate/verify.sh
+++ b/.github/actions/verify-gate/verify.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Optional inputs — the composite action always passes them (defaults ''),
 # but default them here so the script also runs safely outside Actions.
-: "${REQUIRED:=}" "${ADVISORY:=}" "${SKIP_GUARD:=}" "${ALWAYS_REPORT:=}"
+: "${REQUIRED:=}" "${ADVISORY:=}" "${SKIP_GUARD:=}" "${ALWAYS_REPORT:=}" "${ALWAYS_VERIFY:=}"
 
 fail() { echo "::error::$1: $2"; exit 1; }
 ok()   { echo "$1: $2 (OK)"; }
@@ -19,6 +19,11 @@ done
 lookup() { echo "${RESULT[$1]:-missing}"; }
 
 verify 'changes' "$CHANGES_RESULT"
+# Always-run jobs (e.g. the lint/format `checks`) are verified in BOTH
+# branches — a failure must not slip through when the gated branch is off.
+for name in $ALWAYS_VERIFY; do
+  verify "$name" "$(lookup "$name")"
+done
 
 if [ "$BRANCH" = "true" ]; then
   for name in $REQUIRED; do

--- a/.github/actions/verify-gate/verify.sh
+++ b/.github/actions/verify-gate/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Shared gate engine for ci-gate / e2e-gate (see action.yml for the inputs).
+# Run by the composite action; never invoke directly.
+set -euo pipefail
+
+# Optional inputs — the composite action always passes them (defaults ''),
+# but default them here so the script also runs safely outside Actions.
+: "${REQUIRED:=}" "${ADVISORY:=}" "${SKIP_GUARD:=}" "${ALWAYS_REPORT:=}"
+
+fail() { echo "::error::$1: $2"; exit 1; }
+ok()   { echo "$1: $2 (OK)"; }
+verify() { case "$2" in success) ok "$1" "$2" ;; *) fail "$1" "$2" ;; esac; }
+
+# name:result lookup table (missing = the job never existed).
+declare -A RESULT
+for spec in $RESULTS; do
+  RESULT["${spec%%:*}"]="${spec#*:}"
+done
+lookup() { echo "${RESULT[$1]:-missing}"; }
+
+verify 'changes' "$CHANGES_RESULT"
+
+if [ "$BRANCH" = "true" ]; then
+  for name in $REQUIRED; do
+    verify "$name" "$(lookup "$name")"
+  done
+  # Advisory jobs warn instead of failing the gate (fork-browser legs).
+  for name in $ADVISORY; do
+    r="$(lookup "$name")"
+    case "$r" in
+      success) ok "$name" "$r" ;;
+      *) echo "::warning::$name $r (advisory)" ;;
+    esac
+  done
+  echo "All gated jobs verified ($BRANCH_LABEL present)"
+else
+  echo "gated jobs skipped — no $BRANCH_LABEL (OK)"
+  # Guard: a gated job that ran despite no relevant changes lost its
+  # changed-paths `if:` — fail loudly instead of silently burning
+  # runner-minutes on every docs-only PR again.
+  for name in $SKIP_GUARD; do
+    r="$(lookup "$name")"
+    if [ "$r" != "skipped" ]; then
+      echo "::error::$name ran despite no $BRANCH_LABEL (result: $r) — changed-paths gate removed?"
+      exit 1
+    fi
+  done
+  # Guard: an always-report job (the publish gate) that did not report success
+  # gained a job-level `if:` — the required check would go missing and block
+  # strict branch protection. Fail loudly if that design is undone.
+  for name in $ALWAYS_REPORT; do
+    r="$(lookup "$name")"
+    if [ "$r" != "success" ]; then
+      echo "::error::$name did not report success despite no $BRANCH_LABEL (result: $r) — always-report design undone?"
+      exit 1
+    fi
+  done
+  echo 'skipped / always-report checks OK'
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
     if: always()
     needs: [changes, checks, build]
     steps:
+      # Local action — a fresh runner needs the repo checked out first.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/verify-gate
         with:
           changes-result: ${{ needs.changes.result }}
@@ -139,5 +141,6 @@ jobs:
           results: |-
             checks:${{ needs.checks.result }}
             build:${{ needs.build.result }}
-          required: checks
+          always-verify: checks
+          required: build
           always-report: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Required checks must also run on the merge-queue's temporary branch when
+  # a PR lands via the queue (Settings → merge queue) — see docs/DEVELOPING.md.
+  merge_group:
 
 permissions:
   contents: read
@@ -50,6 +53,7 @@ jobs:
       - run: pnpm format
       - run: pnpm test
       - run: pnpm check:decisions
+      - run: pnpm check:gates
 
   # Publish-path gate: `upload:local --mode=dev` rebuilds the zips and the
   # native binaries for the runner's OS.  This is what catches regressions in
@@ -114,28 +118,26 @@ jobs:
 
   # ── CI gate ──────────────────────────────────────────────────────────────
   # Single branch-protection check — only registers as success when all
-  # upstream jobs pass.  Add/remove jobs without touching branch-protection.
+  # upstream jobs pass. The verify logic (incl. the always-report guard on
+  # `build`, which has NO job-level `if:` by design) lives in the shared
+  # .github/actions/verify-gate engine, kept consistent with e2e-gate.
+  # `pnpm check:gates` enforces this needs list.
   ci-gate:
     name: CI gate
     runs-on: ubuntu-latest
     if: always()
     needs: [changes, checks, build]
     steps:
-      - name: Verify all CI jobs
-        run: |
-          if [ "${{ needs.changes.result }}" != "success" ]; then
-            echo "::error::changes job failed (${{ needs.changes.result }})"
-            exit 1
-          fi
-          fail() { echo "::error::$1: $2"; exit 1; }
-          ok()   { echo "$1: $2 (OK)"; }
-          verify() {
-            case "$2" in success) ok "$1" "$2" ;; *) fail "$1" "$2" ;; esac
-          }
-          verify 'checks' '${{ needs.checks.result }}'
-          if [ "${{ needs.changes.outputs.publish }}" = "true" ]; then
-            verify 'build' '${{ needs.build.result }}'
-          else
-            echo 'publish gate: skipped — no publish-relevant changes (OK)'
-          fi
-          echo 'All CI jobs passed'
+      - uses: ./.github/actions/verify-gate
+        with:
+          changes-result: ${{ needs.changes.result }}
+          branch: ${{ needs.changes.outputs.publish }}
+          branch-label: publish-relevant changes
+          # Literal block: prettier leaves `|` content alone, so each pair
+          # stays on its own line and no ${{ }} expression is ever split.
+          # verify.sh splits the value on whitespace, newlines included.
+          results: |-
+            checks:${{ needs.checks.result }}
+            build:${{ needs.build.result }}
+          required: checks
+          always-report: build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -311,6 +311,8 @@ jobs:
     if: always()
     needs: [changes, snapshot, installer, helper, updater, browser-matrix]
     steps:
+      # Local action — a fresh runner needs the repo checked out first.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/verify-gate
         with:
           changes-result: ${{ needs.changes.result }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,9 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Required checks must also run on the merge-queue's temporary branch when
+  # a PR lands via the queue (Settings → merge queue) — see docs/DEVELOPING.md.
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -32,10 +35,10 @@ concurrency:
 
 jobs:
   # ── Changed-paths filter ──────────────────────────────────────────────────
-  # Docs-only / tooling-only PRs skip the installer + updater E2E jobs: nothing
-  # that builds or runs them changed. `snapshot` stays (browser-matrix needs
-  # it) and the always-running `e2e-gate` still reports, so the required check
-  # never goes missing. See docs/DEVELOPING.md → Continuous integration.
+  # Docs-only / tooling-only PRs skip every E2E job (snapshot, installer,
+  # helper, updater, browser-matrix): nothing that builds or runs them changed.
+  # Only `changes` and the always-running `e2e-gate` report, so the required
+  # check never goes missing. See docs/DEVELOPING.md → Continuous integration.
   changes:
     name: detect changed paths
     runs-on: ubuntu-latest
@@ -70,6 +73,8 @@ jobs:
   # flip the package hash and break the staleness check.
   snapshot:
     name: build dev snapshot
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: $/.github/actions/setup-repo
@@ -107,6 +112,8 @@ jobs:
   # ── Helper E2E (Linux elevated-copy core) ──────────────────────────────────
   helper:
     name: 'helper E2E · ${{ matrix.os }}'
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -294,45 +301,30 @@ jobs:
 
   # ── E2E gate ─────────────────────────────────────────────────────────────
   # Single branch-protection check. Every upstream job is a hard gate, so a
-  # green aggregate check cannot hide a failed, cancelled, or skipped matrix leg.
+  # green aggregate check cannot hide a failed, cancelled, or skipped matrix
+  # leg. The verify logic (required / advisory / skip-guard) lives in the
+  # shared .github/actions/verify-gate engine, kept consistent with ci-gate.
+  # `pnpm check:gates` enforces this needs list.
   e2e-gate:
     name: E2E gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [changes, installer, helper, updater, browser-matrix]
+    needs: [changes, snapshot, installer, helper, updater, browser-matrix]
     steps:
-      - name: Verify all E2E jobs
-        run: |
-          if [ "${{ needs.changes.result }}" != "success" ]; then
-            echo "::error::changes job failed (${{ needs.changes.result }})"
-            exit 1
-          fi
-          fail() { echo "::error::$1: $2"; exit 1; }
-          ok()   { echo "$1: $2 (OK)"; }
-          verify() {
-            case "$2" in success) ok "$1" "$2" ;; *) fail "$1" "$2" ;; esac
-          }
-          verify 'helper' '${{ needs.helper.result }}'
-          if [ "${{ needs.changes.outputs.e2e }}" = "true" ]; then
-            verify 'installer' '${{ needs.installer.result }}'
-            verify 'updater'   '${{ needs.updater.result }}'
-            # browser-matrix is ADVISORY (fork legs download from third-party
-            # hosts — librewolf.dev's package registry, Floorp's GitHub
-            # releases — which can hiccup; see docs/e2e-matrix-plan.md). Warn,
-            # don't fail the gate.
-            case "${{ needs.browser-matrix.result }}" in
-              success) ok 'browser-matrix' '${{ needs.browser-matrix.result }}' ;;
-              *) echo "::warning::browser-matrix ${{ needs.browser-matrix.result }} (advisory)" ;;
-            esac
-          else
-            echo 'installer + updater E2E: skipped — no E2E-relevant changes (OK)'
-            # Guard: if browser-matrix ran despite no E2E-relevant changes, its
-            # changed-paths gate was removed — fail loudly instead of silently
-            # burning ~14 Windows runner-minutes on every docs-only PR again.
-            if [ "${{ needs.browser-matrix.result }}" != "skipped" ]; then
-              echo "::error::browser-matrix ran despite no E2E-relevant changes — changed-paths gate removed?"
-              exit 1
-            fi
-            echo 'browser-matrix: skipped — no E2E-relevant changes (OK)'
-          fi
-          echo 'All E2E jobs passed'
+      - uses: ./.github/actions/verify-gate
+        with:
+          changes-result: ${{ needs.changes.result }}
+          branch: ${{ needs.changes.outputs.e2e }}
+          branch-label: E2E-relevant changes
+          # Literal block: prettier leaves `|` content alone, so each pair
+          # stays on its own line and no ${{ }} expression is ever split.
+          # verify.sh splits the value on whitespace, newlines included.
+          results: |-
+            snapshot:${{ needs.snapshot.result }}
+            installer:${{ needs.installer.result }}
+            helper:${{ needs.helper.result }}
+            updater:${{ needs.updater.result }}
+            browser-matrix:${{ needs.browser-matrix.result }}
+          required: snapshot installer helper updater
+          advisory: browser-matrix
+          skip-guard: snapshot installer helper updater browser-matrix

--- a/.github/workflows/url-watchdog.yml
+++ b/.github/workflows/url-watchdog.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     paths:
       - 'test/e2e/shared/downloads.mjs'
+  # The PR check is stateless + always green, so it can safely run on the
+  # merge queue too (a required check must report on merge_group).
+  merge_group:
   schedule:
     - cron: '0 6 * * 1' # Monday 06:00 UTC — browsers release ~monthly
   workflow_dispatch:
@@ -37,7 +40,7 @@ jobs:
   # ── Weekly: baseline + issues ─────────────────────────────────────────────
   check:
     name: check browser download URLs
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -75,7 +78,7 @@ jobs:
   # can be added to branch protection as a required check.
   pr-check:
     name: browser download URLs (PR)
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/url-watchdog.yml
+++ b/.github/workflows/url-watchdog.yml
@@ -51,12 +51,16 @@ jobs:
 
       # Baseline = last-seen version + size (+ one-time sha256 per release).
       # Weekly access keeps the 7-day cache TTL rolling; a missed run just
-      # re-baselines.
+      # re-baselines. Keys ROTATE per run (run_id): the cache service skips a
+      # save whose exact key already exists, so a fixed key would silently
+      # never persist the updated baseline after the first run. Restore falls
+      # back to the newest entry of the previous runs via the prefix.
       - name: Restore baseline
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .watchdog
-          key: url-watchdog-baseline-v1
+          key: url-watchdog-baseline-${{ github.run_id }}
+          restore-keys: url-watchdog-baseline-
 
       - name: Check browser downloads
         run: node tools/check-browser-downloads.mjs
@@ -64,12 +68,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       # save-always: the script rewrites baseline.json every run even when the
-      # restore step hit, so a version bump is persisted for the next run.
+      # restore step hit; the fresh key persists a version bump for the next
+      # run (immutable old entries just expire after 7 days).
       - name: Save baseline
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .watchdog
-          key: url-watchdog-baseline-v1
+          key: url-watchdog-baseline-${{ github.run_id }}
           save-always: true
 
   # ── PR: stateless rot check at review time ────────────────────────────────

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -291,17 +291,26 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
   surfaces findings as annotations. Run manually via `workflow_dispatch`, or locally with
   `node tools/check-browser-downloads.mjs --dry-run`.
 
-**PR path filtering** — the installer + updater E2E jobs (`.github/workflows/e2e.yml`) run only when
-a changed file can affect them (`core/**`, `config/installer.conf`, `installer/**`,
-`tools/publish/**`, `test/e2e/**`, `package.json`, `pnpm-lock.yaml`, the workflow/actions); the
-publish gate (`build` in `.github/workflows/ci.yml`) runs only when `core/**`,
-`config/installer.conf`, `installer/**`, `tools/publish/**`, `package.json`, `pnpm-lock.yaml`, or
-the workflow/actions changed. Docs-only / tooling-only PRs skip both, while `checks`, `ci-gate` and
-`e2e-gate` always run so the required checks keep reporting. The `browser-matrix` legs (Firefox Dev
-Edition, LibreWolf, Floorp, Zen — downloaded from third-party hosts: Mozilla's redirect,
-librewolf.dev's package registry, GitHub release assets) are gated on the same filter and are
-advisory when they run: failures warn in the gate instead of failing the PR. Waterfox has no direct
-download URL and stays manual (tracked by version only in the URL watchdog).
+**PR path filtering** — every E2E job (`.github/workflows/e2e.yml`: the `snapshot` build, the
+installer/updater matrices, the `helper` elevated-copy test, and the `browser-matrix` fork legs) and
+the publish gate (`build` in `.github/workflows/ci.yml`) run only when a changed file can affect
+them (`core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, `test/e2e/**`,
+`package.json`, `pnpm-lock.yaml`, the workflows/actions). Docs-only / tooling-only PRs skip all of
+them; `changes`, `checks`, `ci-gate` and `e2e-gate` always run, so the required checks keep
+reporting. The aggregate gates share one engine — `.github/actions/verify-gate` (required / advisory
+/ skip-guard / always-report checks) — and `pnpm check:gates` statically enforces the contract:
+every workflow job is listed in its gate's `needs:`, path-filter `if:`s stay in place, and
+always-report jobs carry no job-level `if:`. The `browser-matrix` legs (Firefox Dev Edition,
+LibreWolf, Floorp, Zen — downloaded from third-party hosts: Mozilla's redirect, librewolf.dev's
+package registry, GitHub release assets) are advisory when they run: failures warn in the gate
+instead of failing the PR. Waterfox has no direct download URL and stays manual (tracked by version
+only in the URL watchdog).
+
+**Merge queue** — the workflows trigger on `merge_group` in addition to `pull_request`, so the
+required checks also run on the merge queue's temporary branch. Enabling the queue (Settings →
+General → merge queue, with branch protection requiring it) lands PRs by rebasing their head onto
+main, which sidesteps the "Update branch" over-trigger caveat in ADR 0017 — main changes merged into
+the PR no longer count as PR changes for the path filters.
 
 Run the smoke test locally (Windows, from the repo root):
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -304,13 +304,13 @@ always-report jobs carry no job-level `if:`. The `browser-matrix` legs (Firefox 
 LibreWolf, Floorp, Zen — downloaded from third-party hosts: Mozilla's redirect, librewolf.dev's
 package registry, GitHub release assets) are advisory when they run: failures warn in the gate
 instead of failing the PR. Waterfox has no direct download URL and stays manual (tracked by version
-only in the URL watchdog).
-
-**Merge queue** — the workflows trigger on `merge_group` in addition to `pull_request`, so the
-required checks also run on the merge queue's temporary branch. Enabling the queue (Settings →
-General → merge queue, with branch protection requiring it) lands PRs by rebasing their head onto
-main, which sidesteps the "Update branch" over-trigger caveat in ADR 0017 — main changes merged into
-the PR no longer count as PR changes for the path filters.
+only in the URL watchdog).**Merge queue** — the workflows trigger on `merge_group` in addition to
+`pull_request`, so the required checks also run on the merge queue's temporary merge-group branch.
+Enabling the queue (Settings → General → merge queue, with branch protection requiring it) makes the
+queue keep each PR up to date with main and validate it before landing (the final merge uses the
+repo's configured merge method). Because the "Update branch" step is never used, the ADR 0017
+over-trigger caveat — main changes merged into a PR counting as PR changes for the path filters —
+does not arise for queued PRs.
 
 Run the smoke test locally (Windows, from the repo root):
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -304,7 +304,9 @@ always-report jobs carry no job-level `if:`. The `browser-matrix` legs (Firefox 
 LibreWolf, Floorp, Zen — downloaded from third-party hosts: Mozilla's redirect, librewolf.dev's
 package registry, GitHub release assets) are advisory when they run: failures warn in the gate
 instead of failing the PR. Waterfox has no direct download URL and stays manual (tracked by version
-only in the URL watchdog).**Merge queue** — the workflows trigger on `merge_group` in addition to
+only in the URL watchdog).
+
+**Merge queue** — the workflows trigger on `merge_group` in addition to
 `pull_request`, so the required checks also run on the merge queue's temporary merge-group branch.
 Enabling the queue (Settings → General → merge queue, with branch protection requiring it) makes the
 queue keep each PR up to date with main and validate it before landing (the final merge uses the

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -306,13 +306,13 @@ package registry, GitHub release assets) are advisory when they run: failures wa
 instead of failing the PR. Waterfox has no direct download URL and stays manual (tracked by version
 only in the URL watchdog).
 
-**Merge queue** — the workflows trigger on `merge_group` in addition to
-`pull_request`, so the required checks also run on the merge queue's temporary merge-group branch.
-Enabling the queue (Settings → General → merge queue, with branch protection requiring it) makes the
-queue keep each PR up to date with main and validate it before landing (the final merge uses the
-repo's configured merge method). Because the "Update branch" step is never used, the ADR 0017
-over-trigger caveat — main changes merged into a PR counting as PR changes for the path filters —
-does not arise for queued PRs.
+**Merge queue** — the workflows trigger on `merge_group` in addition to `pull_request`, so the
+required checks also run on the merge queue's temporary merge-group branch. Enabling the queue
+(Settings → General → merge queue, with branch protection requiring it) makes the queue keep each PR
+up to date with main and validate it before landing (the final merge uses the repo's configured
+merge method). Because the "Update branch" step is never used, the ADR 0017 over-trigger caveat —
+main changes merged into a PR counting as PR changes for the path filters — does not arise for
+queued PRs.
 
 Run the smoke test locally (Windows, from the repo root):
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -285,9 +285,11 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
   LibreWolf, Floorp, Zen; Waterfox tracked by version only) from its vendor API and verifies the
   download endpoint with a 1 KB ranged GET. Each new release is downloaded once, SHA-256'd and
   recorded in the per-release watchdog issue (`label:url-watchdog`) — the durable ledger. Opens
-  issues on rot (404, HTML error page, changed API shape) and same-version binary size changes. The
-  PR mode (`--pr`) is stateless, always green, and surfaces findings as annotations. Run manually
-  via `workflow_dispatch`, or locally with `node tools/check-browser-downloads.mjs --dry-run`.
+  issues on rot (404, HTML error page, changed API shape) and same-version binary size changes. Each
+  run logs the baseline's cache-hit status and age, so a silently evicted Actions cache is visible
+  instead of masquerading as a first run. The PR mode (`--pr`) is stateless, always green, and
+  surfaces findings as annotations. Run manually via `workflow_dispatch`, or locally with
+  `node tools/check-browser-downloads.mjs --dry-run`.
 
 **PR path filtering** — the installer + updater E2E jobs (`.github/workflows/e2e.yml`) run only when
 a changed file can affect them (`core/**`, `config/installer.conf`, `installer/**`,

--- a/docs/decisions/0017-ci-validation-contract.md
+++ b/docs/decisions/0017-ci-validation-contract.md
@@ -33,7 +33,8 @@ elevated-copy test joined the installer/updater/browser-matrix gates — and the
 share one verify engine (`.github/actions/verify-gate`) whose contract (every job in the gate's
 `needs:`, filters in place, always-report jobs ungated) is enforced statically by
 `pnpm check:gates`. The fork legs no longer act as an always-on canary for upstream fork releases
-breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PRcatches a breakage.
+breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PRcatches a
+breakage.
 
 PRs land via the GitHub merge queue: each queued PR is validated in a temporary merge-group
 

--- a/docs/decisions/0017-ci-validation-contract.md
+++ b/docs/decisions/0017-ci-validation-contract.md
@@ -34,9 +34,10 @@ share one verify engine (`.github/actions/verify-gate`) whose contract (every jo
 `needs:`, filters in place, always-report jobs ungated) is enforced statically by
 `pnpm check:gates`. The fork legs no longer act as an always-on canary for upstream fork releases
 breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PR catches a
-breakage. PRs land via the GitHub merge queue, which rebases heads onto main automatically; the
-earlier "Update branch" caveat (a PR updated from main over-runs the matrix once, because merged-in
-base changes count as PR changes for the path filter) no longer applies to queued PRs. The download
-map and watchdog are test harness, not product — they are noted as "Not recorded" in the index, not
-re-ADRed. Revisit-if: a fork host becomes reliable enough for hard gates, or a docs-only change
-needs the full E2E matrix.
+breakage.PRs land via the GitHub merge queue: each queued PR is validated in a temporary merge-group
+branch against the latest base (the final merge uses the repo's configured merge method), so the
+"Update branch" step is never used. The earlier caveat (a PR updated from main over-runs the matrix
+once, because merged-in base changes count as PR changes for the path filter) therefore no longer
+applies to queued PRs. The download map and watchdog are test harness, not product — they are noted
+as "Not recorded" in the index, not re-ADRed. Revisit-if: a fork host becomes reliable enough for
+hard gates, or a docs-only change needs the full E2E matrix.

--- a/docs/decisions/0017-ci-validation-contract.md
+++ b/docs/decisions/0017-ci-validation-contract.md
@@ -28,12 +28,15 @@ releases.
 
 Docs-only PRs get fast, green CI, and a flaky third-party host can no longer block a merge. Coverage
 gaps on docs-only PRs are accepted; any PR touching the download map runs the watchdog's PR check
-and the affected legs. The fork legs no longer act as an always-on canary for upstream fork releases
+and the affected legs. Every E2E job is path-filtered — the snapshot build and the helper
+elevated-copy test joined the installer/updater/browser-matrix gates — and the two aggregate gates
+share one verify engine (`.github/actions/verify-gate`) whose contract (every job in the gate's
+`needs:`, filters in place, always-report jobs ungated) is enforced statically by
+`pnpm check:gates`. The fork legs no longer act as an always-on canary for upstream fork releases
 breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PR catches a
-breakage. One caveat: a PR that branched before a gating change and is later updated from main (the
-"Update branch" button, required by strict branch protection) over-runs the full matrix once —
-GitHub's changed-files diff counts base-branch changes merged into the head, so the paths filter
-over-triggers. Rebase the PR onto main instead of merging it in to avoid the over-run; when it
-happens it is harmless (conservative direction). The download map and watchdog are test harness, not
-product — they are noted as "Not recorded" in the index, not re-ADRed. Revisit-if: a fork host
-becomes reliable enough for hard gates, or a docs-only change needs the full E2E matrix.
+breakage. PRs land via the GitHub merge queue, which rebases heads onto main automatically; the
+earlier "Update branch" caveat (a PR updated from main over-runs the matrix once, because merged-in
+base changes count as PR changes for the path filter) no longer applies to queued PRs. The download
+map and watchdog are test harness, not product — they are noted as "Not recorded" in the index, not
+re-ADRed. Revisit-if: a fork host becomes reliable enough for hard gates, or a docs-only change
+needs the full E2E matrix.

--- a/docs/decisions/0017-ci-validation-contract.md
+++ b/docs/decisions/0017-ci-validation-contract.md
@@ -33,8 +33,10 @@ elevated-copy test joined the installer/updater/browser-matrix gates — and the
 share one verify engine (`.github/actions/verify-gate`) whose contract (every job in the gate's
 `needs:`, filters in place, always-report jobs ungated) is enforced statically by
 `pnpm check:gates`. The fork legs no longer act as an always-on canary for upstream fork releases
-breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PR catches a
-breakage.PRs land via the GitHub merge queue: each queued PR is validated in a temporary merge-group
+breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PRcatches a breakage.
+
+PRs land via the GitHub merge queue: each queued PR is validated in a temporary merge-group
+
 branch against the latest base (the final merge uses the repo's configured merge method), so the
 "Update branch" step is never used. The earlier caveat (a PR updated from main over-runs the matrix
 once, because merged-in base changes count as PR changes for the path filter) therefore no longer

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format:fix": "node tools/format-c.mjs --write && prettier --config ./config/prettier.config.js --ignore-path ./config/.prettierignore . --write",
     "test": "node --test \"test/unit/**/*.test.mjs\"",
     "check:decisions": "node tools/check-decisions.mjs",
+    "check:gates": "node tools/check-gate-coverage.mjs",
     "test:hash": "node installer/test/test_hash.mjs && node installer/test/test_self_update.mjs",
     "test:e2e": "node test/e2e/shared/run.mjs",
     "test:e2e:installer": "node test/e2e/shared/run.mjs --installer",

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -12,9 +12,8 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-downloads.mjs')).href;
-const {compareBaseline, issueBody, issueTitle, parseContentRange, sha256File} = await import(
-  scriptUrl
-);
+const {compareBaseline, formatAge, issueBody, issueTitle, parseContentRange, sha256File} =
+  await import(scriptUrl);
 
 test('compareBaseline: first run, new version, unchanged', () => {
   assert.equal(compareBaseline(null, {version: '154.0.1'}), 'first-run');
@@ -52,6 +51,14 @@ test('issueBody: new-version body carries the verified SHA-256 ledger', () => {
   assert.match(body, /Watchdog run: https:\/\/github\.com/);
   assert.match(body, /New librewolf release: 154\.0-2 → 154\.0\.1-2/);
   assert.match(body, /Verified SHA-256 \(153225824 bytes\): `ec27c770aa/);
+});
+
+test('formatAge: human-readable baseline age, clamped at 0', () => {
+  assert.equal(formatAge(0), '0m');
+  assert.equal(formatAge(8 * 60_000), '8m');
+  assert.equal(formatAge(5 * 3_600_000 + 12 * 60_000), '5h 12m');
+  assert.equal(formatAge(3 * 86_400_000 + 2 * 3_600_000), '3d 2h');
+  assert.equal(formatAge(-5_000), '0m'); // clock skew → clamp, no negative
 });
 
 test('parseContentRange: total size or null', () => {

--- a/test/unit/tools/check-gate-coverage.test.mjs
+++ b/test/unit/tools/check-gate-coverage.test.mjs
@@ -37,10 +37,20 @@ jobs:
     if: always()
     needs: [changes, snapshot, installer]
     steps:
-      - run: echo ok
+      - uses: actions/checkout
+      - uses: ./.github/actions/verify-gate
+        with:
+          changes-result: \${{ needs.changes.result }}
+          branch: \${{ needs.changes.outputs.e2e }}
+          branch-label: E2E-relevant changes
+          results: |-
+            snapshot:\${{ needs.snapshot.result }}
+            installer:\${{ needs.installer.result }}
+          required: snapshot installer
+          skip-guard: snapshot installer
 `;
 
-test('parseJobs: collects job names, job-level needs + if, ignores step-level if', () => {
+test('parseJobs: collects job names, needs, ifs, and the verify-gate with block', () => {
   const jobs = parseJobs(FIXTURE);
   assert.deepEqual([...jobs.keys()], ['changes', 'snapshot', 'installer', 'e2e-gate']);
   // Step-level if (8-space) is NOT a job-level if.
@@ -49,6 +59,9 @@ test('parseJobs: collects job names, job-level needs + if, ignores step-level if
   assert.deepEqual(jobs.get('installer').needs, ['changes']);
   assert.deepEqual(jobs.get('e2e-gate').ifs, ['always()']);
   assert.deepEqual(jobs.get('e2e-gate').needs, ['changes', 'snapshot', 'installer']);
+  assert.deepEqual(jobs.get('e2e-gate').with.results, ['snapshot', 'installer']);
+  assert.equal(jobs.get('e2e-gate').with.required, 'snapshot installer');
+  assert.equal(jobs.get('e2e-gate').with['skip-guard'], 'snapshot installer');
 });
 
 test('checkWorkflow: a compliant workflow passes', () => {
@@ -116,4 +129,51 @@ test('checkWorkflow: gate without if: always() is flagged', () => {
     gated: ['snapshot', 'installer'],
   });
   assert.ok(errors.some(e => e.includes("must carry 'if: always()'")));
+});
+
+test('checkWorkflow: a needed job absent from verify-gate results is flagged', () => {
+  const broken = FIXTURE.replace('snapshot:${{ needs.snapshot.result }}\n', '');
+  const errors = checkWorkflow(broken, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.ok(
+    errors.some(e => e.includes("needs 'snapshot'") && e.includes('results do not include it'))
+  );
+});
+
+test('checkWorkflow: an unclassified results job is flagged', () => {
+  const broken = FIXTURE.replace(
+    'required: snapshot installer\n          skip-guard: snapshot installer',
+    'required: installer\n          skip-guard: installer'
+  );
+  const errors = checkWorkflow(broken, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.ok(
+    errors.some(e => e.includes("results include 'snapshot'") && e.includes('not classified'))
+  );
+});
+
+test('checkWorkflow: a classified job absent from results is flagged', () => {
+  const broken = FIXTURE.replace(
+    'skip-guard: snapshot installer',
+    'skip-guard: snapshot installer builder'
+  );
+  const errors = checkWorkflow(broken, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.ok(
+    errors.some(
+      e => e.includes("classifies 'builder'") && e.includes('not in the verify-gate results')
+    )
+  );
 });

--- a/test/unit/tools/check-gate-coverage.test.mjs
+++ b/test/unit/tools/check-gate-coverage.test.mjs
@@ -1,0 +1,119 @@
+// test/unit/tools/check-gate-coverage.test.mjs — Unit tests for the static
+// gate-contract checker (tools/check-gate-coverage.mjs). The real workflow
+// files are asserted by `pnpm check:gates` itself; these tests pin the parser
+// and the contract rules with fixtures.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-gate-coverage.mjs')).href;
+const {checkWorkflow, parseJobs} = await import(scriptUrl);
+
+const FIXTURE = `name: X
+on:
+  pull_request:
+jobs:
+  # ── filter ──
+  changes:
+    name: detect changed paths
+    outputs:
+      e2e: \${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout
+        if: runner.os == 'Windows'
+  snapshot:
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
+    runs-on: ubuntu-latest
+  installer:
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
+    runs-on: ubuntu-latest
+  e2e-gate:
+    name: E2E gate
+    if: always()
+    needs: [changes, snapshot, installer]
+    steps:
+      - run: echo ok
+`;
+
+test('parseJobs: collects job names, job-level needs + if, ignores step-level if', () => {
+  const jobs = parseJobs(FIXTURE);
+  assert.deepEqual([...jobs.keys()], ['changes', 'snapshot', 'installer', 'e2e-gate']);
+  // Step-level if (8-space) is NOT a job-level if.
+  assert.deepEqual(jobs.get('changes').ifs, []);
+  assert.deepEqual(jobs.get('installer').ifs, ["needs.changes.outputs.e2e == 'true'"]);
+  assert.deepEqual(jobs.get('installer').needs, ['changes']);
+  assert.deepEqual(jobs.get('e2e-gate').ifs, ['always()']);
+  assert.deepEqual(jobs.get('e2e-gate').needs, ['changes', 'snapshot', 'installer']);
+});
+
+test('checkWorkflow: a compliant workflow passes', () => {
+  const errors = checkWorkflow(FIXTURE, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.deepEqual(errors, []);
+});
+
+test('checkWorkflow: job missing from gate needs is flagged', () => {
+  const broken = FIXTURE.replace(
+    'needs: [changes, snapshot, installer]',
+    'needs: [changes, snapshot]'
+  );
+  const errors = checkWorkflow(broken, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.ok(errors.some(e => e.includes('installer') && e.includes('bypass the gate')));
+});
+
+test('checkWorkflow: a gated job that lost its filter if is flagged', () => {
+  const broken = FIXTURE.replace(
+    "  installer:\n    needs: changes\n    if: needs.changes.outputs.e2e == 'true'",
+    '  installer:\n    needs: changes'
+  );
+  const errors = checkWorkflow(broken, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.ok(
+    errors.some(e =>
+      e.includes("must carry the path-filter 'if: needs.changes.outputs.e2e == 'true''")
+    )
+  );
+});
+
+test('checkWorkflow: an always-report job must not gain a job-level if', () => {
+  const withIf = FIXTURE.replace(
+    '  snapshot:\n    needs: changes',
+    "  snapshot:\n    needs: changes\n    if: needs.changes.outputs.e2e == 'true'"
+  );
+  const errors = checkWorkflow(withIf, {
+    file: 'ci.yml',
+    gate: 'e2e-gate',
+    branchKey: 'publish',
+    noJobIf: ['snapshot'],
+  });
+  assert.ok(errors.some(e => e.includes('snapshot') && e.includes('always-report design')));
+});
+
+test('checkWorkflow: gate without if: always() is flagged', () => {
+  const broken = FIXTURE.replace('    if: always()\n', '');
+  const errors = checkWorkflow(broken, {
+    file: 'e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer'],
+  });
+  assert.ok(errors.some(e => e.includes("must carry 'if: always()'")));
+});

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -19,7 +19,9 @@
  *        downloads the installer once, hashes it and records {version, size,
  *        sha256} in the baseline (.watchdog/baseline.json, stored in the
  *        Actions cache). Same-version runs re-check only the 1 KB range, but
- *        flag a size change (binary replaced without a bump).
+ *        flag a size change (binary replaced without a bump). Each run logs the
+ *        baseline's cache-hit status and age, so a silently evicted cache is
+ *        visible instead of masquerading as a first run.
  *   4. ISSUES — new versions, rot, and same-version size changes open a GitHub
  *        issue, deduped per browser (the exact issue title is matched against
  *        open issues carrying the `url-watchdog` label). New-release issues
@@ -207,6 +209,19 @@ export function compareBaseline(prev, curr) {
 }
 
 /**
+ * Human-readable age from a millisecond span — e.g. '3d 2h', '5h 12m', '8m'.
+ * Exported for unit tests; clamped to 0 so clock skew never prints negative.
+ */
+export function formatAge(ms) {
+  const min = Math.max(0, Math.floor(ms / 60_000));
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h ${min % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}
+
+/**
  * The dedup key for an issue: exact-title match against open issues carrying
  * the url-watchdog label, so a re-run never duplicates an open finding.
  */
@@ -310,8 +325,19 @@ export async function main() {
   const baselineFile = path.join(baselineDir, 'baseline.json');
 
   let baseline = {};
-  if (!prMode && fs.existsSync(baselineFile)) {
+  const baselineFound = !prMode && fs.existsSync(baselineFile);
+  if (baselineFound) {
     baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf-8'));
+    // Cache-hit telemetry: an evicted/expired Actions cache would otherwise
+    // masquerade as a first run or a version bump. The cache restore preserves
+    // the file mtime, so age = time since the previous run wrote the baseline.
+    const stat = fs.statSync(baselineFile);
+    console.log(
+      `baseline: cache hit — written ${new Date(stat.mtimeMs).toISOString()} ` +
+        `(${formatAge(Date.now() - stat.mtimeMs)} ago)`
+    );
+  } else if (!prMode) {
+    console.log('baseline: cache miss — first run, re-baselining all browsers');
   }
 
   const findings = [];

--- a/tools/check-gate-coverage.mjs
+++ b/tools/check-gate-coverage.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+/**
+ * tools/check-gate-coverage.mjs — static contract for the aggregate gates.
+ *
+ * `e2e-gate` / `ci-gate` are the repo's single branch-protection checks, so a
+ * green aggregate check must cover every job. Two regressions are invisible to
+ * the runtime guards in .github/actions/verify-gate:
+ *
+ * 1. A NEW job added to a workflow is silently INVISIBLE to the gate unless it is
+ *    listed in the gate's `needs:`.
+ * 2. A path-filter `if:` removed from a gated job silently un-gates it (the
+ *    runtime skip-guard only fires on the NEXT docs-only PR).
+ *
+ * This script parses the two workflow files and asserts the contract:
+ *
+ * - needs-coverage: every job (except the gate itself) is in the gate's needs.
+ * - gated-if: jobs that must be path-filtered carry the filter's job-level `if:
+ *   needs.changes.outputs.<key> == 'true'`.
+ * - no-job-if: jobs that must always run/report (the publish gate's always-report
+ *   design) carry NO job-level `if:`.
+ * - gate-if: the gate job carries `if: always()`.
+ *
+ * Exit code 0 = contract holds. Run via `pnpm check:gates` (part of the
+ * `checks` CI job). The parser is deliberately small — the workflow files are
+ * ours and simple; YAML anchors or folded job definitions would need a real
+ * parser, and the gate engine (verify-gate) would need re-testing anyway.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const JOB_LINE = /^ {2}([A-Za-z0-9_-]+):\s*$/;
+const NEEDS_LINE = /^ {4}needs:\s*(.+)$/;
+const IF_LINE = /^ {4}if:\s*(.+)$/;
+
+/**
+ * Split a workflow YAML into per-job blocks. Only the top-level `jobs:` map is
+ * parsed; within a job block, job-level `needs:`/`if:` lines (4-space indent)
+ * are captured — step-level `if:`s live at deeper indents and are ignored.
+ *
+ * @param {string} text
+ * @returns {Map<string, {ifs: string[]; needs: string[]}>}
+ */
+export function parseJobs(text) {
+  const jobs = new Map();
+  let current = null;
+  let inJobs = false;
+  for (const line of text.split('\n')) {
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+    if (/^\S/.test(line)) break; // a top-level key after `jobs:`
+    const m = JOB_LINE.exec(line);
+    if (m) {
+      current = m[1];
+      jobs.set(current, {ifs: [], needs: []});
+      continue;
+    }
+    if (!current) continue;
+    const n = NEEDS_LINE.exec(line);
+    if (n) {
+      // Both forms appear in the workflows: 'needs: changes' and
+      // 'needs: [changes, snapshot]'.
+      const raw = n[1].trim();
+      jobs.get(current).needs =
+        raw.startsWith('[') ?
+          raw
+            .slice(1, -1)
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+        : [raw];
+      continue;
+    }
+    const f = IF_LINE.exec(line);
+    if (f) jobs.get(current).ifs.push(f[1]);
+  }
+  return jobs;
+}
+
+/**
+ * Assert the gate contract for one workflow. Returns a list of error strings
+ * (empty = contract holds).
+ *
+ * @param {string} text workflow YAML
+ * @param {{
+ *   file: string;
+ *   gate: string;
+ *   branchKey: string;
+ *   gated?: string[];
+ *   noJobIf?: string[];
+ * }} contract
+ * @returns {string[]}
+ */
+export function checkWorkflow(text, contract) {
+  const {file, gate, branchKey, gated = [], noJobIf = []} = contract;
+  const errors = [];
+  const jobs = parseJobs(text);
+  const gateJob = jobs.get(gate);
+  if (!gateJob) {
+    errors.push(`${file}: gate job '${gate}' not found`);
+    return errors;
+  }
+
+  for (const name of jobs.keys()) {
+    if (name === gate) continue;
+    if (!gateJob.needs.includes(name)) {
+      errors.push(
+        `${file}: job '${name}' is not in ${gate}'s needs — it would bypass the gate silently`
+      );
+    }
+  }
+  for (const name of gateJob.needs) {
+    if (!jobs.has(name)) {
+      errors.push(`${file}: ${gate} needs unknown job '${name}'`);
+    }
+  }
+
+  const expectIf = `needs.changes.outputs.${branchKey} == 'true'`;
+  for (const name of gated) {
+    const job = jobs.get(name);
+    if (!job) {
+      errors.push(`${file}: gated job '${name}' not found`);
+      continue;
+    }
+    if (!job.ifs.includes(expectIf)) {
+      errors.push(`${file}: '${name}' must carry the path-filter 'if: ${expectIf}'`);
+    }
+  }
+  for (const name of noJobIf) {
+    const job = jobs.get(name);
+    if (!job) {
+      errors.push(`${file}: job '${name}' not found (noJobIf)`);
+      continue;
+    }
+    if (job.ifs.length > 0) {
+      errors.push(
+        `${file}: '${name}' must have NO job-level if (always-report design), found: ${job.ifs.join(', ')}`
+      );
+    }
+  }
+  if (!gateJob.ifs.includes('always()')) {
+    errors.push(`${file}: gate '${gate}' must carry 'if: always()'`);
+  }
+  return errors;
+}
+
+const CONTRACTS = [
+  {
+    file: '.github/workflows/e2e.yml',
+    gate: 'e2e-gate',
+    branchKey: 'e2e',
+    gated: ['snapshot', 'installer', 'helper', 'updater', 'browser-matrix'],
+  },
+  {
+    file: '.github/workflows/ci.yml',
+    gate: 'ci-gate',
+    branchKey: 'publish',
+    noJobIf: ['build'], // always-report design — heavy steps gated, job always runs
+  },
+];
+
+export function main() {
+  const errors = [];
+  for (const contract of CONTRACTS) {
+    const text = fs.readFileSync(path.join(REPO_ROOT, contract.file), 'utf-8');
+    errors.push(...checkWorkflow(text, contract));
+  }
+  if (errors.length > 0) {
+    for (const e of errors) console.error(`✗ ${e}`);
+    console.error(`\nGate contracts violated (${errors.length}).`);
+    process.exit(1);
+  }
+  const jobCount = CONTRACTS.map(c => {
+    const jobs = parseJobs(fs.readFileSync(path.join(REPO_ROOT, c.file), 'utf-8'));
+    return `${c.file}: ${jobs.size} jobs, gate covers all`;
+  }).join('\n  ');
+  console.log(`✓ Gate contracts hold\n  ${jobCount}`);
+}
+
+const isMain = process.argv[1] && path.basename(process.argv[1]) === 'check-gate-coverage.mjs';
+if (isMain) {
+  main();
+}

--- a/tools/check-gate-coverage.mjs
+++ b/tools/check-gate-coverage.mjs
@@ -36,19 +36,28 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
 const JOB_LINE = /^ {2}([A-Za-z0-9_-]+):\s*$/;
 const NEEDS_LINE = /^ {4}needs:\s*(.+)$/;
 const IF_LINE = /^ {4}if:\s*(.+)$/;
+const WITH_LINE = /^ {8}with:\s*$/;
+const WITH_INPUT = /^ {10}([A-Za-z0-9_-]+):\s*(.*)$/;
+const RESULTS_PAIR = /^ {12}([A-Za-z0-9_-]+):/;
 
 /**
  * Split a workflow YAML into per-job blocks. Only the top-level `jobs:` map is
  * parsed; within a job block, job-level `needs:`/`if:` lines (4-space indent)
- * are captured — step-level `if:`s live at deeper indents and are ignored.
+ * are captured — step-level `if:`s live at deeper indents and are ignored. The
+ * verify-gate `with:` block (10-space inputs, 12-space `results:` pairs) is
+ * captured per job for the wiring assertions.
  *
  * @param {string} text
- * @returns {Map<string, {ifs: string[]; needs: string[]}>}
+ * @returns {Map<
+ *   string,
+ *   {ifs: string[]; needs: string[]; with: Object<string, any>}
+ * >}
  */
 export function parseJobs(text) {
   const jobs = new Map();
   let current = null;
   let inJobs = false;
+  let withKey = null;
   for (const line of text.split('\n')) {
     if (/^jobs:\s*$/.test(line)) {
       inJobs = true;
@@ -56,13 +65,43 @@ export function parseJobs(text) {
     }
     if (!inJobs) continue;
     if (/^\S/.test(line)) break; // a top-level key after `jobs:`
+
+    // Inside a `with:` block: 12-space `results:` pairs, 10-space inputs, or
+    // an outdent that ends the block.
+    if (withKey !== null) {
+      const rl = RESULTS_PAIR.exec(line);
+      if (rl && withKey === 'results') {
+        jobs.get(current).with.results.push(rl[1]);
+        continue;
+      }
+      const wi = WITH_INPUT.exec(line);
+      if (wi) {
+        withKey = wi[1] === 'results' ? 'results' : wi[1];
+        if (withKey === 'results') jobs.get(current).with.results = [];
+        else jobs.get(current).with[wi[1]] = wi[2].trim();
+        continue;
+      }
+      withKey = null; // left the with block
+    }
+
     const m = JOB_LINE.exec(line);
     if (m) {
       current = m[1];
-      jobs.set(current, {ifs: [], needs: []});
+      jobs.set(current, {ifs: [], needs: [], with: {}});
       continue;
     }
     if (!current) continue;
+    if (WITH_LINE.test(line)) {
+      withKey = '__with__';
+      continue;
+    }
+    const wi = WITH_INPUT.exec(line);
+    if (wi) {
+      withKey = wi[1] === 'results' ? 'results' : wi[1];
+      if (withKey === 'results') jobs.get(current).with.results = [];
+      else jobs.get(current).with[wi[1]] = wi[2].trim();
+      continue;
+    }
     const n = NEEDS_LINE.exec(line);
     if (n) {
       // Both forms appear in the workflows: 'needs: changes' and
@@ -147,6 +186,42 @@ export function checkWorkflow(text, contract) {
   }
   if (!gateJob.ifs.includes('always()')) {
     errors.push(`${file}: gate '${gate}' must carry 'if: always()'`);
+  }
+
+  // verify-gate `with:` wiring: every needed job (except `changes`, which is
+  // verified through changes-result) must be in `results:`, every `results`
+  // job must be classified in one of the branch inputs, and every classified
+  // job must be in `results:`. A needed job absent from results would run
+  // verify.sh's lookup with 'missing' — wrong behavior surfaced only at
+  // runtime, so pin it statically.
+  const w = gateJob.with;
+  const splitList = v =>
+    typeof v === 'string' && v.trim() ? v.trim().split(/\s+/).filter(Boolean) : [];
+  const results = w.results || [];
+  const classified = [
+    ...splitList(w.required),
+    ...splitList(w.advisory),
+    ...splitList(w['skip-guard']),
+    ...splitList(w['always-report']),
+    ...splitList(w['always-verify']),
+  ];
+  for (const name of gateJob.needs) {
+    if (name === 'changes') continue;
+    if (!results.includes(name)) {
+      errors.push(`${file}: ${gate} needs '${name}' but its verify-gate results do not include it`);
+    }
+  }
+  for (const name of results) {
+    if (!classified.includes(name)) {
+      errors.push(
+        `${file}: ${gate} results include '${name}' but it is not classified (required/advisory/skip-guard/always-report/always-verify)`
+      );
+    }
+  }
+  for (const name of classified) {
+    if (!results.includes(name)) {
+      errors.push(`${file}: ${gate} classifies '${name}' but it is not in the verify-gate results`);
+    }
   }
   return errors;
 }


### PR DESCRIPTION
One PR for the whole CI-hardening batch — supersedes #67, #68 and #69 (closed). Since every change touches workflow files, the path filter runs the full matrix on the PR itself, so the new gate wiring validates itself live.

## What's in it

**Shared gate engine** — `.github/actions/verify-gate` (composite action + `verify.sh`) replaces the duplicated inline shell in `ci-gate` / `e2e-gate`: required / advisory / skip-guard / always-report checks. The skip-guard now covers **every** gated E2E job (a removed path-filter `if:` fails the next docs-only PR, naming the job); the always-report guard preserves the publish-gate design (a reintroduced job-level `if:` fails instead of re-breaking strict branch protection).

**Full path filtering** — snapshot (dev-snapshot build) and helper (elevated-copy) joined installer/updater/browser-matrix: docs-only PRs now skip **all** E2E jobs, not just the big ones.

**Static contract** — `pnpm check:gates` (wired into the `checks` job) asserts: every workflow job is in its gate's `needs:`, path-filter `if:`s are in place, always-report jobs carry no job-level `if:`, gates carry `if: always()`. A new job can no longer silently bypass the gate. 6 unit tests pin the parser + rules.

**Merge queue readiness** — `merge_group` triggers on ci/e2e/url-watchdog so required checks run on the queue's temporary branch. Enabling the queue in repo settings (Settings → General → merge queue; branch protection requiring it) lands PRs by rebasing heads onto main, sidestepping the update-branch over-trigger documented in ADR 0017.

**Watchdog telemetry** — each weekly run logs `baseline: cache hit — written <ts> (<age> ago)` or `baseline: cache miss — first run`, so a silently evicted baseline cache is visible.

ADR 0017 + DEVELOPING.md updated to match.

## Validation

- `verify.sh` engine simulated live across 8 scenarios (legit ×2 per gate, advisory, each guard firing, changes-failure) — plus newline-separated results from the literal-block `results:` input.
- `pnpm test`: 114 pass / 0 fail; `pnpm check:gates` ✓; `pnpm check:decisions` ✓; `pnpm format` ✓; `pnpm lint` ✓.

## Settings to flip (after merge)

1. Settings → General → **merge queue**: enabled.
2. Branch protection: require the merge queue; keep the required checks as-is (CI gate, E2E gate, … — they already report on `merge_group`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI, E2E, and URL monitoring now support merge-queue validation.
  * E2E checks are selectively skipped for documentation- and tooling-only changes.
  * Added automated validation for workflow gate coverage and reporting.
  * Browser-download checks now display cache age and status.

* **Bug Fixes**
  * Improved handling of missing or outdated browser-download baselines.
  * Corrected human-readable duration formatting, including clock-skew values.

* **Documentation**
  * Updated CI guidance and validation decision records for merge queues, path filtering, and advisory checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->