### PR TITLE
test: exercise installer UI in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,8 +121,8 @@ jobs:
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
 
-      - name: Run installer E2E
-        run: node test/e2e/installer/installer-e2e.mjs
+      - name: Run installer E2E (HTTP + UI)
+        run: node test/e2e/installer/installer-e2e.mjs --ui --headless
 
   # ── Helper E2E (Linux elevated-copy core) ──────────────────────────────────
   helper:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,19 +121,7 @@ jobs:
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
 
-      - name: Run installer E2E (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq xvfb
-          xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' node test/e2e/installer/installer-e2e.mjs --ui --headless
-
-      - name: Run installer E2E (macOS)
-        if: matrix.os == 'macos-latest'
-        run: node test/e2e/installer/installer-e2e.mjs --ui --headless
-
-      - name: Run installer E2E (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Run installer E2E (HTTP + UI)
         run: node test/e2e/installer/installer-e2e.mjs --ui --headless
 
   # ── Helper E2E (Linux elevated-copy core) ──────────────────────────────────

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,7 +132,9 @@ jobs:
 
       - name: Run installer E2E (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        run: xvfb-run node test/e2e/installer/installer-e2e.mjs --ui --headless
+        # -a picks a free display number, avoiding collisions with the
+        # updater E2E job that also runs under xvfb-run on the same runner.
+        run: xvfb-run -a node test/e2e/installer/installer-e2e.mjs --ui --headless
 
       - name: Run installer E2E (macOS/Windows)
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
@@ -239,7 +241,7 @@ jobs:
       # step above) and auto-discovers the snapshot dir.
       - name: Run updater E2E (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: xvfb-run node test/e2e/updater/updater-e2e.mjs
+        run: xvfb-run -a node test/e2e/updater/updater-e2e.mjs
 
       - name: Run updater E2E (macOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,7 +121,19 @@ jobs:
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
 
-      - name: Run installer E2E (HTTP + UI)
+      - name: Run installer E2E (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+          xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run installer E2E (macOS)
+        if: matrix.os == 'macos-latest'
+        run: node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run installer E2E (Windows)
+        if: matrix.os == 'windows-latest'
         run: node test/e2e/installer/installer-e2e.mjs --ui --headless
 
   # ── Helper E2E (Linux elevated-copy core) ──────────────────────────────────

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,17 +125,17 @@ jobs:
       # server on Linux runners), so install xvfb and run under it — same as
       # the updater job below.
       - name: Install Linux test prerequisites
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq xvfb
 
       - name: Run installer E2E (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu')
         run: xvfb-run node test/e2e/installer/installer-e2e.mjs --ui --headless
 
       - name: Run installer E2E (macOS/Windows)
-        if: matrix.os != 'ubuntu-latest'
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
         run: node test/e2e/installer/installer-e2e.mjs --ui --headless
 
   # ── Helper E2E (Linux elevated-copy core) ──────────────────────────────────

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,7 +121,21 @@ jobs:
       - name: Build snapshot
         run: pnpm upload:local --mode=dev
 
-      - name: Run installer E2E (HTTP + UI)
+      # The UI layer launches a real Firefox (even headless it needs a display
+      # server on Linux runners), so install xvfb and run under it — same as
+      # the updater job below.
+      - name: Install Linux test prerequisites
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+
+      - name: Run installer E2E (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run installer E2E (macOS/Windows)
+        if: matrix.os != 'ubuntu-latest'
         run: node test/e2e/installer/installer-e2e.mjs --ui --headless
 
   # ── Helper E2E (Linux elevated-copy core) ──────────────────────────────────

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -48,7 +48,8 @@ typedef struct {
 /* Forward declarations */
 static void find_active_profile_readonly(const char *binary_path, char *out_profile_path);
 #if defined(__APPLE__)
-static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size);
+static void find_profile_from_macos_argv(pid_t pid, const char *binary_path,
+                                         char *out, size_t out_size);
 #endif
 static int hash_uploaded_zip(int is_utils, char *out_hash, size_t hash_size,
                              char ***out_list, int *out_count);
@@ -1705,7 +1706,8 @@ static bool is_duplicate_entry(RunningBrowser *results, int count,
  * find a browser's active profile when it is a temp dir (e.g. a puppeteer
  * profile) that never appears in profiles.ini.
  */
-static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) {
+static void find_profile_from_macos_argv(pid_t pid, const char *binary_path,
+                                         char *out, size_t out_size) {
     out[0] = '\0';
     int mib[3] = { CTL_KERN, KERN_PROCARGS2, pid };
     size_t size = 0;
@@ -1731,8 +1733,39 @@ static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) 
                     strcmp(p, "-P") == 0) {
                     const char *val = p + strlen(p) + 1;
                     if (val < end && *val) {
-                        strncpy(out, val, out_size - 1);
-                        out[out_size - 1] = '\0';
+                        if (strcmp(p, "-P") == 0) {
+                            char base_dir[MAX_PATH_LEN] = { 0 };
+                            const char *home = getenv("HOME");
+                            if (!home) {
+                                struct passwd *pw = getpwuid(getuid());
+                                if (pw) home = pw->pw_dir;
+                            }
+                            if (home) {
+                                switch (identify_variant_from_path(binary_path)) {
+                                    case BROWSER_ZEN:
+                                    case BROWSER_ZEN_TWILIGHT:
+                                        snprintf(base_dir, sizeof(base_dir), "%s/.zen", home);
+                                        break;
+                                    case BROWSER_WATERFOX:
+                                    case BROWSER_WATERFOX_BETA:
+                                        snprintf(base_dir, sizeof(base_dir), "%s/.waterfox", home);
+                                        break;
+                                    case BROWSER_LIBREWOLF:
+                                        snprintf(base_dir, sizeof(base_dir), "%s/.librewolf", home);
+                                        break;
+                                    case BROWSER_FLOORP:
+                                        snprintf(base_dir, sizeof(base_dir), "%s/.floorp", home);
+                                        break;
+                                    default:
+                                        snprintf(base_dir, sizeof(base_dir), "%s/.mozilla/firefox", home);
+                                        break;
+                                }
+                                lookup_profile_by_name(base_dir, val, out, out_size);
+                            }
+                        } else {
+                            strncpy(out, val, out_size - 1);
+                            out[out_size - 1] = '\0';
+                        }
                     }
                 }
                 idx++;
@@ -2627,7 +2660,9 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
 
                     // Dedup by (binary_path + profile_path) so different profiles are distinct
                     if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {
-                        snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s", TARGET_EXECUTABLES[0]);
+                        const char *exe_name = strrchr(full_path, '/');
+                        exe_name = exe_name ? exe_name + 1 : full_path;
+                        snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s", exe_name);
                         strncpy(results[count].binary_path, full_path, MAX_PATH_LEN);
                         strncpy(results[count].profile_path, profile_path, MAX_PATH_LEN);
                         results[count].pid = (unsigned long)pid;
@@ -2676,15 +2711,16 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
                 // (e.g. puppeteer's) is not in profiles.ini and would
                 // otherwise resolve to nothing, sending the UI tab elsewhere.
                 char profile_path[MAX_PATH_LEN] = { 0 };
-                find_profile_from_macos_argv(pid, profile_path, sizeof(profile_path));
+                find_profile_from_macos_argv(pid, full_path, profile_path, sizeof(profile_path));
                 if (strlen(profile_path) == 0) {
                     find_active_profile_readonly(full_path, profile_path);
                 }
 
                 // Dedup by (binary_path + profile_path) so different profiles are distinct
                 if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {
-                    snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s",
-                             TARGET_EXECUTABLES[0]);
+                    const char *exe_name = strrchr(full_path, '/');
+                    exe_name = exe_name ? exe_name + 1 : full_path;
+                    snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s", exe_name);
                     strncpy(results[count].binary_path, full_path, MAX_PATH_LEN);
                     strncpy(results[count].profile_path, profile_path, MAX_PATH_LEN);
                     results[count].pid = (unsigned long)pid;

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -2675,6 +2675,19 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
             if (len != -1) {
                 full_path[len] = '\0';
 
+                // A package update may have unlinked the running binary; the
+                // kernel then reports "<path> (deleted)".  Strip that suffix
+                // so the stored binary_path stays valid (it is later passed
+                // to execl() on relaunch).  is_target_executable() keeps its
+                // own stripping as a defensive fallback.
+                static const char kDeletedSuffix[] = " (deleted)";
+                const size_t dlen = sizeof(kDeletedSuffix) - 1;
+                if (len > (ssize_t)dlen &&
+                    memcmp(full_path + len - dlen, kDeletedSuffix, dlen) == 0) {
+                    len -= (ssize_t)dlen;
+                    full_path[len] = '\0';
+                }
+
                 if (is_target_executable(full_path)) {
                     // Detect profile BEFORE dedup check (PID-aware on Linux)
                     char profile_path[MAX_PATH_LEN] = { 0 };

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -2668,7 +2668,7 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
                 // (e.g. puppeteer's) is not in profiles.ini and would
                 // otherwise resolve to nothing, sending the UI tab elsewhere.
                 char profile_path[MAX_PATH_LEN] = { 0 };
-                find_profile_from_macos_argv(pid, profile_path);
+                find_profile_from_macos_argv(pid, profile_path, sizeof(profile_path));
                 if (strlen(profile_path) == 0) {
                     find_active_profile_readonly(full_path, profile_path);
                 }

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1136,6 +1136,38 @@ static const char *TARGET_EXECUTABLES[] = {
     NULL
 };
 
+/**
+ * True if the process executable at `full_path` is one of the target browsers.
+ *
+ * Windows matches the process image name (`pe.szExeFile`); POSIX scans resolve
+ * a full path (proc_pidpath / /proc/<pid>/exe) and MUST compare its basename,
+ * not strstr on the whole path: the installer itself runs from
+ * <repo>/firefox-scripts/... and a substring match would detect it (and its
+ * empty profile) as a browser, stealing the UI tab from the real browser.
+ */
+static int is_target_executable(const char *full_path) {
+    if (!full_path || full_path[0] == '\0') return 0;
+    const char *base = strrchr(full_path, '/');
+    base = base ? base + 1 : full_path;
+#if defined(_WIN32)
+    const char *wbase = strrchr(base, '\\');
+    if (wbase) base = wbase + 1;
+    for (int i = 0; TARGET_EXECUTABLES[i] != NULL; i++) {
+        if (_stricmp(base, TARGET_EXECUTABLES[i]) == 0) return 1;
+    }
+#elif defined(__APPLE__)
+    // macOS filesystems are case-insensitive by default.
+    for (int i = 0; TARGET_EXECUTABLES[i] != NULL; i++) {
+        if (strcasecmp(base, TARGET_EXECUTABLES[i]) == 0) return 1;
+    }
+#else
+    for (int i = 0; TARGET_EXECUTABLES[i] != NULL; i++) {
+        if (strcmp(base, TARGET_EXECUTABLES[i]) == 0) return 1;
+    }
+#endif
+    return 0;
+}
+
 enum BrowserVariant identify_variant_from_path(const char *path) {
     if (strstr(path, "Zen twilight") || strstr(path, "zen-twilight") || strstr(path, "Twilight")) {
         return BROWSER_ZEN_TWILIGHT;
@@ -2539,35 +2571,33 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
             if (len != -1) {
                 full_path[len] = '\0';
 
-                for (int i = 0; TARGET_EXECUTABLES[i] != NULL; i++) {
-                    if (strstr(full_path, TARGET_EXECUTABLES[i]) != NULL) {
-                        // Detect profile BEFORE dedup check (PID-aware on Linux)
-                        char profile_path[MAX_PATH_LEN] = { 0 };
-                        find_profile_for_pid((unsigned long)pid, full_path, profile_path);
+                if (is_target_executable(full_path)) {
+                    // Detect profile BEFORE dedup check (PID-aware on Linux)
+                    char profile_path[MAX_PATH_LEN] = { 0 };
+                    find_profile_for_pid((unsigned long)pid, full_path, profile_path);
 
-                        // Dedup by (binary_path + profile_path) so different profiles are distinct
-                        if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {
-                            snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s", TARGET_EXECUTABLES[i]);
-                            strncpy(results[count].binary_path, full_path, MAX_PATH_LEN);
-                            strncpy(results[count].profile_path, profile_path, MAX_PATH_LEN);
-                            results[count].pid = (unsigned long)pid;
+                    // Dedup by (binary_path + profile_path) so different profiles are distinct
+                    if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {
+                        snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s", TARGET_EXECUTABLES[0]);
+                        strncpy(results[count].binary_path, full_path, MAX_PATH_LEN);
+                        strncpy(results[count].profile_path, profile_path, MAX_PATH_LEN);
+                        results[count].pid = (unsigned long)pid;
 
-                            resolve_browser_name(full_path, results[count].identified_browser, sizeof(results[count].identified_browser));
-                            read_application_version(full_path,
-                                                     identify_variant_from_path(full_path),
-                                                     results[count].version, sizeof(results[count].version));
+                        resolve_browser_name(full_path, results[count].identified_browser, sizeof(results[count].identified_browser));
+                        read_application_version(full_path,
+                                                 identify_variant_from_path(full_path),
+                                                 results[count].version, sizeof(results[count].version));
 
-                            if (strlen(results[count].profile_path) > 0) {
-                                char binary_dir[MAX_PATH_LEN];
-                                strncpy(binary_dir, full_path, MAX_PATH_LEN);
-                                get_parent_dir(binary_dir);
+                        if (strlen(results[count].profile_path) > 0) {
+                            char binary_dir[MAX_PATH_LEN];
+                            strncpy(binary_dir, full_path, MAX_PATH_LEN);
+                            get_parent_dir(binary_dir);
 
-                                results[count].config_installed = check_config_status(binary_dir);
-                                results[count].utils_installed = check_utils_status(results[count].profile_path);
-                            }
-
-                            count++;
+                            results[count].config_installed = check_config_status(binary_dir);
+                            results[count].utils_installed = check_utils_status(results[count].profile_path);
                         }
+
+                        count++;
                     }
                 }
             }
@@ -2589,37 +2619,36 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
             pid_t pid = procs[i].kp_proc.p_pid;
             char full_path[MAX_PATH_LEN] = { 0 };
 
-            if (proc_pidpath(pid, full_path, sizeof(full_path)) > 0) {
-                for (int j = 0; TARGET_EXECUTABLES[j] != NULL; j++) {
-                    if (strstr(full_path, TARGET_EXECUTABLES[j]) != NULL) {
-                        // Detect profile BEFORE dedup check
-                        char profile_path[MAX_PATH_LEN] = { 0 };
-                        find_active_profile_readonly(full_path, profile_path);
+            if (proc_pidpath(pid, full_path, sizeof(full_path)) > 0 &&
+                is_target_executable(full_path)) {
+                // Detect profile BEFORE dedup check
+                char profile_path[MAX_PATH_LEN] = { 0 };
+                find_active_profile_readonly(full_path, profile_path);
 
-                        // Dedup by (binary_path + profile_path) so different profiles are distinct
-                        if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {
-                            snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s", TARGET_EXECUTABLES[j]);
-                            strncpy(results[count].binary_path, full_path, MAX_PATH_LEN);
-                            strncpy(results[count].profile_path, profile_path, MAX_PATH_LEN);
-                            results[count].pid = (unsigned long)pid;
+                // Dedup by (binary_path + profile_path) so different profiles are distinct
+                if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {
+                    snprintf(results[count].exe_name, sizeof(results[count].exe_name), "%s",
+                             TARGET_EXECUTABLES[0]);
+                    strncpy(results[count].binary_path, full_path, MAX_PATH_LEN);
+                    strncpy(results[count].profile_path, profile_path, MAX_PATH_LEN);
+                    results[count].pid = (unsigned long)pid;
 
-                            resolve_browser_name(full_path, results[count].identified_browser, sizeof(results[count].identified_browser));
-                            read_application_version(full_path,
-                                                     identify_variant_from_path(full_path),
-                                                     results[count].version, sizeof(results[count].version));
+                    resolve_browser_name(full_path, results[count].identified_browser,
+                                         sizeof(results[count].identified_browser));
+                    read_application_version(full_path,
+                                             identify_variant_from_path(full_path),
+                                             results[count].version, sizeof(results[count].version));
 
-                            if (strlen(results[count].profile_path) > 0) {
-                                char binary_dir[MAX_PATH_LEN];
-                                strncpy(binary_dir, full_path, MAX_PATH_LEN);
-                                get_parent_dir(binary_dir);
+                    if (strlen(results[count].profile_path) > 0) {
+                        char binary_dir[MAX_PATH_LEN];
+                        strncpy(binary_dir, full_path, MAX_PATH_LEN);
+                        get_parent_dir(binary_dir);
 
-                                results[count].config_installed = check_config_status(binary_dir);
-                                results[count].utils_installed = check_utils_status(results[count].profile_path);
-                            }
-
-                            count++;
-                        }
+                        results[count].config_installed = check_config_status(binary_dir);
+                        results[count].utils_installed = check_utils_status(results[count].profile_path);
                     }
+
+                    count++;
                 }
             }
         }

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1725,11 +1725,8 @@ static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) 
         // honor argc so we never wander into the environment block.
         p += strlen(p) + 1;  // skip argv[0] (the executable path)
         int idx = 1;
-        // DEBUG (E2E): dump the argv so a missing profile is diagnosable.
-        fprintf(stderr, "[mac-argv] pid=%d argc=%d", (int)pid, argc);
         while (idx < argc && p < end) {
             if (*p) {
-                fprintf(stderr, " [%d]=%s", idx, p);
                 if (strcmp(p, "-profile") == 0 || strcmp(p, "--profile") == 0 ||
                     strcmp(p, "-P") == 0) {
                     const char *val = p + strlen(p) + 1;
@@ -1742,7 +1739,6 @@ static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) 
             }
             p += strlen(p) + 1;
         }
-        fprintf(stderr, "\n");
     }
     free(buf);
 }

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -47,6 +47,9 @@ typedef struct {
 
 /* Forward declarations */
 static void find_active_profile_readonly(const char *binary_path, char *out_profile_path);
+#if defined(__APPLE__)
+static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size);
+#endif
 static int hash_uploaded_zip(int is_utils, char *out_hash, size_t hash_size,
                              char ***out_list, int *out_count);
 static void free_file_list(char ***list, int *count);

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -50,6 +50,9 @@ static void find_active_profile_readonly(const char *binary_path, char *out_prof
 #if defined(__APPLE__)
 static void find_profile_from_macos_argv(pid_t pid, const char *binary_path,
                                          char *out, size_t out_size);
+/* Defined below with the Linux helpers; shared by the macOS argv scan. */
+static int lookup_profile_by_name(const char *base_dir, const char *profile_name,
+                                  char *out_path, size_t out_size);
 #endif
 static int hash_uploaded_zip(int is_utils, char *out_hash, size_t hash_size,
                              char ***out_list, int *out_count);
@@ -1777,7 +1780,7 @@ static void find_profile_from_macos_argv(pid_t pid, const char *binary_path,
 }
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 /**
  * Look up a profile name in profiles.ini and return its full path.
  * Returns 0 on success, -1 if not found.
@@ -1835,7 +1838,9 @@ static int lookup_profile_by_name(const char *base_dir, const char *profile_name
 
     return 0;
 }
+#endif /* __linux__ || __APPLE__ */
 
+#if defined(__linux__)
 /**
  * Read /proc/<pid>/cmdline to find the profile name/path this process was launched with.
  * Falls back to find_active_profile_readonly() if command line doesn't specify a profile.

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1754,6 +1754,44 @@ static int lookup_profile_by_name(const char *base_dir, const char *profile_name
     return 0;
 }
 
+#if defined(__APPLE__)
+/**
+ * Read a process's argv on macOS (no /proc) via sysctl KERN_PROCARGS2 and
+ * extract the --profile/-P argument it was launched with, if any.  Used to
+ * find a browser's active profile when it is a temp dir (e.g. a puppeteer
+ * profile) that never appears in profiles.ini.
+ */
+static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) {
+    out[0] = '\0';
+    int mib[3] = { CTL_KERN, KERN_PROCARGS2, pid };
+    size_t size = 0;
+    if (sysctl(mib, 3, NULL, &size, NULL, 0) < 0 || size > 4 * 1024 * 1024) return;
+    char *buf = malloc(size);
+    if (!buf) return;
+    if (sysctl(mib, 3, buf, &size, NULL, 0) == 0 && size > sizeof(int)) {
+        int argc = 0;
+        memcpy(&argc, buf, sizeof(argc));
+        // After argc: executable path, then the NUL-separated argv, then an
+        // empty string, then the environment.  Skip the executable and scan
+        // argv for -profile/-P (the value is the NEXT argument).
+        char *p = buf + sizeof(int);
+        char *end = buf + size;
+        p += strlen(p) + 1;  // skip argv[0] (the executable path)
+        for (int a = 1; a < argc && p < end && *p; a++) {
+            const char *arg = p;
+            p += strlen(p) + 1;
+            if ((strcmp(arg, "--profile") == 0 || strcmp(arg, "-P") == 0) &&
+                p < end && *p) {
+                strncpy(out, p, out_size - 1);
+                out[out_size - 1] = '\0';
+                break;
+            }
+        }
+    }
+    free(buf);
+}
+#endif
+
 /**
  * Read /proc/<pid>/cmdline to find the profile name/path this process was launched with.
  * Falls back to find_active_profile_readonly() if command line doesn't specify a profile.
@@ -2621,9 +2659,16 @@ int scan_and_filter_browsers(RunningBrowser *results, int max_results) {
 
             if (proc_pidpath(pid, full_path, sizeof(full_path)) > 0 &&
                 is_target_executable(full_path)) {
-                // Detect profile BEFORE dedup check
+                // Detect profile BEFORE dedup check. macOS has no /proc, so
+                // read the process argv (KERN_PROCARGS2) to find the explicit
+                // --profile/-P the browser was launched with — a temp profile
+                // (e.g. puppeteer's) is not in profiles.ini and would
+                // otherwise resolve to nothing, sending the UI tab elsewhere.
                 char profile_path[MAX_PATH_LEN] = { 0 };
-                find_active_profile_readonly(full_path, profile_path);
+                find_profile_from_macos_argv(pid, profile_path);
+                if (strlen(profile_path) == 0) {
+                    find_active_profile_readonly(full_path, profile_path);
+                }
 
                 // Dedup by (binary_path + profile_path) so different profiles are distinct
                 if (!is_duplicate_entry(results, count, full_path, profile_path) && count < max_results) {

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1717,14 +1717,24 @@ static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) 
         memcpy(&argc, buf, sizeof(argc));
         // After argc: executable path, then the NUL-separated argv, then an
         // empty string, then the environment.  Skip the executable and scan
-        // argv for -profile/-P (the value is the NEXT argument).
+        // argv for -profile/--profile/-P (the value is the NEXT argument).
         char *p = buf + sizeof(int);
         char *end = buf + size;
-        p += strlen(p) + 1;  // skip argv[0] (the executable path)
+        // DEBUG (E2E): dump the argv so a missing profile is diagnosable.
+        fprintf(stderr, "[mac-argv] pid=%d argc=%d", (int)pid, argc);
+        for (int d = 0; d < argc && p < end && *p; d++) {
+            fprintf(stderr, " [%d]=%s", d, p);
+            p += strlen(p) + 1;
+        }
+        fprintf(stderr, "\n");
+        // Skip argv[0] (already printed above) and scan the rest.
+        p = buf + sizeof(int);
+        p += strlen(p) + 1;
         for (int a = 1; a < argc && p < end && *p; a++) {
             const char *arg = p;
             p += strlen(p) + 1;
-            if ((strcmp(arg, "--profile") == 0 || strcmp(arg, "-P") == 0) &&
+            if ((strcmp(arg, "-profile") == 0 || strcmp(arg, "--profile") == 0 ||
+                 strcmp(arg, "-P") == 0) &&
                 p < end && *p) {
                 strncpy(out, p, out_size - 1);
                 out[out_size - 1] = '\0';

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1168,8 +1168,21 @@ static int is_target_executable(const char *full_path) {
         if (strcasecmp(base, TARGET_EXECUTABLES[i]) == 0) return 1;
     }
 #else
+    // A running binary whose file was replaced by a package update shows up
+    // as "<path> (deleted)" in /proc/<pid>/exe; strip only that recognized
+    // suffix so the still-running browser keeps matching its basename.
+    char name[MAX_PATH_LEN];
+    size_t blen = strlen(base);
+    static const char kDeletedSuffix[] = " (deleted)";
+    const size_t dlen = sizeof(kDeletedSuffix) - 1;
+    if (blen > dlen && memcmp(base + blen - dlen, kDeletedSuffix, dlen) == 0) {
+        blen -= dlen;
+    }
+    if (blen >= sizeof(name)) blen = sizeof(name) - 1;
+    memcpy(name, base, blen);
+    name[blen] = '\0';
     for (int i = 0; TARGET_EXECUTABLES[i] != NULL; i++) {
-        if (strcmp(base, TARGET_EXECUTABLES[i]) == 0) return 1;
+        if (strcmp(name, TARGET_EXECUTABLES[i]) == 0) return 1;
     }
 #endif
     return 0;
@@ -1744,23 +1757,27 @@ static void find_profile_from_macos_argv(pid_t pid, const char *binary_path,
                                 if (pw) home = pw->pw_dir;
                             }
                             if (home) {
+                                // macOS keeps browser profiles under
+                                // ~/Library/Application Support (matching
+                                // find_active_profile_readonly() below), not
+                                // in the dot-directories Linux uses.
                                 switch (identify_variant_from_path(binary_path)) {
                                     case BROWSER_ZEN:
                                     case BROWSER_ZEN_TWILIGHT:
-                                        snprintf(base_dir, sizeof(base_dir), "%s/.zen", home);
+                                        snprintf(base_dir, sizeof(base_dir), "%s/Library/Application Support/zen", home);
                                         break;
                                     case BROWSER_WATERFOX:
                                     case BROWSER_WATERFOX_BETA:
-                                        snprintf(base_dir, sizeof(base_dir), "%s/.waterfox", home);
+                                        snprintf(base_dir, sizeof(base_dir), "%s/Library/Application Support/Waterfox", home);
                                         break;
                                     case BROWSER_LIBREWOLF:
-                                        snprintf(base_dir, sizeof(base_dir), "%s/.librewolf", home);
+                                        snprintf(base_dir, sizeof(base_dir), "%s/Library/Application Support/LibreWolf", home);
                                         break;
                                     case BROWSER_FLOORP:
-                                        snprintf(base_dir, sizeof(base_dir), "%s/.floorp", home);
+                                        snprintf(base_dir, sizeof(base_dir), "%s/Library/Application Support/Floorp", home);
                                         break;
                                     default:
-                                        snprintf(base_dir, sizeof(base_dir), "%s/.mozilla/firefox", home);
+                                        snprintf(base_dir, sizeof(base_dir), "%s/Library/Application Support/Firefox", home);
                                         break;
                                 }
                                 lookup_profile_by_name(base_dir, val, out, out_size);

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1720,27 +1720,29 @@ static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) 
         // argv for -profile/--profile/-P (the value is the NEXT argument).
         char *p = buf + sizeof(int);
         char *end = buf + size;
+        // KERN_PROCARGS2 lays out: argc, argv[0] path string, then the argv
+        // entries (an empty string separates them) — skip empty entries and
+        // honor argc so we never wander into the environment block.
+        p += strlen(p) + 1;  // skip argv[0] (the executable path)
+        int idx = 1;
         // DEBUG (E2E): dump the argv so a missing profile is diagnosable.
         fprintf(stderr, "[mac-argv] pid=%d argc=%d", (int)pid, argc);
-        for (int d = 0; d < argc && p < end && *p; d++) {
-            fprintf(stderr, " [%d]=%s", d, p);
+        while (idx < argc && p < end) {
+            if (*p) {
+                fprintf(stderr, " [%d]=%s", idx, p);
+                if (strcmp(p, "-profile") == 0 || strcmp(p, "--profile") == 0 ||
+                    strcmp(p, "-P") == 0) {
+                    const char *val = p + strlen(p) + 1;
+                    if (val < end && *val) {
+                        strncpy(out, val, out_size - 1);
+                        out[out_size - 1] = '\0';
+                    }
+                }
+                idx++;
+            }
             p += strlen(p) + 1;
         }
         fprintf(stderr, "\n");
-        // Skip argv[0] (already printed above) and scan the rest.
-        p = buf + sizeof(int);
-        p += strlen(p) + 1;
-        for (int a = 1; a < argc && p < end && *p; a++) {
-            const char *arg = p;
-            p += strlen(p) + 1;
-            if ((strcmp(arg, "-profile") == 0 || strcmp(arg, "--profile") == 0 ||
-                 strcmp(arg, "-P") == 0) &&
-                p < end && *p) {
-                strncpy(out, p, out_size - 1);
-                out[out_size - 1] = '\0';
-                break;
-            }
-        }
     }
     free(buf);
 }

--- a/installer/src/detect_browser.c
+++ b/installer/src/detect_browser.c
@@ -1698,6 +1698,44 @@ static bool is_duplicate_entry(RunningBrowser *results, int count,
     return false;
 }
 
+#if defined(__APPLE__)
+/**
+ * Read a process's argv on macOS (no /proc) via sysctl KERN_PROCARGS2 and
+ * extract the --profile/-P argument it was launched with, if any.  Used to
+ * find a browser's active profile when it is a temp dir (e.g. a puppeteer
+ * profile) that never appears in profiles.ini.
+ */
+static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) {
+    out[0] = '\0';
+    int mib[3] = { CTL_KERN, KERN_PROCARGS2, pid };
+    size_t size = 0;
+    if (sysctl(mib, 3, NULL, &size, NULL, 0) < 0 || size > 4 * 1024 * 1024) return;
+    char *buf = malloc(size);
+    if (!buf) return;
+    if (sysctl(mib, 3, buf, &size, NULL, 0) == 0 && size > sizeof(int)) {
+        int argc = 0;
+        memcpy(&argc, buf, sizeof(argc));
+        // After argc: executable path, then the NUL-separated argv, then an
+        // empty string, then the environment.  Skip the executable and scan
+        // argv for -profile/-P (the value is the NEXT argument).
+        char *p = buf + sizeof(int);
+        char *end = buf + size;
+        p += strlen(p) + 1;  // skip argv[0] (the executable path)
+        for (int a = 1; a < argc && p < end && *p; a++) {
+            const char *arg = p;
+            p += strlen(p) + 1;
+            if ((strcmp(arg, "--profile") == 0 || strcmp(arg, "-P") == 0) &&
+                p < end && *p) {
+                strncpy(out, p, out_size - 1);
+                out[out_size - 1] = '\0';
+                break;
+            }
+        }
+    }
+    free(buf);
+}
+#endif
+
 #if defined(__linux__)
 /**
  * Look up a profile name in profiles.ini and return its full path.
@@ -1756,44 +1794,6 @@ static int lookup_profile_by_name(const char *base_dir, const char *profile_name
 
     return 0;
 }
-
-#if defined(__APPLE__)
-/**
- * Read a process's argv on macOS (no /proc) via sysctl KERN_PROCARGS2 and
- * extract the --profile/-P argument it was launched with, if any.  Used to
- * find a browser's active profile when it is a temp dir (e.g. a puppeteer
- * profile) that never appears in profiles.ini.
- */
-static void find_profile_from_macos_argv(pid_t pid, char *out, size_t out_size) {
-    out[0] = '\0';
-    int mib[3] = { CTL_KERN, KERN_PROCARGS2, pid };
-    size_t size = 0;
-    if (sysctl(mib, 3, NULL, &size, NULL, 0) < 0 || size > 4 * 1024 * 1024) return;
-    char *buf = malloc(size);
-    if (!buf) return;
-    if (sysctl(mib, 3, buf, &size, NULL, 0) == 0 && size > sizeof(int)) {
-        int argc = 0;
-        memcpy(&argc, buf, sizeof(argc));
-        // After argc: executable path, then the NUL-separated argv, then an
-        // empty string, then the environment.  Skip the executable and scan
-        // argv for -profile/-P (the value is the NEXT argument).
-        char *p = buf + sizeof(int);
-        char *end = buf + size;
-        p += strlen(p) + 1;  // skip argv[0] (the executable path)
-        for (int a = 1; a < argc && p < end && *p; a++) {
-            const char *arg = p;
-            p += strlen(p) + 1;
-            if ((strcmp(arg, "--profile") == 0 || strcmp(arg, "-P") == 0) &&
-                p < end && *p) {
-                strncpy(out, p, out_size - 1);
-                out[out_size - 1] = '\0';
-                break;
-            }
-        }
-    }
-    free(buf);
-}
-#endif
 
 /**
  * Read /proc/<pid>/cmdline to find the profile name/path this process was launched with.

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -2556,11 +2556,16 @@ static int main_impl(int argc, char *argv[]) {
         // installer-e2e.mjs (which inherits this process's stdio) can report
         // why a tab did or did not appear in the test browser.
         printf("[installer] detected %d browser(s):\n", detected_count);
+        log_msg("[installer] detected %d browser(s):\n", detected_count);
         for (int i = 0; i < detected_count; i++) {
             printf("  [%d] %s\n      binary: %s\n      profile: %s\n", i,
                    detected_browsers[i].identified_browser,
                    detected_browsers[i].binary_path,
                    detected_browsers[i].profile_path);
+            log_msg("  [%d] %s binary: %s profile: %s\n", i,
+                    detected_browsers[i].identified_browser,
+                    detected_browsers[i].binary_path,
+                    detected_browsers[i].profile_path);
         }
         if (detected_count > 0) {
             // Prefer the most recently used browser window over the first
@@ -2570,6 +2575,8 @@ static int main_impl(int argc, char *argv[]) {
             if (ui_host_idx < 0) ui_host_idx = 0;
             printf("[installer] opening %s in browser %d (%s)\n", g_ui_url,
                    ui_host_idx, detected_browsers[ui_host_idx].identified_browser);
+            log_msg("[installer] opening %s in browser %d (%s)\n", g_ui_url,
+                    ui_host_idx, detected_browsers[ui_host_idx].identified_browser);
             // Record which profile hosts the UI tab so the restart worker can
             // reopen the UI there after a restart that kills this browser.
             if (strlen(detected_browsers[ui_host_idx].profile_path) > 0) {
@@ -2582,6 +2589,7 @@ static int main_impl(int argc, char *argv[]) {
             focus_browser_window(detected_browsers[ui_host_idx].pid);
         } else {
             printf("[installer] no browsers detected; falling back to default browser\n");
+            log_msg("[installer] no browsers detected; falling back to default browser\n");
             open_browser(g_ui_url, NULL);  // fallback to default browser
         }
         fflush(stdout);  // long-running process: make the E2E diagnostics visible

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -1903,6 +1903,18 @@ static void open_url_in_profile(const char *binary, const char *profile, const c
     log_msg("[openurl] CreateProcessW failed: %lu\n", GetLastError());
     open_browser(url, NULL);
 #else
+#ifdef __APPLE__
+    char cmd[MAX_PATH_LEN * 2 + 256];
+    /* Launch the browser binary directly with --profile so the URL opens in
+     * the specific profile Puppeteer created. Fall back to open_browser on
+     * failure. */
+    snprintf(cmd, sizeof(cmd), "\"%s\" --profile \"%s\" \"%s\" &", binary, profile, url);
+    if (system(cmd) == 0) {
+        log_msg("[openurl] %s\n", cmd);
+        return;
+    }
+    /* Fall through to the generic open method */
+#endif
     open_browser(url, binary);
 #endif
 }

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -1903,18 +1903,6 @@ static void open_url_in_profile(const char *binary, const char *profile, const c
     log_msg("[openurl] CreateProcessW failed: %lu\n", GetLastError());
     open_browser(url, NULL);
 #else
-#ifdef __APPLE__
-    char cmd[MAX_PATH_LEN * 2 + 256];
-    /* Launch the browser binary directly with --profile so the URL opens in
-     * the specific profile Puppeteer created. Fall back to open_browser on
-     * failure. */
-    snprintf(cmd, sizeof(cmd), "\"%s\" --profile \"%s\" \"%s\" &", binary, profile, url);
-    if (system(cmd) == 0) {
-        log_msg("[openurl] %s\n", cmd);
-        return;
-    }
-    /* Fall through to the generic open method */
-#endif
     open_browser(url, binary);
 #endif
 }

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -2552,12 +2552,24 @@ static int main_impl(int argc, char *argv[]) {
     snprintf(g_ui_url, sizeof(g_ui_url), "http://localhost:%d/?t=%s", port, g_session_token);
     log_msg("[startup] opening %s\n", g_ui_url);
     if (!g_smoke_test) {
+        // E2E diagnostics: echo the detection + launch decision to stdout so
+        // installer-e2e.mjs (which inherits this process's stdio) can report
+        // why a tab did or did not appear in the test browser.
+        printf("[installer] detected %d browser(s):\n", detected_count);
+        for (int i = 0; i < detected_count; i++) {
+            printf("  [%d] %s\n      binary: %s\n      profile: %s\n", i,
+                   detected_browsers[i].identified_browser,
+                   detected_browsers[i].binary_path,
+                   detected_browsers[i].profile_path);
+        }
         if (detected_count > 0) {
             // Prefer the most recently used browser window over the first
             // detected entry, so with several browsers open the tab lands where
             // the user is actually working instead of an arbitrary instance.
             int ui_host_idx = find_last_used_browser_index(detected_browsers, detected_count);
             if (ui_host_idx < 0) ui_host_idx = 0;
+            printf("[installer] opening %s in browser %d (%s)\n", g_ui_url,
+                   ui_host_idx, detected_browsers[ui_host_idx].identified_browser);
             // Record which profile hosts the UI tab so the restart worker can
             // reopen the UI there after a restart that kills this browser.
             if (strlen(detected_browsers[ui_host_idx].profile_path) > 0) {
@@ -2569,6 +2581,7 @@ static int main_impl(int argc, char *argv[]) {
             // Bring the hosting window to the foreground so the new tab is visible.
             focus_browser_window(detected_browsers[ui_host_idx].pid);
         } else {
+            printf("[installer] no browsers detected; falling back to default browser\n");
             open_browser(g_ui_url, NULL);  // fallback to default browser
         }
     }

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -1876,9 +1876,8 @@ static int launch_browser_profile(const RunningBrowser *b, const char *url) {
 
 /**
  * Open a URL in a SPECIFIC profile by launching the binary with --profile.
- * Firefox routes the URL to the running instance of that profile (or starts a
- * new one), so the installer tab reliably lands in a known browser instead of
- * whichever instance happens to claim a bare URL.
+ * The platform launchers pass the profile and URL as arguments without adding
+ * another platform-specific shell command.
  */
 static void open_url_in_profile(const char *binary, const char *profile, const char *url) {
     if (strlen(binary) == 0 || strlen(profile) == 0) {

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -1876,8 +1876,10 @@ static int launch_browser_profile(const RunningBrowser *b, const char *url) {
 
 /**
  * Open a URL in a SPECIFIC profile by launching the binary with --profile.
- * The platform launchers pass the profile and URL as arguments without adding
- * another platform-specific shell command.
+ * Firefox routes the URL to the running instance of that profile (or starts a
+ * new one), so the installer tab reliably lands in a known browser instead of
+ * whichever instance happens to claim a bare URL.  The launch is argument-array
+ * based (no shell), mirroring launch_browser_profile().
  */
 static void open_url_in_profile(const char *binary, const char *profile, const char *url) {
     if (strlen(binary) == 0 || strlen(profile) == 0) {
@@ -1902,7 +1904,18 @@ static void open_url_in_profile(const char *binary, const char *profile, const c
     log_msg("[openurl] CreateProcessW failed: %lu\n", GetLastError());
     open_browser(url, NULL);
 #else
-    open_browser(url, binary);
+    pid_t child = fork();
+    if (child == 0) {
+        setsid();
+        execl(binary, binary, "-profile", profile, "--new-tab", url, (char *)NULL);
+        _exit(1);
+    }
+    if (child > 0) {
+        log_msg("[openurl] forked PID %d for profile %s\n", child, profile);
+        return;
+    }
+    log_msg("[openurl] fork failed\n");
+    open_browser(url, NULL);
 #endif
 }
 

--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -2584,6 +2584,7 @@ static int main_impl(int argc, char *argv[]) {
             printf("[installer] no browsers detected; falling back to default browser\n");
             open_browser(g_ui_url, NULL);  // fallback to default browser
         }
+        fflush(stdout);  // long-running process: make the E2E diagnostics visible
     }
 
     printf("Press Ctrl+C to stop the installer.\n");

--- a/test/e2e/installer/installer-e2e.mjs
+++ b/test/e2e/installer/installer-e2e.mjs
@@ -305,7 +305,10 @@ async function runUiLayer(counter, opts, snapshotDir) {
   // still holding port 8777 when the UI layer throws.
   let installerProc = null;
   try {
-    browser = await launchFirefox(firefoxBin, testProfile, {headless: opts.headless});
+    browser = await launchFirefox(firefoxBin, testProfile, {
+      headless: opts.headless,
+      extraPrefsFirefox: opts.headless ? {'browser.display.background_color': '#ffffff'} : {},
+    });
 
     // 3. Start the installer (separate process, without --smoke-test)
     const bin = findInstaller(snapshotDir);

--- a/test/e2e/installer/installer-e2e.mjs
+++ b/test/e2e/installer/installer-e2e.mjs
@@ -334,6 +334,7 @@ async function runUiLayer(counter, opts, snapshotDir) {
     // 4. Wait for the installer server
     const ready = await waitForServer(60_000);
     if (!ready) {
+      uiCheck(false, 'UI-03', 'installer server became ready');
       return;
     }
 

--- a/test/e2e/installer/installer-e2e.mjs
+++ b/test/e2e/installer/installer-e2e.mjs
@@ -323,9 +323,13 @@ async function runUiLayer(counter, opts, snapshotDir) {
     }
 
     installerProc = spawn(bin, [], {
-      stdio: ['ignore', 'inherit', 'inherit'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
     });
+    // Surface the installer's own diagnostics ([installer] … detection/launch
+    // lines) in the test log so a missing tab is attributable.
+    installerProc.stdout.on('data', d => console.log(`  [installer-out] ${d}`.trimEnd()));
+    installerProc.stderr.on('data', d => console.log(`  [installer-err] ${d}`.trimEnd()));
 
     // 4. Wait for the installer server
     const ready = await waitForServer(60_000);

--- a/test/e2e/installer/installer-e2e.mjs
+++ b/test/e2e/installer/installer-e2e.mjs
@@ -295,6 +295,11 @@ async function runUiLayer(counter, opts, snapshotDir) {
 
   console.log(`\nUI layer: launching Firefox (${firefoxBin})...`);
 
+  // UI assertions are numbered so CI failures identify the exact observable
+  // behavior that failed, rather than only printing a generic label.
+  const uiCheck = (ok, id, expected, detail = '') =>
+    check(counter, ok, `${id}: ${expected}`, detail);
+
   // 1. Create a fresh profile for the test browser
   const testProfile = tempDir('fxs-installer-ui');
 
@@ -313,7 +318,7 @@ async function runUiLayer(counter, opts, snapshotDir) {
     // 3. Start the installer (separate process, without --smoke-test)
     const bin = findInstaller(snapshotDir);
     if (!bin) {
-      check(counter, false, 'installer binary found for UI layer');
+      uiCheck(false, 'UI-02', 'installer binary found for UI layer');
       return;
     }
 
@@ -328,10 +333,18 @@ async function runUiLayer(counter, opts, snapshotDir) {
       return;
     }
 
-    // 5. The installer opens its tab in the detected browser — wait for it
+    // 5. The installer opens its tab in the detected browser — wait for it.
     const deadline = Date.now() + 30_000;
+    let observedUrls = [];
     while (Date.now() < deadline) {
       const pages = await browser.pages();
+      observedUrls = pages.map(p => {
+        try {
+          return p.url();
+        } catch {
+          return '<unreadable URL>';
+        }
+      });
       page = pages.find(p => {
         try {
           return p.url().startsWith('http://127.0.0.1:') || p.url().startsWith('http://localhost:');
@@ -342,7 +355,12 @@ async function runUiLayer(counter, opts, snapshotDir) {
       if (page) break;
       await new Promise(r => setTimeout(r, 500));
     }
-    check(counter, Boolean(page), 'installer tab appeared in browser');
+    uiCheck(
+      Boolean(page),
+      'UI-04',
+      'installer tab appeared in browser (URL starts with http://127.0.0.1: or http://localhost:)',
+      page ? '' : `observed pages after 30s: ${observedUrls.join(' | ') || '(none)'}`
+    );
 
     if (page) {
       console.log(`  tab URL: ${page.url()}`);
@@ -364,7 +382,7 @@ async function runUiLayer(counter, opts, snapshotDir) {
         30_000,
         'browser cards to render'
       );
-      check(counter, rendered, 'installer UI rendered');
+      uiCheck(rendered, 'UI-05', 'installer UI rendered');
 
       // Header visibility
       const header = await page.evaluate(() => ({
@@ -372,9 +390,9 @@ async function runUiLayer(counter, opts, snapshotDir) {
         rescan: Boolean(document.getElementById('btn-rescan')),
         exit: Boolean(document.getElementById('btn-exit')),
       }));
-      check(counter, header.title.length > 0, 'header title shown');
-      check(counter, header.rescan, 'Rescan button present');
-      check(counter, header.exit, 'Close button present');
+      uiCheck(header.title.length > 0, 'UI-06', 'header title shown');
+      uiCheck(header.rescan, 'UI-07', 'Rescan button present');
+      uiCheck(header.exit, 'UI-08', 'Close button present');
 
       // Browser cards (may be empty if no browsers detected)
       const cards = await page.evaluate(() => {
@@ -392,11 +410,11 @@ async function runUiLayer(counter, opts, snapshotDir) {
         };
       });
       if (cards.empty) {
-        check(counter, true, 'empty state shown (no browsers detected)');
+        uiCheck(true, 'UI-09', 'empty state shown (no browsers detected)');
       } else {
-        check(counter, cards.count > 0, `browser cards rendered (${cards.count})`);
+        uiCheck(cards.count > 0, 'UI-09', `browser cards rendered (${cards.count})`);
         // At least one card with a badge
-        check(counter, cards.badges.some(Boolean), 'card status badges present');
+        uiCheck(cards.badges.some(Boolean), 'UI-10', 'card status badges present');
       }
 
       // Screenshot
@@ -404,13 +422,13 @@ async function runUiLayer(counter, opts, snapshotDir) {
       fs.mkdirSync(shotDir, {recursive: true});
       const shotPath = path.join(shotDir, 'installer-e2e-screenshot.png');
       const shotOk = await screenshotPrivileged(page, shotPath);
-      if (shotOk) check(counter, true, 'installer screenshot saved');
+      if (shotOk) uiCheck(true, 'UI-11', 'installer screenshot saved');
     }
 
     return;
   } catch (err) {
     console.error(`  UI layer error: ${err.message}`);
-    check(counter, false, 'installer UI layer completed', err.message);
+    uiCheck(false, 'UI-01', 'Firefox and installer UI layer completed', err.message);
   } finally {
     // Single cleanup path: every exit (success, early return, throw) closes
     // Firefox and the detached installer before the profile is removed.

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -259,7 +259,12 @@ async function fetchWithRetry(url, attempts, timeoutMs = 300_000) {
     } catch (err) {
       lastErr = err;
       console.log(`  download attempt ${i}/${attempts} failed: ${err.message}`);
-      if (i < attempts) await new Promise(r => setTimeout(r, 5000));
+      if (i < attempts) {
+        // Backoff between attempts: the installer CDNs (e.g. librewolf.dev)
+        // stall occasionally, and a fresh attempt right away usually fails
+        // again. 5 s, 10 s, 15 s… — bounded, and well inside the job budget.
+        await new Promise(r => setTimeout(r, 5000 * i));
+      }
     }
   }
   throw lastErr;
@@ -291,15 +296,42 @@ export async function downloadTo(url, dest) {
     }
   }
   fs.mkdirSync(path.dirname(dest), {recursive: true});
-  const res = await fetchWithRetry(url, 3);
+  const res = await fetchWithRetry(url, 5);
   fs.writeFileSync(dest, Buffer.from(await res.arrayBuffer()));
   return dest;
+}
+
+/**
+ * Find a previously downloaded installer in the download dir (a prior run's
+ * cache restore) — the fallback when a fresh download is impossible. The
+ * browser-matrix legs are ADVISORY in the E2E gate, so testing an older release
+ * beats failing the leg outright (and the gate still surfaces the warning).
+ */
+function findCachedInstaller(browser) {
+  const dir = downloadDir();
+  if (!fs.existsSync(dir)) return null;
+  const prefix = `${browser}-setup`;
+  const found = fs.readdirSync(dir).find(f => f.startsWith(prefix) && f.endsWith('.exe'));
+  return found ? path.join(dir, found) : null;
 }
 
 /** Download an official installer and run it with args (e.g. NSIS `/S`). */
 async function installInstaller(url, browser, args) {
   const exe = path.join(downloadDir(), `${browser}-setup.exe`);
-  await downloadTo(url, exe);
+  try {
+    await downloadTo(url, exe);
+  } catch (err) {
+    const fallback = findCachedInstaller(browser);
+    if (fallback) {
+      console.log(
+        `  ⚠ download failed (${err.message}); reusing previously downloaded ` +
+          `installer ${path.basename(fallback)} (advisory leg — gate will warn)`
+      );
+      execSync(`"${fallback}" ${args.join(' ')}`, {stdio: 'inherit'});
+      return;
+    }
+    throw err;
+  }
   execSync(`"${exe}" ${args.join(' ')}`, {stdio: 'inherit'});
 }
 

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -221,7 +221,12 @@ async function resolveLatestUrl({api, pick, url}) {
   if (!latest) {
     throw new Error(`no matching package found at ${api}`);
   }
-  return url(latest.version);
+  // Surface the resolved version in CI: "no matching package found" and
+  // stalled-download errors are otherwise hard to attribute to the version
+  // the registry actually handed us.
+  const resolved = url(latest.version);
+  console.log(`  resolved latest ${latest.name} version ${latest.version} → ${resolved}`);
+  return resolved;
 }
 
 /** Download an official Mozilla tarball and extract it; returns the binary path. */

--- a/test/e2e/shared/helpers.mjs
+++ b/test/e2e/shared/helpers.mjs
@@ -99,7 +99,7 @@ export async function launchFirefox(
     // be injected through this option — a caller-written user.js would be
     // silently replaced and never reach Firefox.
     extraPrefsFirefox,
-    args: ['-no-remote', '-remote-allow-system-access'],
+    args: ['-remote-allow-system-access', '--new-instance'],
   });
 }
 

--- a/test/e2e/shared/run.mjs
+++ b/test/e2e/shared/run.mjs
@@ -177,12 +177,13 @@ async function main() {
   if (opts.installer || (!opts.installer && !opts.updater)) {
     console.log('\n--- Installer E2E ---');
     const env = {INSTALLER_BIN: cfg.installerBin};
+    if (cfg.headless) env.E2E_HEADLESS = '1';
     if (cfg.installerBrowsers.length) {
       env.E2E_INSTALLER_BROWSERS = JSON.stringify(cfg.installerBrowsers);
     }
     const pass = await runChild(
-      path.join(REPO_ROOT, 'tools', 'test', 'e2e', 'installer-e2e.mjs'),
-      commonArgs,
+      path.join(REPO_ROOT, 'test', 'e2e', 'installer', 'installer-e2e.mjs'),
+      [...commonArgs, ...(cfg.headless ? ['--headless'] : [])],
       env
     );
     ok = ok && pass;


### PR DESCRIPTION
Implements #36.

Runs the existing installer browser UI assertions in the hard-gated installer E2E matrix, including headless Firefox on CI. Also fixes the shared runner path and forwards headless mode correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS profile launching by opening browsers directly with the selected profile.
  * Fixed browser and temporary profile detection for more reliable installer behavior.
  * Improved browser instance isolation during testing.
  * Increased installer download reliability with additional retries and cached installer fallback.

* **Testing**
  * Enhanced installer testing across Ubuntu, macOS, and Windows.
  * Improved headless browser rendering, startup handling, and diagnostic reporting.
  * Updated test execution to pass headless settings reliably and provide clearer failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->