### PR TITLE
test(e2e): add portable Firefox Release matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -261,6 +261,89 @@ jobs:
             dist/installer-e2e-*.png
           if-no-files-found: ignore
 
+  # ── Portable Firefox Release E2E (#56) ────────────────────────────────────
+  # Firefox Release is installed into a runner-temp custom directory rather
+  # than Program Files, /Applications, or a package-managed location. The
+  # existing installer and updater tests then exercise detection, GreD
+  # discovery, installation, and updater-tab behavior against that binary.
+  portable-firefox:
+    name: 'portable Firefox E2E · ${{ matrix.os }}'
+    needs: [changes, snapshot]
+    if: needs.changes.outputs.updater == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+    steps:
+      - uses: $/.github/actions/setup-repo
+
+      - name: Set portable browser directory
+        shell: bash
+        run: |
+          echo "PORTABLE_BROWSER_DIR=${{ runner.temp }}/firefox-portable" >> "$GITHUB_ENV"
+          mkdir -p "${{ runner.temp }}/firefox-portable"
+
+      - name: Resolve Firefox Release download URL
+        id: portable-url
+        shell: bash
+        run: |
+          URL=$(node test/e2e/shared/downloads.mjs firefox --url)
+          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          echo "key=firefox-portable-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
+          echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
+
+      - name: Cache Firefox Release download
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.BROWSER_DL_DIR }}
+          key: ${{ steps.portable-url.outputs.key }}
+
+      - name: Install Firefox Release portably
+        shell: bash
+        run: node test/e2e/shared/downloads.mjs firefox
+
+      - name: Assert portable layout
+        shell: bash
+        run: |
+          case "$FIREFOX_BINARY" in
+            "$PORTABLE_BROWSER_DIR"/*) ;;
+            *) echo "::error::Firefox binary is not inside portable directory: $FIREFOX_BINARY"; exit 1 ;;
+          esac
+          test -f "$FIREFOX_BINARY"
+          echo "Portable Firefox: $FIREFOX_BINARY"
+
+      - name: Download dev snapshot
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: dev-snapshot
+          path: dist/
+
+      - name: Install Linux test prerequisites
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+
+      - name: Run portable installer E2E (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: xvfb-run -a node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run portable installer E2E (macOS/Windows)
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        run: node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run portable updater E2E (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: xvfb-run -a node test/e2e/updater/updater-e2e.mjs
+
+      - name: Run portable updater E2E (macOS/Windows)
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        run: node test/e2e/updater/updater-e2e.mjs
+
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
   # Each browser downloads an official installer directly: LibreWolf resolves
   # its newest version from the Codeberg package registry; Floorp and Zen use
@@ -343,7 +426,7 @@ jobs:
     name: E2E gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [changes, snapshot, installer, helper, updater, browser-matrix]
+    needs: [changes, snapshot, installer, helper, updater, portable-firefox, browser-matrix]
     steps:
       # Local action — a fresh runner needs the repo checked out first.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -359,6 +442,7 @@ jobs:
             installer:${{ needs.changes.outputs.installer == 'true' }}
             helper:${{ needs.changes.outputs.updater == 'true' }}
             updater:${{ needs.changes.outputs.updater == 'true' }}
+            portable-firefox:${{ needs.changes.outputs.updater == 'true' }}
             browser-matrix:${{ needs.changes.outputs.updater == 'true' || needs.changes.outputs.core == 'true' }}
           # Literal block: prettier leaves `|` content alone, so each pair
           # stays on its own line and no ${{ }} expression is ever split.
@@ -368,7 +452,8 @@ jobs:
             installer:${{ needs.installer.result }}
             helper:${{ needs.helper.result }}
             updater:${{ needs.updater.result }}
+            portable-firefox:${{ needs.portable-firefox.result }}
             browser-matrix:${{ needs.browser-matrix.result }}
-          required: snapshot installer helper updater
+          required: snapshot installer helper updater portable-firefox
           advisory: browser-matrix
-          skip-guard: snapshot installer helper updater browser-matrix
+          skip-guard: snapshot installer helper updater portable-firefox browser-matrix

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -379,7 +379,9 @@ jobs:
           case "${{ runner.os }}" in
             Linux) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_linux-dev" >> "$GITHUB_ENV" ;;
             macOS) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_mac-dev" >> "$GITHUB_ENV" ;;
-            Windows) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_win-dev.exe" >> "$GITHUB_ENV" ;;
+            # github.workspace expands to a native Windows path (D:\a\...);
+            # $PWD would be MSYS-style (/d/a/...) which Node's fs cannot use.
+            Windows) echo "INSTALLER_BIN=${{ github.workspace }}\\dist\\installer\\installer_win-dev.exe" >> "$GITHUB_ENV" ;;
           esac
           chmod +x dist/installer/installer_* 2>/dev/null || true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -279,7 +279,9 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: ./.github/actions/setup-repo
+      # $/ prefix: the runner materializes the local action from the triggering
+      # commit — a ./ local action would need a checkout step first.
+      - uses: $/.github/actions/setup-repo
 
       - name: Set portable browser directory (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -407,6 +407,18 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
         run: node test/e2e/updater/updater-e2e.mjs
 
+      # Same failure diagnostics as the installer/updater jobs: the E2E
+      # harness leaves failure screenshots in dist/ for artifact upload.
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-diagnostics-portable-firefox-${{ matrix.os }}
+          path: |
+            dist/installer-e2e-*.png
+            dist/updater-e2e-*.png
+          if-no-files-found: ignore
+
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
   # Each browser downloads an official installer directly: LibreWolf resolves
   # its newest version from the Codeberg package registry; Floorp and Zen use

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -322,6 +322,24 @@ jobs:
           name: dev-snapshot
           path: dist/
 
+      # The shared snapshot is built on Ubuntu and therefore contains only the
+      # Linux installer. Build the native installer locally for this runner;
+      # package zips remain sourced from the shared snapshot.
+      - name: Build native installer
+        shell: bash
+        run: |
+          case "${{ runner.os }}" in
+            Linux) make -C installer dist_linux MODE=dev ;;
+            macOS) make -C installer dist_mac MODE=dev ;;
+            Windows) make -C installer dist_win MODE=dev ;;
+          esac
+          case "${{ runner.os }}" in
+            Linux) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_linux-dev" >> "$GITHUB_ENV" ;;
+            macOS) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_mac-dev" >> "$GITHUB_ENV" ;;
+            Windows) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_win-dev.exe" >> "$GITHUB_ENV" ;;
+          esac
+          chmod +x dist/installer/installer_* 2>/dev/null || true
+
       - name: Install Linux test prerequisites
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -203,7 +203,7 @@ jobs:
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs ${{ matrix.browser }} --url)
-          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          KEY=$(node --input-type=module -e "import {createHash} from 'node:crypto'; console.log(createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "key=firefox-dl-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
@@ -292,7 +292,7 @@ jobs:
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs firefox --url)
-          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          KEY=$(node --input-type=module -e "import {createHash} from 'node:crypto'; console.log(createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
           echo "key=firefox-portable-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
 
@@ -379,7 +379,7 @@ jobs:
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs ${{ matrix.browser }} --url)
-          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          KEY=$(node --input-type=module -e "import {createHash} from 'node:crypto'; console.log(createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
           echo "key=browser-dl-${{ runner.os }}-${{ matrix.browser }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
       - name: Cache ${{ matrix.browser }} installer

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -279,7 +279,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: $/.github/actions/setup-repo
+      - uses: ./.github/actions/setup-repo
 
       - name: Set portable browser directory (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -296,8 +296,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
           "PORTABLE_BROWSER_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Resolve Firefox Release download URL
-        id: portable-url
+      - name: Resolve Firefox Release download URL (Linux/macOS)
+        id: portable-url-unix
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs firefox --url)
@@ -305,11 +306,23 @@ jobs:
           echo "key=firefox-portable-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
 
+      - name: Resolve Firefox Release download URL (Windows)
+        id: portable-url-windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $url = node test/e2e/shared/downloads.mjs firefox --url
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+          $sha = [System.Security.Cryptography.SHA256]::HashData($bytes)
+          $key = ([Convert]::ToHexString($sha)).ToLowerInvariant().Substring(0, 16)
+          "key=firefox-portable-${{ runner.os }}-$key" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "BROWSER_DL_DIR=$(Join-Path $env:RUNNER_TEMP 'browser-dl')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache Firefox Release download
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.BROWSER_DL_DIR }}
-          key: ${{ steps.portable-url.outputs.key }}
+          key: ${{ steps.portable-url-unix.outputs.key || steps.portable-url-windows.outputs.key }}
 
       - name: Install Firefox Release portably (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -281,11 +281,20 @@ jobs:
     steps:
       - uses: $/.github/actions/setup-repo
 
-      - name: Set portable browser directory
+      - name: Set portable browser directory (Linux/macOS)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           echo "PORTABLE_BROWSER_DIR=${{ runner.temp }}/firefox-portable" >> "$GITHUB_ENV"
           mkdir -p "${{ runner.temp }}/firefox-portable"
+
+      - name: Set portable browser directory (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dir = Join-Path $env:RUNNER_TEMP 'firefox-portable'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          "PORTABLE_BROWSER_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Resolve Firefox Release download URL
         id: portable-url
@@ -302,11 +311,18 @@ jobs:
           path: ${{ env.BROWSER_DL_DIR }}
           key: ${{ steps.portable-url.outputs.key }}
 
-      - name: Install Firefox Release portably
+      - name: Install Firefox Release portably (Linux/macOS)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: node test/e2e/shared/downloads.mjs firefox
 
-      - name: Assert portable layout
+      - name: Install Firefox Release portably (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: node test/e2e/shared/downloads.mjs firefox
+
+      - name: Assert portable layout (Linux/macOS)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           case "$FIREFOX_BINARY" in
@@ -315,6 +331,18 @@ jobs:
           esac
           test -f "$FIREFOX_BINARY"
           echo "Portable Firefox: $FIREFOX_BINARY"
+
+      - name: Assert portable layout (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not $env:FIREFOX_BINARY.StartsWith($env:PORTABLE_BROWSER_DIR, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Firefox binary is not inside portable directory: $env:FIREFOX_BINARY"
+          }
+          if (-not (Test-Path -LiteralPath $env:FIREFOX_BINARY -PathType Leaf)) {
+            throw "Firefox binary not found: $env:FIREFOX_BINARY"
+          }
+          Write-Host "Portable Firefox: $env:FIREFOX_BINARY"
 
       - name: Download dev snapshot
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -350,10 +350,10 @@ async function installPortableFirefox(url, platform) {
     await downloadTo(url, exe);
     // NSIS /D must be the final argument and uses a custom directory instead
     // of the registered Program Files location.
-    // Run through cmd.exe so Git Bash does not rewrite the Windows path.
-    // NSIS requires /D= as the final argument; quoting the value preserves
-    // spaces in runner.temp paths while keeping the whole option one argv item.
-    const result = spawnSync('cmd.exe', ['/d', '/s', '/c', `"${exe}" /S /D="${dest}"`], {
+    // Pass the final /D= option directly to NSIS. PowerShell launches this
+    // Node process with native Windows paths, and verbatim arguments prevent
+    // MSYS/Git Bash path rewriting when the same helper is used locally.
+    const result = spawnSync(exe, ['/S', `/D=${dest}`], {
       stdio: 'inherit',
       windowsVerbatimArguments: true,
     });
@@ -417,6 +417,13 @@ async function installDmg(url, appName) {
     if (device || mountPoint) {
       execSync(`hdiutil detach "${device || mountPoint}"`);
     }
+  }
+}
+
+/** Export the resolved browser binary for GitHub Actions callers. */
+export function exportBinaryPath(binary) {
+  if (process.env.GITHUB_ENV) {
+    fs.appendFileSync(process.env.GITHUB_ENV, `FIREFOX_BINARY=${binary}\n`);
   }
 }
 
@@ -517,9 +524,7 @@ Release into a custom directory instead of a system location. With --url, prints
 
   const binary = await installBrowser(browser, normalized);
   console.log(binary);
-  if (process.env.GITHUB_ENV) {
-    fs.appendFileSync(process.env.GITHUB_ENV, `FIREFOX_BINARY=${binary}\n`);
-  }
+  exportBinaryPath(binary);
 }
 
 // Basename (not endsWith) so modules with a similar name — e.g.

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -369,11 +369,15 @@ async function installPortableFirefox(url, platform) {
   if (platform === 'darwin') {
     const dmg = path.join(downloadDir(), 'firefox-portable.dmg');
     await downloadTo(url, dmg);
+    // Same hardened parse as installDmg below: the mount point is the last
+    // column and may contain spaces, so take everything after `/Volumes/` on
+    // matching lines and keep the device for cleanup.
     const out = execSync(`hdiutil attach -nobrowse -readonly "${dmg}"`).toString();
-    const mount = out
+    const mounts = out
       .split('\n')
-      .map(line => line.slice(line.indexOf('/Volumes/')).trim())
-      .find(line => line.startsWith('/Volumes/'));
+      .filter(line => line.includes('/Volumes/'))
+      .map(line => line.slice(line.indexOf('/Volumes/')).trim());
+    const mount = mounts[mounts.length - 1];
     const device = (out.match(/\/dev\/disk\S+/g) || [])[0];
     try {
       if (!mount) throw new Error(`cannot find Firefox DMG mount point: ${out}`);

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -350,9 +350,13 @@ async function installPortableFirefox(url, platform) {
     await downloadTo(url, exe);
     // NSIS /D must be the final argument and uses a custom directory instead
     // of the registered Program Files location.
-    // Pass the destination as one argv item. Quoting the value inside the
-    // /D= argument preserves spaces in runner.temp paths for NSIS.
-    const result = spawnSync(exe, ['/S', `/D="${dest}"`], {stdio: 'inherit'});
+    // Run through cmd.exe so Git Bash does not rewrite the Windows path.
+    // NSIS requires /D= as the final argument; quoting the value preserves
+    // spaces in runner.temp paths while keeping the whole option one argv item.
+    const result = spawnSync('cmd.exe', ['/d', '/s', '/c', `"${exe}" /S /D="${dest}"`], {
+      stdio: 'inherit',
+      windowsVerbatimArguments: true,
+    });
     if (result.error) throw result.error;
     if (result.status !== 0) {
       throw new Error(`Firefox portable installer exited with code ${result.status}`);

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -231,7 +231,7 @@ async function resolveLatestUrl({api, pick, url}) {
 
 /** Download an official Mozilla tarball and extract it; returns the binary path. */
 async function installTarball(url, browser) {
-  const dest = path.join(os.homedir(), 'firefox-app');
+  const dest = process.env.PORTABLE_BROWSER_DIR || path.join(os.homedir(), 'firefox-app');
   const archive = path.join(downloadDir(), `firefox-${browser}.tar.xz`);
   fs.mkdirSync(dest, {recursive: true});
 
@@ -335,6 +335,51 @@ async function installInstaller(url, browser, args) {
   execSync(`"${exe}" ${args.join(' ')}`, {stdio: 'inherit'});
 }
 
+/** Download Firefox Release into a custom, non-registered directory. */
+async function installPortableFirefox(url, platform) {
+  const dest = process.env.PORTABLE_BROWSER_DIR;
+  if (!dest) throw new Error('PORTABLE_BROWSER_DIR is required for portable Firefox');
+  fs.mkdirSync(dest, {recursive: true});
+
+  if (platform === 'linux') {
+    const binary = await installTarball(url, 'firefox-portable');
+    return binary;
+  }
+
+  if (platform === 'win32') {
+    const exe = path.join(downloadDir(), 'firefox-portable-setup.exe');
+    await downloadTo(url, exe);
+    // NSIS /D must be the final argument and uses a custom directory instead
+    // of the registered Program Files location.
+    execSync(`"${exe}" /S /D=${dest}`, {stdio: 'inherit'});
+    const binary = path.join(dest, 'firefox.exe');
+    if (!fs.existsSync(binary)) throw new Error(`portable Firefox binary not found: ${binary}`);
+    return binary;
+  }
+
+  if (platform === 'darwin') {
+    const dmg = path.join(downloadDir(), 'firefox-portable.dmg');
+    await downloadTo(url, dmg);
+    const out = execSync(`hdiutil attach -nobrowse -readonly "${dmg}"`).toString();
+    const mount = out
+      .split('\n')
+      .map(line => line.slice(line.indexOf('/Volumes/')).trim())
+      .find(line => line.startsWith('/Volumes/'));
+    const device = (out.match(/\/dev\/disk\S+/g) || [])[0];
+    try {
+      if (!mount) throw new Error(`cannot find Firefox DMG mount point: ${out}`);
+      execSync(`cp -R "${mount}/Firefox.app" "${dest}/"`);
+    } finally {
+      if (device || mount) execSync(`hdiutil detach "${device || mount}"`);
+    }
+    const binary = path.join(dest, 'Firefox.app', 'Contents', 'MacOS', 'firefox');
+    if (!fs.existsSync(binary)) throw new Error(`portable Firefox binary not found: ${binary}`);
+    return binary;
+  }
+
+  throw new Error(`unsupported portable Firefox platform: ${platform}`);
+}
+
 /** Download an official dmg, mount it, and copy the app into /Applications. */
 async function installDmg(url, appName) {
   const dmg = path.join(downloadDir(), `${appName.replace(/\.app$/, '')}.dmg`);
@@ -386,6 +431,17 @@ export async function installBrowser(browser, platform = process.platform) {
         (def.page ? ` — manual install only (official page: ${def.page})` : '')
     );
   }
+  if (browser === 'firefox' && process.env.PORTABLE_BROWSER_DIR) {
+    const url = recipe.tarball || recipe.url;
+    const binary = await installPortableFirefox(
+      url,
+      key === 'win' ? 'win32'
+      : key === 'mac' ? 'darwin'
+      : 'linux'
+    );
+    console.log(`  ${browser} installed portably: ${binary}`);
+    return binary;
+  }
   if (recipe.tarball) {
     const binary = await installTarball(recipe.tarball, browser);
     console.log(`  ${browser} installed from official tarball: ${binary}`);
@@ -431,7 +487,8 @@ async function main() {
 
 Installs <browser> for the current OS (or --os) using its official download
 recipe, then prints the resolved binary path and, in GitHub Actions, sets
-FIREFOX_BINARY via $GITHUB_ENV. With --url, prints the download URL instead
+FIREFOX_BINARY via $GITHUB_ENV. Set PORTABLE_BROWSER_DIR to install Firefox
+Release into a custom directory instead of a system location. With --url, prints the download URL instead
 (used to key the CI download cache).`);
     process.exit(browser ? 0 : 1);
   }

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -20,7 +20,7 @@
  * official download page instead; the CLI fails with a clear message.
  */
 
-import {execSync} from 'node:child_process';
+import {execSync, spawnSync} from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -230,8 +230,7 @@ async function resolveLatestUrl({api, pick, url}) {
 }
 
 /** Download an official Mozilla tarball and extract it; returns the binary path. */
-async function installTarball(url, browser) {
-  const dest = process.env.PORTABLE_BROWSER_DIR || path.join(os.homedir(), 'firefox-app');
+async function installTarball(url, browser, dest = path.join(os.homedir(), 'firefox-app')) {
   const archive = path.join(downloadDir(), `firefox-${browser}.tar.xz`);
   fs.mkdirSync(dest, {recursive: true});
 
@@ -342,7 +341,7 @@ async function installPortableFirefox(url, platform) {
   fs.mkdirSync(dest, {recursive: true});
 
   if (platform === 'linux') {
-    const binary = await installTarball(url, 'firefox-portable');
+    const binary = await installTarball(url, 'firefox-portable', dest);
     return binary;
   }
 
@@ -351,7 +350,13 @@ async function installPortableFirefox(url, platform) {
     await downloadTo(url, exe);
     // NSIS /D must be the final argument and uses a custom directory instead
     // of the registered Program Files location.
-    execSync(`"${exe}" /S /D=${dest}`, {stdio: 'inherit'});
+    // Pass the destination as one argv item. Quoting the value inside the
+    // /D= argument preserves spaces in runner.temp paths for NSIS.
+    const result = spawnSync(exe, ['/S', `/D="${dest}"`], {stdio: 'inherit'});
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`Firefox portable installer exited with code ${result.status}`);
+    }
     const binary = path.join(dest, 'firefox.exe');
     if (!fs.existsSync(binary)) throw new Error(`portable Firefox binary not found: ${binary}`);
     return binary;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for running installer and updater tests with a portable Firefox installation across Linux, Windows, and macOS.
  * Added platform-specific portable browser setup and validation.
  * Updated end-to-end checks so the release gate includes portable Firefox coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->