### PR TITLE
docs(decisions): installer UI stays a tab; release versioning (0018, 0019)

### DIFF
--- a/docs/decisions/0018-installer-ui-browser-tab.md
+++ b/docs/decisions/0018-installer-ui-browser-tab.md
@@ -1,0 +1,34 @@
+# 0018: Installer UI stays an embedded browser tab (no desktop app)
+
+- **Status:** accepted
+- **Date:** 2026-08-27
+
+## Context
+
+The installer serves an embedded web UI over `http://127.0.0.1:8777` and opens it in the detected
+browser's tab. A recurring proposal is to render that UI as a native desktop application instead.
+The tab model exists because of earlier decisions: the C binary performs **zero network I/O** — the
+tab fetches every payload from CORS-enabled hosts and POSTs the bytes back
+([0005](./0005-installer-zero-network-io.md)) — and the local API is gated by a per-run session
+token ([0010](./0010-session-token-no-cors.md)). The tab also shares its stylesheet with the updater
+tab (`updater.css` is generated from `installer/web/style.css` at publish time, [0008]).
+
+## Decision
+
+The installer UI remains an **embedded browser tab** served by the C binary's local HTTP server. We
+will not build a native desktop / webview app.
+
+## Consequences
+
+One HTML/JS/CSS UI works on every OS; a desktop app would need three native stacks or three webview
+embeddings (WebView2, webkit2gtk, WKWebView), each with its own build, packaging and runtime
+dependencies — more code and a larger test matrix, not less. It also preserves the security posture
+of [0005]: C stays a small static binary with no HTTP client / TLS / JSON parser, whereas a webview
+shell would reintroduce a network-capable runtime and the CORS-equivalent trust decisions that 0005
+deliberately avoided. Testability stays with the existing harness: the tab is driven by the
+Puppeteer-BiDi installer E2E ([#36](https://github.com/onemen/firefox-scripts/issues/36)), while
+native/webview shells are notoriously hard to automate cross-platform. Costs that remain: the UI
+depends on a running browser, must survive the restart flow
+([0014](./0014-restart-session-restore.md)), and stale-tab handling on the fixed port stays in
+scope. Revisit-if: an embeddable sandboxed webview becomes a dependency-free standard on all three
+OSes, or the installer must work with no browser installed.

--- a/docs/decisions/0019-release-versioning.md
+++ b/docs/decisions/0019-release-versioning.md
@@ -1,0 +1,35 @@
+# 0019: Release versioning — stable artifact names, date-stamped component tags, moving `latest`
+
+- **Status:** accepted
+- **Date:** 2026-08-27
+
+## Context
+
+Publishing currently uploads everything to one `latest` release (`RELEASE_NAME` in
+`config/installer.conf`). The updater and the installer tab fetch artifacts by **fixed names** from
+`releases/download/latest/...` (`utils.zip`, `fx-folder.zip`, `updater-ui.zip`, `installer_<os>`,
+`helper_<os>` — baked into `updater-config.sys.mjs`, [0013]) so artifact names must never change per
+version. Users asked for: no versioned zip names (`utils-1.0.1.zip` would break the updater URLs and
+unzip into a `utils-1.0.1/` folder), no "new version" signal when only the installer changed, and a
+version that communicates freshness without pretending every package changed.
+
+## Decision
+
+- Artifact names are **permanent and unversioned**: `utils.zip`, `fx-folder.zip`, `updater-ui.zip`,
+  `installer_win.exe` / `installer_mac` / `installer_linux`, `helper_<os>`.
+- Releases are tagged **per component + date**: `scripts-<YYYY-MM-DD>` (the zips) and
+  `installer-<YYYY-MM-DD>` (installer + helper binaries). A component release is created only when
+  that component changed.
+- `latest` (existing moving tag) always carries the **complete asset set** and stays GitHub's
+  "Latest"; component releases are created with `make_latest=false`. README, docs and the updater
+  point only at `latest` — never at versioned URLs.
+
+## Consequences
+
+A new installer never re-publishes unchanged zips: no re-upload, no hash churn, no user confusion.
+Humans read the date tags; machines keep reading `hashes.json` ([0002]) — the date is a lookup aid,
+not an update mechanism. The stable `latest` URL keeps the updater/README links constant. Added
+cost: publishing stamps two extra tags per release — the pipeline work belongs in publish automation
+[#33](https://github.com/onemen/firefox-scripts/issues/33) under the v1.0 gate (the `latest`-tag
+move already ships, P0-1/#40). Revisit-if: users need semantic version comparisons — only then add
+semver aliases on top, never rename artifacts.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -66,6 +66,10 @@ Open these before proposing a new primitive, surface, or storage home.
   `content userchromejs`
 - [0017](./0017-ci-validation-contract.md) — CI validation contract: path-filtered gates, advisory
   fork legs, download map as source of truth
+- [0018](./0018-installer-ui-browser-tab.md) — Installer UI stays an embedded browser tab; no
+  desktop/webview app
+- [0019](./0019-release-versioning.md) — Stable unversioned artifact names + date-stamped component
+  tags + moving `latest`
 
 ## Historical
 


### PR DESCRIPTION
Two decision records for the v1.0 gate:

- **[ADR 0018](./docs/decisions/0018-installer-ui-browser-tab.md)** — the installer UI stays an embedded browser tab served by the C binary's local HTTP server. No native/webview desktop app: three native stacks or three webview embeddings (WebView2 / webkit2gtk / WKWebView) would be more code and a bigger test matrix, not less; it preserves ADR 0005's zero-network-I/O posture and stays automatable by the Puppeteer-BiDi harness (issue #36).
- **[ADR 0019](./docs/decisions/0019-release-versioning.md)** — release versioning: artifact names stay permanent and unversioned (`utils.zip`, `fx-folder.zip`, `updater-ui.zip`, `installer_<os>`, `helper_<os>` — the updater fetches by fixed names from `releases/download/latest/...`); per-component date-stamped tags (`scripts-<date>` / `installer-<date>`) created only when that component changed, `make_latest=false`; `latest` keeps the complete asset set and stays the only URL anything points at.

Part of #4 (release gate); #33 (publish automation — pipeline work tracked separately); #36 (installer UI E2E surface unchanged). Docs-only.