### PR TITLE
docs: interactive RDP debugging of core files (debugging-firefox skill vendored)

### DIFF
--- a/.agent/skills/debugging-firefox/LICENSE
+++ b/.agent/skills/debugging-firefox/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 117649
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agent/skills/debugging-firefox/SKILL.md
+++ b/.agent/skills/debugging-firefox/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: debugging-firefox
+description: Use when inspecting Firefox browser chrome or add-on runtime behavior, working with classic DevTools RDP or --start-debugger-server, installing or reloading an XPI without restart, or proving a live Firefox regression in an existing profile.
+license: MIT
+compatibility: Requires Node.js 22+ and desktop Firefox exposing classic DevTools RDP browser-chrome actors. Executable path and loopback port are caller-selectable.
+---
+
+# Debugging Firefox
+
+## Core principle
+
+Treat the live Firefox session as user data. Use one task-owned loopback RDP socket and restore every task-owned change.
+
+## Target and ownership
+
+An explicitly supplied executable overrides discovery. Resolve that exact file, preserve spaces and non-ASCII characters with argument arrays, identify its reported version when safe, and never substitute another installation. If no path is supplied, discover without hardcoded locations across desktop Release, ESR, Beta, Developer Edition, Nightly, custom, portable/extracted, and side-by-side installations.
+
+On macOS require the Firefox binary inside the application bundle; on Windows and Linux accept the caller-selected executable or launcher. A supplied path does not authorize launch; launch only when a debugger listener is needed and ownership permits.
+
+Use `127.0.0.1` and the caller-selected port. Before launch, detect handoff to a different running instance and profile locks. Stop rather than adding `--no-remote`, creating/selecting a profile, or changing channels.
+
+Allow one mutation owner per instance and one live task-owned socket at a time. Other tasks may use read-only sockets; mutation requires handoff. At contention, report the exact retained executable, open no competing mutation socket, and state restart requires ownership release plus separate approval.
+
+## Workflow
+
+1. Capture the baseline: target identity, browser state, ownership, and privacy-minimized restoration invariants.
+2. Before any operation, connect once with [scripts/firefox-rdp.mjs](scripts/firefox-rdp.mjs). Require root greeting, `listProcesses`, parent descriptor, `getTarget`, console actor, and `evaluateJSAsync`; timeout/transport failure takes the restart rule; explicit unsupported stops; never retry that listener.
+3. Read [references/live-testing.md](references/live-testing.md) before mutation, behavior proof, or restart. Install/reload claims require install/readiness and restoration; behavior claims require an exercised user-facing/native path. Otherwise mark behavior unverified and continue install-only work.
+4. After dispatch, a timeout invalidates the socket; one authorized sequential replacement may only query task-owned authoritative state once before deciding whether retry is safe.
+5. In `finally`, restore only task-owned changes; compare captured restoration invariants with the baseline; close the client; report retained Firefox listeners/processes.
+
+An unhealthy preflight permits one pre-authorized restart with baseline and released ownership. Discard protocol state; rediscover and rerun preflight once. A second unhealthy result or explicit unsupported response stops.
+
+## Quick reference
+
+| Need | Gate |
+|---|---|
+| Target | Exact file, or fallback discovery |
+| Mutation | Explicit owner or handoff |
+| Readiness | Bounded predicate; authoritative check after timeout |
+| Proof | Actual path plus restoration |
+
+## Common mistakes
+
+Do not keep concurrent task-owned sockets, replay a timed-out mutation, restart without separate approval, or use `gBrowser.adoptTab()` as native-drag proof.
+
+## Boundary
+
+Ordinary webpages use normal browser automation. Never terminate pre-existing Firefox or remove a requested add-on.
+
+Run offline tests before live use:
+
+```text
+node scripts/firefox-rdp.test.mjs
+```

--- a/.agent/skills/debugging-firefox/references/live-testing.md
+++ b/.agent/skills/debugging-firefox/references/live-testing.md
@@ -1,0 +1,92 @@
+# Live Firefox test contract
+
+Read this before installing or reloading an XPI, changing live browser state, or taking the restart branch. Scale assertions to the requested behavior; do not turn a focused regression into a compatibility suite.
+
+## Evidence ladder
+
+Keep each claim at its highest completed level:
+
+1. **Static:** source inspection and syntax checks.
+2. **Package:** the exact XPI contains the intended files and metadata.
+3. **Protocol:** framing, actor discovery, request correlation, and capability probes succeed.
+4. **Install/readiness:** the intended add-on version is active in the target process and feature-specific readiness succeeds.
+5. **Behavior:** the actual user-facing or native runtime path produces the expected result.
+6. **Restoration:** task-owned state is removed and the shared session matches its baseline.
+
+## Resolve the target before connecting
+
+Target identity comprises the resolved executable; reported product, version, or build identifier when available; detected platform; PID and start time; caller-selected loopback port; profile identity; and a stable browser-instance sentinel.
+
+An explicitly supplied executable overrides discovery. Validate it as the exact file and preserve it through argument arrays. A directory, missing file, substituted binary, channel mismatch, unsafe handoff to a different existing Firefox instance, or locked profile blocks launch. Do not silently add isolation flags, create/select a profile, or choose another channel. Discovery is only a fallback when no executable was supplied.
+
+Record whether Firefox and the listener predated the task and whether this task launched either. Do not launch merely to inspect a supplied path. Connect only to `127.0.0.1` at the caller-selected port.
+
+## Ownership and baseline
+
+- Establish one explicit mutation owner for the Firefox instance. Other tasks remain read-only and use separate sockets, or close their clients and explicitly hand off mutation ownership. If coordination is unavailable or target identity is uncertain, stop before mutation.
+- Use one live task-owned socket at a time. Do not share it across tasks or reconnect per evaluation. After invalidation or restart, dispose the old client before the single authorized sequential replacement.
+- Capture opaque window/tab order and selection, feature state, listener/process ownership, add-on state, and only the URLs/titles needed as evidence. Choose restoration invariants before mutation.
+- Keep task-operation sentinels and live identities, including original method references, in a uniquely named property on a stable browser window. Keep only serializable restoration invariants in the client.
+- For browser-managed groups or containers, retain group identity and neighboring anchors. Treat a global native index as diagnostic unless the requested behavior owns it.
+
+## Capability gate
+
+Begin with a small read-only probe using the tested client. Record the root greeting, traits, and actor forms. The supported parent-process path requires:
+
+1. `listProcesses` on the root actor;
+2. a parent-process descriptor;
+3. `getTarget` on that descriptor;
+4. a console actor on the target; and
+5. `evaluateJSAsync` on the console actor.
+
+If any part is missing, return `unsupported` with the exact missing capability and detected target identity. Do not guess alternate actors, packets, or privileged globals. Probe every version-sensitive API needed by the planned matrix before mutation.
+
+This gate is the listener preflight and runs before any task operation. Connection refusal/reset, a malformed or missing greeting, or timeout/transport failure in a mandatory capability marks the listener unhealthy. Dispose that client. With prior restart authorization, a complete baseline, and exclusive ownership, take the restart checkpoint immediately instead of opening a replacement socket to the same listener. Without those prerequisites, stop before the task call. Rerun the full gate once on the replacement instance; another unhealthy result stops without a task operation or second restart. Treat an explicit unsupported-capability response as incompatibility, not listener failure.
+
+## Same-process XPI install and readiness
+
+Validate the exact XPI path, contents, expected add-on ID, and version first. Through the same parent-process connection, import `AddonManager`, construct an `nsIFile`, pass the native path serialized with `JSON.stringify(xpiPath)` to `initWithPath()`, and call `AddonManager.getInstallForFile(file)`. Capture candidate state/error before and after `install.install()`, then query the expected add-on ID, version, active/disabled flags, and restart requirement. Observed numeric states are run evidence, not cross-version constants.
+
+Start asynchronous work behind the browser-window sentinel. Poll a small serialized status object with bounded `evaluateJson` or `pollJson` calls; raw RDP values may be protocol grips. Readiness is feature-owned: assert the predicate for every affected pre-existing window or frame. A navigation `tabNavigated` event with `state: "stop"` proves navigation completion, not application or network idle.
+
+A timeout invalidates the socket but does not cancel dispatched Firefox-side work and never authorizes replay. Dispose the invalidated client, then create one authorized sequential replacement only to query the task-owned sentinel or authoritative add-on state once. Resume without replay if the operation succeeded. One retry is safe only when the operation is absent, conclusively failed without effects, or fully restored; otherwise stop and report the last state.
+
+If an active same-version install still serves old chrome/resource bytes, do not bump the version or repeat installation as a cache workaround. Take the restart branch only with separate authorization; otherwise label the cache-sensitive behavior unverified.
+
+## Real-path regression design
+
+Test the earliest native path that reproduces the failure. Until the first divergent call or error is observed, the cause is **unlocalized**. A passing downstream shortcut narrows the boundary but is not the acceptance test.
+
+For a native cross-window tab-drag regression:
+
+1. Create one uniquely identifiable disposable tab.
+2. Trace the native drag/drop handler with temporary in-memory hooks.
+3. Perform drag-out, then return the replacement tab created by adoption.
+4. Assert destination group identity, selection, contiguous native `_tPos` order, and no thrown errors or duplicate tabs.
+5. Remove only the disposable tab/window and tracing.
+
+Direct `gBrowser.adoptTab()` bypasses the native drop handler and cannot prove this regression.
+
+## Restart checkpoint
+
+Restart only for a pre-authorized unhealthy listener preflight or after restartless operation is shown insufficient and the user separately approves it. Capture the executable/profile, original instance sentinel, PID/process tree, listener, serializable session invariants, relevant add-on state, and task-owned resources. Require every other known task to release mutation ownership and close its client; uncertain release blocks restart.
+
+Request an ordinary quit through the sole authorized control path. Socket closure is expected: dispose the old client and wait to the diagnostic deadline without killing a shared or pre-existing process. Relaunch the same executable and profile without adding isolation flags. Detect the replacement PID, expose the caller-approved loopback listener, create one new client, rediscover capabilities, and capture a new sentinel and actor set. Old actors, sentinels, sockets, and snapshots are invalid.
+
+Wait for feature readiness and authoritative session restoration, repeat the intended real-path behavior, then compare the captured invariants. Recreate a task-owned captured page once only if absent after restoration completes; do not reorder unrelated tabs. Record what was restored and every remaining difference.
+
+## Cleanup matrix
+
+| Initial ownership | Required end state |
+|---|---|
+| Firefox and listener pre-existed | Close only this task's client; leave both running. |
+| Task started listener on pre-existing Firefox | Close the client; leave Firefox running and report that the listener persists until Firefox exits. |
+| Task launched dedicated Firefox | Close the client, terminate only the recorded owned process tree, and verify its listener stopped. |
+
+In `finally`, restore task-owned globals, wrapped methods, preferences, tabs/groups, window selection/focus, and feature layout. Do not uninstall an add-on the user asked to install or update, and never clean up another task's resources.
+
+## Result contract
+
+Report the resolved executable, reported product and version/build, and detected platform; PID/start time; opaque/redacted profile identity and instance sentinel; port and ownership; capability path; XPI identity; install state/error; per-window readiness; actual-path assertions; restoration comparison; client closure; and any listener/process left running.
+
+Name the highest evidence level reached. Label **static inference**, **live observation**, and **unverified compatibility** separately. A build or package check does not prove live Firefox behavior; a completed install does not prove readiness or the real path; blocked or skipped checks remain unverified.

--- a/.agent/skills/debugging-firefox/scripts/firefox-rdp.mjs
+++ b/.agent/skills/debugging-firefox/scripts/firefox-rdp.mjs
@@ -1,0 +1,209 @@
+import net from "node:net";
+
+function validateTimeout(timeoutMs) {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 2147483647) {
+    throw new TypeError("Firefox RDP timeoutMs must be an integer from 1 to 2147483647");
+  }
+}
+
+export function encodePacket(packet) {
+  const json = JSON.stringify(packet);
+  return Buffer.from(`${Buffer.byteLength(json)}:${json}`, "utf8");
+}
+
+export function createPacketDecoder(onPacket) {
+  let buffer = Buffer.alloc(0);
+  return chunk => {
+    buffer = Buffer.concat([buffer, chunk]);
+    for (;;) {
+      const colon = buffer.indexOf(58);
+      if (colon < 0 && buffer.length < 200) return;
+      if (colon < 0 || colon >= 200) throw new Error("Invalid RDP frame header");
+      const prefix = buffer.subarray(0, colon).toString("ascii");
+      if (!/^(0|[1-9]\d*)$/.test(prefix)) throw new Error(`Invalid RDP frame length: ${prefix}`);
+      const length = Number(prefix);
+      if (!Number.isSafeInteger(length) || length > 2 ** 40) {
+        throw new Error(`Invalid RDP frame length: ${prefix}`);
+      }
+      const end = colon + 1 + length;
+      if (buffer.length < end) return;
+      onPacket(JSON.parse(buffer.subarray(colon + 1, end).toString("utf8")));
+      buffer = buffer.subarray(end);
+    }
+  };
+}
+
+export class FirefoxRdpClient {
+  constructor({ host = "127.0.0.1", port, localPort, timeoutMs = 30000 } = {}) {
+    if (host !== "127.0.0.1") throw new TypeError("Firefox RDP client only accepts 127.0.0.1");
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new TypeError("Firefox RDP port must be an integer from 1 to 65535");
+    }
+    validateTimeout(timeoutMs);
+    if (localPort !== undefined &&
+        (!Number.isInteger(localPort) || localPort < 0 || localPort > 65535)) {
+      throw new TypeError("Firefox RDP localPort must be an integer from 0 to 65535");
+    }
+    Object.assign(this, { host, port, localPort, timeoutMs });
+    this.packets = [];
+    this.waiters = [];
+    this.terminalError = null;
+    this.evaluationTail = Promise.resolve();
+  }
+
+  deliver(packet) {
+    const index = this.waiters.findIndex(waiter => waiter.predicate(packet));
+    if (index < 0) return this.packets.push(packet);
+    const [waiter] = this.waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+    waiter.resolve(packet);
+  }
+
+  next(predicate, timeoutMs = this.timeoutMs, label = "RDP packet") {
+    validateTimeout(timeoutMs);
+    if (this.terminalError) return Promise.reject(this.terminalError);
+    const index = this.packets.findIndex(predicate);
+    if (index >= 0) return Promise.resolve(this.packets.splice(index, 1)[0]);
+    return new Promise((resolve, reject) => {
+      const waiter = { predicate, resolve, reject };
+      waiter.timer = setTimeout(() => {
+        const pending = this.waiters.indexOf(waiter);
+        if (pending >= 0) this.waiters.splice(pending, 1);
+        const error = new Error(`${label} timed out after ${timeoutMs} ms`);
+        this.terminate(error);
+        this.socket?.destroy();
+        reject(error);
+      }, timeoutMs);
+      this.waiters.push(waiter);
+    });
+  }
+
+  send(packet) {
+    if (!this.socket || this.socket.destroyed) throw new Error("RDP socket is not connected");
+    this.socket.write(encodePacket(packet));
+  }
+
+  async connect() {
+    if (this.socket) throw new Error("RDP client already connected");
+    const options = { host: this.host, port: this.port, localAddress: "127.0.0.1" };
+    if (this.localPort !== undefined) options.localPort = this.localPort;
+    this.socket = net.createConnection(options);
+    this.socket.setKeepAlive(true, 10000);
+    const decode = createPacketDecoder(packet => this.deliver(packet));
+    this.socket.on("data", chunk => {
+      try {
+        decode(chunk);
+      } catch (error) {
+        this.terminate(error);
+        this.socket.destroy();
+      }
+    });
+    this.socket.on("error", error => this.terminate(error));
+    this.socket.on("close", () => this.terminate(new Error("RDP socket closed")));
+    try {
+      await new Promise((resolve, reject) => {
+        this.socket.once("connect", resolve);
+        this.socket.once("error", reject);
+      });
+      this.hello = await this.next(packet => packet.from === "root" && packet.applicationType,
+        this.timeoutMs, "root greeting");
+      this.send({ to: "root", type: "listProcesses" });
+      const processes = await this.next(packet => packet.from === "root" && (packet.processes || packet.error),
+        this.timeoutMs, "listProcesses");
+      if (processes.error) throw new Error(`listProcesses failed: ${processes.message || processes.error}`);
+      const parent = processes.processes.find(process => process.isParent);
+      if (!parent) throw new Error("Firefox RDP did not expose a parent-process descriptor");
+      this.send({ to: parent.actor, type: "getTarget" });
+      const response = await this.next(packet => packet.from === parent.actor && (packet.process || packet.error),
+        this.timeoutMs, "getTarget");
+      if (response.error) throw new Error(`getTarget failed: ${response.message || response.error}`);
+      this.consoleActor = response.process.consoleActor;
+      if (!this.consoleActor) throw new Error("Firefox RDP target did not expose a console actor");
+      return this.hello;
+    } catch (error) {
+      this.socket.destroy();
+      throw error;
+    }
+  }
+
+  evaluate(text, timeoutMs = this.timeoutMs) {
+    validateTimeout(timeoutMs);
+    const evaluation = this.evaluationTail.then(async () => {
+      if (this.terminalError) throw this.terminalError;
+      if (!this.consoleActor) throw new Error("RDP parent-process target is not attached");
+      this.send({ to: this.consoleActor, type: "evaluateJSAsync", text, disableBreaks: true });
+      const ack = await this.next(packet => packet.from === this.consoleActor &&
+        ((packet.resultID && packet.type !== "evaluationResult") || packet.error), timeoutMs,
+        "evaluateJSAsync");
+      if (ack.error) throw new Error(`evaluateJSAsync failed: ${ack.message || ack.error}`);
+      const result = await this.next(packet => packet.from === this.consoleActor &&
+        ((packet.type === "evaluationResult" && packet.resultID === ack.resultID) || packet.error), timeoutMs,
+        "evaluateJSAsync");
+      if (result.error) throw new Error(`evaluateJSAsync failed: ${result.message || result.error}`);
+      if (result.hasException) throw new Error(result.exceptionMessage || "Firefox evaluation failed");
+      return result.result;
+    });
+    this.evaluationTail = evaluation.catch(() => {});
+    return evaluation;
+  }
+
+  async evaluateJson(text, timeoutMs = this.timeoutMs) {
+    const result = await this.evaluate(text, timeoutMs);
+    if (typeof result !== "string") throw new TypeError("Firefox evaluation did not return JSON text");
+    return JSON.parse(result);
+  }
+
+  async pollJson(text, predicate, {
+    intervalMs = 250,
+    label = "Firefox predicate",
+    timeoutMs = this.timeoutMs,
+  } = {}) {
+    validateTimeout(timeoutMs);
+    const deadline = Date.now() + timeoutMs;
+    let value;
+    let timer;
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        const error = new Error(`${label} timed out after ${timeoutMs} ms: ${JSON.stringify(value)}`);
+        this.terminate(error);
+        this.socket?.destroy();
+        reject(error);
+      }, timeoutMs);
+    });
+    try {
+      return await Promise.race([timeout, (async () => {
+        while (Date.now() < deadline) {
+          value = await this.evaluateJson(text,
+            Math.max(1, Math.min(this.timeoutMs, deadline - Date.now())));
+          if (predicate(value)) return value;
+          await new Promise(resolve => setTimeout(resolve,
+            Math.max(0, Math.min(intervalMs, deadline - Date.now()))));
+        }
+        return timeout;
+      })()]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  failWaiters(error) {
+    for (const waiter of this.waiters.splice(0)) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  }
+
+  terminate(error) {
+    this.terminalError ||= error;
+    this.failWaiters(this.terminalError);
+  }
+
+  async close() {
+    if (!this.socket || this.socket.destroyed) return;
+    const closed = new Promise(resolve => this.socket.once("close", resolve));
+    this.socket.end();
+    const timer = setTimeout(() => this.socket.destroy(), 2000);
+    await closed;
+    clearTimeout(timer);
+  }
+}

--- a/.agent/skills/debugging-firefox/scripts/firefox-rdp.test.mjs
+++ b/.agent/skills/debugging-firefox/scripts/firefox-rdp.test.mjs
@@ -1,0 +1,388 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import net from "node:net";
+import test from "node:test";
+
+import {
+  createPacketDecoder,
+  encodePacket,
+  FirefoxRdpClient,
+} from "./firefox-rdp.mjs";
+
+async function createEvaluationServer(onEvaluate) {
+  const state = { connections: 0 };
+  const server = net.createServer(socket => {
+    state.connections++;
+    const send = packet => socket.write(encodePacket(packet));
+    const decode = createPacketDecoder(packet => {
+      if (packet.type === "listProcesses") {
+        send({ from: "root", processes: [{ actor: "process1", isParent: true }] });
+      } else if (packet.type === "getTarget") {
+        send({ from: "process1", process: { actor: "target1", consoleActor: "console1" } });
+      } else if (packet.type === "evaluateJSAsync") {
+        onEvaluate({ packet, send, socket });
+      }
+    });
+    socket.on("data", decode);
+    send({ from: "root", applicationType: "browser" });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { server, state };
+}
+
+async function closeServer(server) {
+  server.close();
+  await once(server, "close");
+}
+
+async function createCapabilityFailureServer(capability, sendError) {
+  const server = net.createServer(socket => {
+    const send = packet => socket.write(encodePacket(packet));
+    const decode = createPacketDecoder(packet => {
+      if (packet.type === "listProcesses") {
+        if (capability !== "listProcesses") {
+          send({ from: "root", processes: [{ actor: "process1", isParent: true }] });
+        } else if (sendError) {
+          send({ from: "root", error: "unrecognizedPacketType", message: "unsupported request" });
+        }
+      } else if (packet.type === "getTarget") {
+        if (capability !== "getTarget") {
+          send({ from: "process1", process: { actor: "target1", consoleActor: "console1" } });
+        } else if (sendError) {
+          send({ from: "process1", error: "unrecognizedPacketType", message: "unsupported request" });
+        }
+      } else if (packet.type === "evaluateJSAsync" && sendError) {
+        send({ from: "console1", error: "unrecognizedPacketType", message: "unsupported request" });
+      }
+    });
+    socket.on("data", decode);
+    send({ from: "root", applicationType: "browser" });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return server;
+}
+
+test("decodes split and coalesced UTF-8 packets as bytes", () => {
+  const actual = [];
+  const decode = createPacketDecoder(packet => actual.push(packet));
+  const split = encodePacket({ from: "root", text: "调试成功" });
+  const coalesced = Buffer.concat([
+    encodePacket({ from: "console1", value: 42 }),
+    encodePacket({ from: "console1", value: 43 }),
+  ]);
+
+  for (const byte of split) decode(Buffer.from([byte]));
+  decode(coalesced);
+
+  assert.deepEqual(actual, [
+    { from: "root", text: "调试成功" },
+    { from: "console1", value: 42 },
+    { from: "console1", value: 43 },
+  ]);
+});
+
+test("rejects non-loopback targets before connecting", () => {
+  assert.throws(
+    () => new FirefoxRdpClient({ host: "192.0.2.1" }),
+    /only accepts 127\.0\.0\.1/,
+  );
+});
+
+test("requires an explicit valid caller-selected port", () => {
+  for (const port of [undefined, -1, 0, 65536, 1.5, "6000"]) {
+    assert.throws(
+      () => new FirefoxRdpClient({ port }),
+      /port must be an integer from 1 to 65535/,
+    );
+  }
+});
+
+test("requires a valid timer range", () => {
+  for (const timeoutMs of [1, 2147483647]) {
+    assert.doesNotThrow(() => new FirefoxRdpClient({ port: 6000, timeoutMs }));
+  }
+  for (const timeoutMs of [0, -1, 2147483648, 1.5, NaN, Infinity, "1000"]) {
+    assert.throws(
+      () => new FirefoxRdpClient({ port: 6000, timeoutMs }),
+      /timeoutMs must be an integer from 1 to 2147483647/,
+    );
+  }
+});
+
+test("validates timeout overrides before protocol work", async () => {
+  for (const run of [
+    client => client.next(() => false, 0),
+    client => client.evaluate("40 + 2", 0),
+    client => client.pollJson("status", () => false, { timeoutMs: 0 }),
+  ]) {
+    const client = new FirefoxRdpClient({ port: 6000 });
+    await assert.rejects(Promise.resolve().then(() => run(client)),
+      /timeoutMs must be an integer from 1 to 2147483647/);
+  }
+});
+
+test("validates an optional caller-selected local port", () => {
+  assert.doesNotThrow(() => new FirefoxRdpClient({ port: 6000, localPort: 0 }));
+  for (const localPort of [-1, 65536, 1.5, NaN, Infinity, "6000"]) {
+    assert.throws(
+      () => new FirefoxRdpClient({ port: 6000, localPort }),
+      /localPort must be an integer from 0 to 65535/,
+    );
+  }
+});
+
+for (const capability of ["listProcesses", "getTarget", "evaluateJSAsync"]) {
+  for (const sendError of [true, false]) {
+    test(`${capability} ${sendError ? "protocol errors" : "timeouts"} name the capability`, async () => {
+      const server = await createCapabilityFailureServer(capability, sendError);
+      const client = new FirefoxRdpClient({ port: server.address().port, timeoutMs: 250 });
+
+      try {
+        await assert.rejects(
+          capability === "evaluateJSAsync"
+            ? client.connect().then(() => client.evaluate("40 + 2"))
+            : client.connect(),
+          new RegExp(`${capability} ${sendError ? "failed: unsupported request" : "timed out"}`),
+        );
+      } finally {
+        await client.close();
+        await closeServer(server);
+      }
+    });
+  }
+}
+
+test("uses one socket and serializes evaluations with competing result IDs", async () => {
+  let connections = 0;
+  let evaluation = 0;
+  let activeEvaluations = 0;
+  let maximumActiveEvaluations = 0;
+  const server = net.createServer(socket => {
+    connections++;
+    const send = packet => {
+      const frame = encodePacket(packet);
+      socket.write(frame.subarray(0, 3));
+      socket.write(frame.subarray(3));
+    };
+    const decode = createPacketDecoder(packet => {
+      if (packet.type === "listProcesses") {
+        send({ from: "root", processes: [{ actor: "process1", isParent: true }] });
+      } else if (packet.type === "getTarget") {
+        send({ from: "process1", process: { actor: "target1", consoleActor: "console1" } });
+        send({ from: "console1", type: "consoleAPICall", message: "unrelated" });
+      } else if (packet.type === "evaluateJSAsync") {
+        evaluation++;
+        activeEvaluations++;
+        maximumActiveEvaluations = Math.max(maximumActiveEvaluations, activeEvaluations);
+        const resultID = `evaluation${evaluation}`;
+        send({ from: "console1", type: "evaluationResult", resultID: "stale", result: -1 });
+        send({ from: "otherActor", resultID: "wrongActor" });
+        send({ from: "console1", resultID });
+        setTimeout(() => {
+          send({ from: "console1", type: "evaluationResult", resultID: "wrongResult", result: -2 });
+          send({ from: "console1", type: "tabNavigated", state: "stop" });
+          send({ from: "console1", type: "evaluationResult", resultID,
+            hasException: false, result: 42 });
+          activeEvaluations--;
+        }, 5);
+      }
+    });
+    socket.on("data", decode);
+    send({ from: "root", applicationType: "browser", traits: { label: "中文" } });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const client = new FirefoxRdpClient({
+    port: server.address().port,
+    timeoutMs: 1000,
+  });
+  await client.connect();
+  assert.deepEqual(await client.next(
+    packet => packet.from === "console1" && packet.type === "consoleAPICall",
+  ), { from: "console1", type: "consoleAPICall", message: "unrelated" });
+  assert.deepEqual(await Promise.all([
+    client.evaluate("40 + 2"),
+    client.evaluate("6 * 7"),
+  ]), [42, 42]);
+  await client.close();
+
+  assert.equal(connections, 1);
+  assert.equal(evaluation, 2);
+  assert.equal(maximumActiveEvaluations, 1);
+  server.close();
+  await once(server, "close");
+});
+
+test("connects and evaluates without starting console listeners", async () => {
+  let listenerRequests = 0;
+  const server = net.createServer(socket => {
+    const send = packet => socket.write(encodePacket(packet));
+    const decode = createPacketDecoder(packet => {
+      if (packet.type === "listProcesses") {
+        send({ from: "root", processes: [{ actor: "process1", isParent: true }] });
+      } else if (packet.type === "getTarget") {
+        send({ from: "process1", process: { actor: "target1", consoleActor: "console1" } });
+      } else if (packet.type === "startListeners" || packet.type === "stopListeners") {
+        listenerRequests++;
+        send({ from: "console1", error: "unrecognizedPacketType" });
+      } else if (packet.type === "evaluateJSAsync") {
+        send({ from: "console1", resultID: "evaluation1" });
+        send({ from: "console1", type: "evaluationResult", resultID: "evaluation1",
+          hasException: false, result: 42 });
+      }
+    });
+    socket.on("data", decode);
+    send({ from: "root", applicationType: "browser" });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const client = new FirefoxRdpClient({ port: server.address().port, timeoutMs: 1000 });
+
+  try {
+    await client.connect();
+    assert.equal(await client.evaluate("40 + 2"), 42);
+  } finally {
+    await client.close();
+    await closeServer(server);
+  }
+  assert.equal(listenerRequests, 0);
+});
+
+test("reuses one socket for JSON evaluation and bounded predicate polling", async () => {
+  let evaluations = 0;
+  const { server, state } = await createEvaluationServer(({ packet, send }) => {
+    const resultID = `evaluation${++evaluations}`;
+    send({ from: "console1", resultID });
+    send({
+      from: "console1",
+      type: "evaluationResult",
+      resultID,
+      hasException: false,
+      result: packet.text === "snapshot"
+        ? JSON.stringify({ tabs: 52 })
+        : JSON.stringify({ ready: evaluations >= 3 }),
+    });
+  });
+  const client = new FirefoxRdpClient({ port: server.address().port, timeoutMs: 1000 });
+
+  try {
+    await client.connect();
+    assert.deepEqual(await client.evaluateJson("snapshot"), { tabs: 52 });
+    assert.deepEqual(await client.pollJson("status", value => value.ready, {
+      intervalMs: 1,
+      label: "feature readiness",
+      timeoutMs: 1000,
+    }), { ready: true });
+    assert.equal(evaluations, 3);
+    assert.equal(state.connections, 1);
+  } finally {
+    await client.close();
+    await closeServer(server);
+  }
+});
+
+test("packet timeout invalidates the client before late evaluation replies", async () => {
+  let evaluations = 0;
+  const { server } = await createEvaluationServer(({ send, socket }) => {
+    const resultID = `evaluation${++evaluations}`;
+    setTimeout(() => {
+      if (socket.destroyed) return;
+      send({ from: "console1", resultID });
+      send({ from: "console1", type: "evaluationResult", resultID,
+        hasException: false, result: evaluations });
+    }, 60);
+  });
+  const client = new FirefoxRdpClient({ port: server.address().port, timeoutMs: 20 });
+
+  try {
+    await client.connect();
+    await assert.rejects(client.evaluate("first"),
+      /evaluateJSAsync timed out after 20 ms/);
+    await assert.rejects(client.evaluate("second"),
+      /evaluateJSAsync timed out after 20 ms/);
+    assert.equal(evaluations, 1);
+    assert.equal(client.socket.destroyed, true);
+  } finally {
+    await client.close();
+    await closeServer(server);
+  }
+});
+
+test("poll timeout includes time queued behind an earlier evaluation", async () => {
+  let evaluations = 0;
+  const { server } = await createEvaluationServer(({ packet, send, socket }) => {
+    const resultID = `evaluation${++evaluations}`;
+    send({ from: "console1", resultID });
+    const reply = () => {
+      if (socket.destroyed) return;
+      send({ from: "console1", type: "evaluationResult", resultID,
+        hasException: false, result: JSON.stringify({ ready: true }) });
+    };
+    if (packet.text === "block") setTimeout(reply, 60);
+    else reply();
+  });
+  const client = new FirefoxRdpClient({ port: server.address().port, timeoutMs: 1000 });
+
+  try {
+    await client.connect();
+    const results = await Promise.allSettled([
+      client.evaluate("block"),
+      client.pollJson("status", value => value.ready, {
+        intervalMs: 1,
+        label: "queued readiness",
+        timeoutMs: 20,
+      }),
+    ]);
+    assert.equal(results[0].status, "rejected");
+    assert.match(results[0].reason.message, /queued readiness timed out after 20 ms/);
+    assert.equal(results[1].status, "rejected");
+    assert.match(results[1].reason.message, /queued readiness timed out after 20 ms/);
+    assert.equal(evaluations, 1);
+    assert.equal(client.socket.destroyed, true);
+  } finally {
+    await client.close();
+    await closeServer(server);
+  }
+});
+
+test("rejects malformed frame lengths", () => {
+  const decode = createPacketDecoder(() => {});
+  assert.throws(() => decode(Buffer.from("nope:{}")), /RDP frame length/);
+});
+
+test("rejects an incomplete RDP header at Firefox's 200-byte limit", () => {
+  const decode = createPacketDecoder(() => {});
+  decode(Buffer.alloc(199, 49));
+  assert.throws(() => decode(Buffer.from("1")), /RDP frame header/);
+});
+
+test("accepts Firefox's packet-length limit and rejects one byte more", () => {
+  const atLimit = createPacketDecoder(() => {});
+  assert.doesNotThrow(() => atLimit(Buffer.from(`${2 ** 40}:`)));
+  const aboveLimit = createPacketDecoder(() => {});
+  assert.throws(() => aboveLimit(Buffer.from(`${2 ** 40 + 1}:`)), /RDP frame length/);
+});
+
+test("turns malformed server frames into connection failures", async () => {
+  let connections = 0;
+  const server = net.createServer(socket => {
+    connections++;
+    socket.write("nope:{}");
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const client = new FirefoxRdpClient({
+    port: server.address().port,
+    timeoutMs: 1000,
+  });
+  await assert.rejects(client.connect(), /RDP frame length/);
+  await client.close();
+
+  assert.equal(connections, 1);
+  server.close();
+  await once(server, "close");
+});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,3 +254,5 @@ Before finishing:
   url-watchdog.yml). The installer + updater E2E jobs and the publish gate are **path-filtered on
   PRs**: they skip when no changed file can affect them (see `docs/DEVELOPING.md` → Continuous
   integration). Prod publish stays manual from `main`; all publish scripts require a clean worktree.
+- **Interactive debugging of core files:** the MIT `debugging-firefox` RDP skill is vendored under
+  `.agent/skills/` — see `docs/debugging-with-rdp.md` (never put it in the lint/format gates).

--- a/config/.prettierignore
+++ b/config/.prettierignore
@@ -11,3 +11,5 @@ logs
 pnpm-lock.yaml
 # build outputs (installer Makefile + publish scripts dump into dist/)
 dist
+# vendored agent skill (upstream formatting; see docs/debugging-with-rdp.md)
+.agent

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -70,6 +70,9 @@ export default defineConfig([
     name: 'global-ignore',
     ignores: [
       '.github',
+      // Vendored agent skill — upstream formatting/rule style (see
+      // docs/debugging-with-rdp.md), kept out of the repo's lint+format gates.
+      '.agent',
       // Build outputs and generated artifacts (gitignored at the repo level).
       'dist/',
       'lib/',

--- a/docs/debugging-with-rdp.md
+++ b/docs/debugging-with-rdp.md
@@ -1,0 +1,85 @@
+# Interactive RDP debugging of core files
+
+The Puppeteer-BiDi E2E harness (ADR 0015) drives web content and the updater tab, but it cannot
+reach **browser-chrome**: a `userChrome.js`, `BootstrapLoader.js` or `config.js` failure is
+invisible there. For that we use the **debugging-firefox** agent skill (MIT; upstream
+[117649/debugging-firefox](https://github.com/117649/debugging-firefox)), vendored at
+`.agent/skills/debugging-firefox/` — a dependency-free Node client for Firefox's classic DevTools
+RDP (the same hook the Browser Toolbox uses), which evaluates privileged parent-process code and can
+install/reload XPIs.
+
+## Install
+
+The skill is vendored in this repo, so hosts that support the
+[Agent Skills spec](https://agentskills.io/specification) pick it up automatically. To track
+upstream instead of the vendored copy:
+
+```bash
+gh skill install 117649/debugging-firefox debugging-firefox
+```
+
+Validating: the offline suite is `node .agent/skills/debugging-firefox/scripts/firefox-rdp.test.mjs`
+(21 tests, mock server only — no Firefox needed). The vendored copy is a dev tool, not shipped code;
+re-sync it deliberately when upstream moves.
+
+## Quick start — disposable instance
+
+Launch a throwaway Firefox with the RDP listener on a temp profile (nothing shared, no user data):
+
+```bash
+PROF=$(mktemp -d)
+printf '%s\n' \
+  'user_pref("devtools.debugger.remote-enabled", true);' \
+  'user_pref("devtools.debugger.prompt-connection", false);' \
+  > "$PROF/user.js"
+firefox --profile "$PROF" --no-remote --start-debugger-server 6080 --headless &
+```
+
+`--headless` is fine for read-only probing. Connect, run the capability gate, evaluate, close:
+
+```js
+import {FirefoxRdpClient} from './.agent/skills/debugging-firefox/scripts/firefox-rdp.mjs';
+
+const client = new FirefoxRdpClient({port: 6080, timeoutMs: 20_000});
+await client.connect(); // gate: greeting → listProcesses → getTarget → console actor
+const info = await client.evaluateJson(`JSON.stringify({
+  version: Services.appinfo.version,
+  profile: Services.dirsvc.get('ProfD', Ci.nsIFile).path,
+})`);
+console.log(info);
+await client.close();
+```
+
+## Eval gotchas (from the live pilot, Firefox 154)
+
+- `evaluateJSAsync` already exposes the privileged globals (`Services`, `ChromeUtils`, `Components`,
+  `Cc`/`Ci`, `IOUtils`, `PathUtils`). Do **not** `ChromeUtils.importESModule(...)` for them — it
+  fails with `Failed to load resource://...`; use the globals directly.
+- XPConnect wants explicit IIDs: `Services.dirsvc.get('ProfD', Ci.nsIFile)` — the no-arg form throws
+  `Not enough arguments`.
+- Results must be serializable — use `evaluateJson` with an expression returning
+  `JSON.stringify(...)`; use `pollJson(text, predicate, {timeoutMs})` for async work instead of raw
+  timers.
+- Escape Windows paths (`\\\\`) inside `evaluate()` strings.
+
+## Cleanup contract
+
+- `client.close()`; terminate only the **profile-matched** process tree and verify the RDP port
+  closed; delete the temp profile.
+- Never attach to or mutate a pre-existing Firefox/profile; one mutation owner per instance; restore
+  everything you changed.
+- Before an XPI install or any mutation, read
+  `.agent/skills/debugging-firefox/references/live-testing.md` (evidence ladder, restart rules).
+
+## Worked example
+
+The pilot that validated this workflow probed, all read-only on a disposable profile: app identity;
+the exact `userChrome.js` FF149 branch computed from `platformVersion` (the
+`toggleAttribute`/`setAttribute` split, bug 2008041); and `userChrome.js`'s own `readFile` primitive
+against `prefs.js`. The same pattern debugs a missing loader, a broken `BootstrapLoader.js` header
+parse, or a `createElement` regression before it reaches CI.
+
+## Boundary
+
+Ordinary webpage automation stays on Puppeteer-BiDi (ADR 0015, `test/e2e/`). RDP is for
+browser-chrome and add-on runtime work that BiDi cannot see.


### PR DESCRIPTION
## What

Make the **debugging-firefox** RDP skill available to agents on this repo and document how to use it:

- **Vendored skill** at `.agent/skills/debugging-firefox/` (MIT; upstream [117649/debugging-firefox](https://github.com/117649/debugging-firefox)) — dependency-free Node client for Firefox's classic DevTools RDP, evaluating privileged parent-process code (same hook as the Browser Toolbox). Kept out of the repo's lint/format gates (`eslint` global-ignore + `.prettierignore`).
- **Cookbook** `docs/debugging-with-rdp.md` — disposable-instance quick start (`--start-debugger-server` + temp profile), the eval gotchas from a live pilot (Firefox 154: privileged globals are pre-exposed — `importESModule` for them fails; XPConnect wants explicit IIDs), the cleanup contract, and when to use RDP vs Puppeteer-BiDi.
- **AGENTS.md** pointer so future agents find it.

## Why

Puppeteer-BiDi (ADR 0015) drives web content and the updater tab but cannot reach browser-chrome — a `userChrome.js` / `BootstrapLoader.js` / `config.js` failure is invisible there. The pilot verified the protocol gate and privileged eval against a real Firefox (identity, the exact `userChrome.js` FF149 branch, and the loader's own `readFile` primitive). Related to #30 (core coverage workflow); dev tooling only — no shipped code changes.

## Validation

Offline skill suite 21/21; `node --check` on the client; eslint + prettier clean; `.agent` confirmed ignored by both gates.