### PR TITLE
feat(ci): hard-gate prod publish on E2E-validated browser versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -535,17 +535,21 @@ jobs:
 
   # ── Record validated browser versions (#4) ────────────────────────────────
   # After every hard-gate E2E leg passed, record the exact firefox /
-  # firefox-dev versions this run validated into .watchdog/validated.json
-  # (Actions cache, rotating key — same pattern as the watchdog baseline).
-  # The prod publish pre-flight requires the current releases to be covered
-  # by this record, so a watchdog baseline refresh alone cannot satisfy the
-  # drift gate: the shipped browser versions must have a passing E2E run.
+  # firefox-dev versions this run validated into .watchdog-validated/
+  # (Actions cache, rotating key — same pattern as the watchdog baseline;
+  # a dedicated dir so the publish pre-flight's baseline restore can never
+  # clobber it). The prod publish pre-flight requires the current releases
+  # to be covered by this record, so a watchdog baseline refresh alone
+  # cannot satisfy the drift gate: the shipped browser versions must have
+  # a passing E2E run.
   record-validation:
     name: record validated browser versions
     needs: [changes, e2e-gate]
+    # e2e-gate success already proves every hard-gate leg ran and passed
+    # (the gate is if: always() and reports all results), so no additional
+    # changed-paths condition: a core-only change still records validation.
     if: >-
-      needs.e2e-gate.result == 'success' && needs.changes.outputs.updater == 'true' &&
-      github.event_name != 'pull_request'
+      needs.e2e-gate.result == 'success' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -554,11 +558,11 @@ jobs:
           node-version: 24
       - name: Record validated browser versions
         env:
-          VALIDATED_DIR: .watchdog
+          VALIDATED_DIR: .watchdog-validated
         run: node tools/ci/record-validated-versions.mjs
       - name: Save validated-versions record
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: .watchdog
+          path: .watchdog-validated
           key: browser-validated-${{ github.run_id }}
           save-always: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -261,6 +261,89 @@ jobs:
             dist/installer-e2e-*.png
           if-no-files-found: ignore
 
+  # ── Portable Firefox Release E2E (#56) ────────────────────────────────────
+  # Firefox Release is installed into a runner-temp custom directory rather
+  # than Program Files, /Applications, or a package-managed location. The
+  # existing installer and updater tests then exercise detection, GreD
+  # discovery, installation, and updater-tab behavior against that binary.
+  portable-firefox:
+    name: 'portable Firefox E2E · ${{ matrix.os }}'
+    needs: [changes, snapshot]
+    if: needs.changes.outputs.updater == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+    steps:
+      - uses: $/.github/actions/setup-repo
+
+      - name: Set portable browser directory
+        shell: bash
+        run: |
+          echo "PORTABLE_BROWSER_DIR=${{ runner.temp }}/firefox-portable" >> "$GITHUB_ENV"
+          mkdir -p "${{ runner.temp }}/firefox-portable"
+
+      - name: Resolve Firefox Release download URL
+        id: portable-url
+        shell: bash
+        run: |
+          URL=$(node test/e2e/shared/downloads.mjs firefox --url)
+          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          echo "key=firefox-portable-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
+          echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
+
+      - name: Cache Firefox Release download
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.BROWSER_DL_DIR }}
+          key: ${{ steps.portable-url.outputs.key }}
+
+      - name: Install Firefox Release portably
+        shell: bash
+        run: node test/e2e/shared/downloads.mjs firefox
+
+      - name: Assert portable layout
+        shell: bash
+        run: |
+          case "$FIREFOX_BINARY" in
+            "$PORTABLE_BROWSER_DIR"/*) ;;
+            *) echo "::error::Firefox binary is not inside portable directory: $FIREFOX_BINARY"; exit 1 ;;
+          esac
+          test -f "$FIREFOX_BINARY"
+          echo "Portable Firefox: $FIREFOX_BINARY"
+
+      - name: Download dev snapshot
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: dev-snapshot
+          path: dist/
+
+      - name: Install Linux test prerequisites
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+
+      - name: Run portable installer E2E (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: xvfb-run -a node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run portable installer E2E (macOS/Windows)
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        run: node test/e2e/installer/installer-e2e.mjs --ui --headless
+
+      - name: Run portable updater E2E (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: xvfb-run -a node test/e2e/updater/updater-e2e.mjs
+
+      - name: Run portable updater E2E (macOS/Windows)
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        run: node test/e2e/updater/updater-e2e.mjs
+
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
   # Each browser downloads an official installer directly: LibreWolf resolves
   # its newest version from the Codeberg package registry; Floorp and Zen use
@@ -343,7 +426,7 @@ jobs:
     name: E2E gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [changes, snapshot, installer, helper, updater, browser-matrix]
+    needs: [changes, snapshot, installer, helper, updater, portable-firefox, browser-matrix]
     steps:
       # Local action — a fresh runner needs the repo checked out first.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -359,6 +442,7 @@ jobs:
             installer:${{ needs.changes.outputs.installer == 'true' }}
             helper:${{ needs.changes.outputs.updater == 'true' }}
             updater:${{ needs.changes.outputs.updater == 'true' }}
+            portable-firefox:${{ needs.changes.outputs.updater == 'true' }}
             browser-matrix:${{ needs.changes.outputs.updater == 'true' || needs.changes.outputs.core == 'true' }}
           # Literal block: prettier leaves `|` content alone, so each pair
           # stays on its own line and no ${{ }} expression is ever split.
@@ -368,7 +452,8 @@ jobs:
             installer:${{ needs.installer.result }}
             helper:${{ needs.helper.result }}
             updater:${{ needs.updater.result }}
+            portable-firefox:${{ needs.portable-firefox.result }}
             browser-matrix:${{ needs.browser-matrix.result }}
-          required: snapshot installer helper updater
+          required: snapshot installer helper updater portable-firefox
           advisory: browser-matrix
-          skip-guard: snapshot installer helper updater browser-matrix
+          skip-guard: snapshot installer helper updater portable-firefox browser-matrix

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -532,3 +532,33 @@ jobs:
           required: snapshot installer helper updater portable-firefox
           advisory: browser-matrix
           skip-guard: snapshot installer helper updater portable-firefox browser-matrix
+
+  # ── Record validated browser versions (#4) ────────────────────────────────
+  # After every hard-gate E2E leg passed, record the exact firefox /
+  # firefox-dev versions this run validated into .watchdog/validated.json
+  # (Actions cache, rotating key — same pattern as the watchdog baseline).
+  # The prod publish pre-flight requires the current releases to be covered
+  # by this record, so a watchdog baseline refresh alone cannot satisfy the
+  # drift gate: the shipped browser versions must have a passing E2E run.
+  record-validation:
+    name: record validated browser versions
+    needs: [changes, e2e-gate]
+    if: >-
+      needs.e2e-gate.result == 'success' && needs.changes.outputs.updater == 'true' &&
+      github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Record validated browser versions
+        env:
+          VALIDATED_DIR: .watchdog
+        run: node tools/ci/record-validated-versions.mjs
+      - name: Save validated-versions record
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .watchdog
+          key: browser-validated-${{ github.run_id }}
+          save-always: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -379,7 +379,9 @@ jobs:
           case "${{ runner.os }}" in
             Linux) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_linux-dev" >> "$GITHUB_ENV" ;;
             macOS) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_mac-dev" >> "$GITHUB_ENV" ;;
-            Windows) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_win-dev.exe" >> "$GITHUB_ENV" ;;
+            # github.workspace expands to a native Windows path (D:\a\...);
+            # $PWD would be MSYS-style (/d/a/...) which Node's fs cannot use.
+            Windows) echo "INSTALLER_BIN=${{ github.workspace }}\\dist\\installer\\installer_win-dev.exe" >> "$GITHUB_ENV" ;;
           esac
           chmod +x dist/installer/installer_* 2>/dev/null || true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -279,7 +279,9 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: ./.github/actions/setup-repo
+      # $/ prefix: the runner materializes the local action from the triggering
+      # commit — a ./ local action would need a checkout step first.
+      - uses: $/.github/actions/setup-repo
 
       - name: Set portable browser directory (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -407,6 +407,18 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
         run: node test/e2e/updater/updater-e2e.mjs
 
+      # Same failure diagnostics as the installer/updater jobs: the E2E
+      # harness leaves failure screenshots in dist/ for artifact upload.
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-diagnostics-portable-firefox-${{ matrix.os }}
+          path: |
+            dist/installer-e2e-*.png
+            dist/updater-e2e-*.png
+          if-no-files-found: ignore
+
   # ── Browser matrix (advisory, Windows) ────────────────────────────────────
   # Each browser downloads an official installer directly: LibreWolf resolves
   # its newest version from the Codeberg package registry; Floorp and Zen use

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -322,6 +322,24 @@ jobs:
           name: dev-snapshot
           path: dist/
 
+      # The shared snapshot is built on Ubuntu and therefore contains only the
+      # Linux installer. Build the native installer locally for this runner;
+      # package zips remain sourced from the shared snapshot.
+      - name: Build native installer
+        shell: bash
+        run: |
+          case "${{ runner.os }}" in
+            Linux) make -C installer dist_linux MODE=dev ;;
+            macOS) make -C installer dist_mac MODE=dev ;;
+            Windows) make -C installer dist_win MODE=dev ;;
+          esac
+          case "${{ runner.os }}" in
+            Linux) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_linux-dev" >> "$GITHUB_ENV" ;;
+            macOS) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_mac-dev" >> "$GITHUB_ENV" ;;
+            Windows) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_win-dev.exe" >> "$GITHUB_ENV" ;;
+          esac
+          chmod +x dist/installer/installer_* 2>/dev/null || true
+
       - name: Install Linux test prerequisites
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -203,7 +203,7 @@ jobs:
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs ${{ matrix.browser }} --url)
-          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          KEY=$(node --input-type=module -e "import {createHash} from 'node:crypto'; console.log(createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "key=firefox-dl-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
@@ -292,7 +292,7 @@ jobs:
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs firefox --url)
-          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          KEY=$(node --input-type=module -e "import {createHash} from 'node:crypto'; console.log(createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
           echo "key=firefox-portable-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
 
@@ -379,7 +379,7 @@ jobs:
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs ${{ matrix.browser }} --url)
-          KEY=$(node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
+          KEY=$(node --input-type=module -e "import {createHash} from 'node:crypto'; console.log(createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 16))" "$URL")
           echo "key=browser-dl-${{ runner.os }}-${{ matrix.browser }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
       - name: Cache ${{ matrix.browser }} installer

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -279,7 +279,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
-      - uses: $/.github/actions/setup-repo
+      - uses: ./.github/actions/setup-repo
 
       - name: Set portable browser directory (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -296,8 +296,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
           "PORTABLE_BROWSER_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Resolve Firefox Release download URL
-        id: portable-url
+      - name: Resolve Firefox Release download URL (Linux/macOS)
+        id: portable-url-unix
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           URL=$(node test/e2e/shared/downloads.mjs firefox --url)
@@ -305,11 +306,23 @@ jobs:
           echo "key=firefox-portable-${{ runner.os }}-$KEY" >> "$GITHUB_OUTPUT"
           echo "BROWSER_DL_DIR=${{ runner.temp }}/browser-dl" >> "$GITHUB_ENV"
 
+      - name: Resolve Firefox Release download URL (Windows)
+        id: portable-url-windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $url = node test/e2e/shared/downloads.mjs firefox --url
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($url)
+          $sha = [System.Security.Cryptography.SHA256]::HashData($bytes)
+          $key = ([Convert]::ToHexString($sha)).ToLowerInvariant().Substring(0, 16)
+          "key=firefox-portable-${{ runner.os }}-$key" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "BROWSER_DL_DIR=$(Join-Path $env:RUNNER_TEMP 'browser-dl')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Cache Firefox Release download
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.BROWSER_DL_DIR }}
-          key: ${{ steps.portable-url.outputs.key }}
+          key: ${{ steps.portable-url-unix.outputs.key || steps.portable-url-windows.outputs.key }}
 
       - name: Install Firefox Release portably (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -281,11 +281,20 @@ jobs:
     steps:
       - uses: $/.github/actions/setup-repo
 
-      - name: Set portable browser directory
+      - name: Set portable browser directory (Linux/macOS)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           echo "PORTABLE_BROWSER_DIR=${{ runner.temp }}/firefox-portable" >> "$GITHUB_ENV"
           mkdir -p "${{ runner.temp }}/firefox-portable"
+
+      - name: Set portable browser directory (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dir = Join-Path $env:RUNNER_TEMP 'firefox-portable'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          "PORTABLE_BROWSER_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Resolve Firefox Release download URL
         id: portable-url
@@ -302,11 +311,18 @@ jobs:
           path: ${{ env.BROWSER_DL_DIR }}
           key: ${{ steps.portable-url.outputs.key }}
 
-      - name: Install Firefox Release portably
+      - name: Install Firefox Release portably (Linux/macOS)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: node test/e2e/shared/downloads.mjs firefox
 
-      - name: Assert portable layout
+      - name: Install Firefox Release portably (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: node test/e2e/shared/downloads.mjs firefox
+
+      - name: Assert portable layout (Linux/macOS)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           case "$FIREFOX_BINARY" in
@@ -315,6 +331,18 @@ jobs:
           esac
           test -f "$FIREFOX_BINARY"
           echo "Portable Firefox: $FIREFOX_BINARY"
+
+      - name: Assert portable layout (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not $env:FIREFOX_BINARY.StartsWith($env:PORTABLE_BROWSER_DIR, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Firefox binary is not inside portable directory: $env:FIREFOX_BINARY"
+          }
+          if (-not (Test-Path -LiteralPath $env:FIREFOX_BINARY -PathType Leaf)) {
+            throw "Firefox binary not found: $env:FIREFOX_BINARY"
+          }
+          Write-Host "Portable Firefox: $env:FIREFOX_BINARY"
 
       - name: Download dev snapshot
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -71,11 +71,21 @@ jobs:
           path: .watchdog
           key: url-watchdog-baseline-${{ github.run_id }}
           restore-keys: url-watchdog-baseline-
+      # Validated-versions record (#4): written only by the E2E workflow's
+      # record-validation job after all browser legs passed. Restored to its
+      # own dir so the watchdog baseline restore above can never clobber it.
+      - name: Restore validated-versions record
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .watchdog-validated
+          key: browser-validated-${{ github.run_id }}
+          restore-keys: browser-validated-
       - name: Check browser version drift
         env:
           MODE: ${{ inputs.mode }}
+          VALIDATED_DIR: ${{ github.workspace }}/.watchdog-validated
         run: |
-          if node tools/check-browser-downloads.mjs --drift; then
+          if node tools/check-browser-downloads.mjs --drift --require-validated; then
             echo "no browser version drift since the last watchdog run"
           elif [ "$MODE" = "prod" ]; then
             echo "::error::new browser version(s) since the last watchdog run — run the URL watchdog workflow (refreshes the baseline + triggers browser-specific E2E), then re-dispatch publish."

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -350,10 +350,10 @@ async function installPortableFirefox(url, platform) {
     await downloadTo(url, exe);
     // NSIS /D must be the final argument and uses a custom directory instead
     // of the registered Program Files location.
-    // Run through cmd.exe so Git Bash does not rewrite the Windows path.
-    // NSIS requires /D= as the final argument; quoting the value preserves
-    // spaces in runner.temp paths while keeping the whole option one argv item.
-    const result = spawnSync('cmd.exe', ['/d', '/s', '/c', `"${exe}" /S /D="${dest}"`], {
+    // Pass the final /D= option directly to NSIS. PowerShell launches this
+    // Node process with native Windows paths, and verbatim arguments prevent
+    // MSYS/Git Bash path rewriting when the same helper is used locally.
+    const result = spawnSync(exe, ['/S', `/D=${dest}`], {
       stdio: 'inherit',
       windowsVerbatimArguments: true,
     });
@@ -417,6 +417,13 @@ async function installDmg(url, appName) {
     if (device || mountPoint) {
       execSync(`hdiutil detach "${device || mountPoint}"`);
     }
+  }
+}
+
+/** Export the resolved browser binary for GitHub Actions callers. */
+export function exportBinaryPath(binary) {
+  if (process.env.GITHUB_ENV) {
+    fs.appendFileSync(process.env.GITHUB_ENV, `FIREFOX_BINARY=${binary}\n`);
   }
 }
 
@@ -517,9 +524,7 @@ Release into a custom directory instead of a system location. With --url, prints
 
   const binary = await installBrowser(browser, normalized);
   console.log(binary);
-  if (process.env.GITHUB_ENV) {
-    fs.appendFileSync(process.env.GITHUB_ENV, `FIREFOX_BINARY=${binary}\n`);
-  }
+  exportBinaryPath(binary);
 }
 
 // Basename (not endsWith) so modules with a similar name — e.g.

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -369,11 +369,15 @@ async function installPortableFirefox(url, platform) {
   if (platform === 'darwin') {
     const dmg = path.join(downloadDir(), 'firefox-portable.dmg');
     await downloadTo(url, dmg);
+    // Same hardened parse as installDmg below: the mount point is the last
+    // column and may contain spaces, so take everything after `/Volumes/` on
+    // matching lines and keep the device for cleanup.
     const out = execSync(`hdiutil attach -nobrowse -readonly "${dmg}"`).toString();
-    const mount = out
+    const mounts = out
       .split('\n')
-      .map(line => line.slice(line.indexOf('/Volumes/')).trim())
-      .find(line => line.startsWith('/Volumes/'));
+      .filter(line => line.includes('/Volumes/'))
+      .map(line => line.slice(line.indexOf('/Volumes/')).trim());
+    const mount = mounts[mounts.length - 1];
     const device = (out.match(/\/dev\/disk\S+/g) || [])[0];
     try {
       if (!mount) throw new Error(`cannot find Firefox DMG mount point: ${out}`);

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -350,9 +350,13 @@ async function installPortableFirefox(url, platform) {
     await downloadTo(url, exe);
     // NSIS /D must be the final argument and uses a custom directory instead
     // of the registered Program Files location.
-    // Pass the destination as one argv item. Quoting the value inside the
-    // /D= argument preserves spaces in runner.temp paths for NSIS.
-    const result = spawnSync(exe, ['/S', `/D="${dest}"`], {stdio: 'inherit'});
+    // Run through cmd.exe so Git Bash does not rewrite the Windows path.
+    // NSIS requires /D= as the final argument; quoting the value preserves
+    // spaces in runner.temp paths while keeping the whole option one argv item.
+    const result = spawnSync('cmd.exe', ['/d', '/s', '/c', `"${exe}" /S /D="${dest}"`], {
+      stdio: 'inherit',
+      windowsVerbatimArguments: true,
+    });
     if (result.error) throw result.error;
     if (result.status !== 0) {
       throw new Error(`Firefox portable installer exited with code ${result.status}`);

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -231,7 +231,7 @@ async function resolveLatestUrl({api, pick, url}) {
 
 /** Download an official Mozilla tarball and extract it; returns the binary path. */
 async function installTarball(url, browser) {
-  const dest = path.join(os.homedir(), 'firefox-app');
+  const dest = process.env.PORTABLE_BROWSER_DIR || path.join(os.homedir(), 'firefox-app');
   const archive = path.join(downloadDir(), `firefox-${browser}.tar.xz`);
   fs.mkdirSync(dest, {recursive: true});
 
@@ -335,6 +335,51 @@ async function installInstaller(url, browser, args) {
   execSync(`"${exe}" ${args.join(' ')}`, {stdio: 'inherit'});
 }
 
+/** Download Firefox Release into a custom, non-registered directory. */
+async function installPortableFirefox(url, platform) {
+  const dest = process.env.PORTABLE_BROWSER_DIR;
+  if (!dest) throw new Error('PORTABLE_BROWSER_DIR is required for portable Firefox');
+  fs.mkdirSync(dest, {recursive: true});
+
+  if (platform === 'linux') {
+    const binary = await installTarball(url, 'firefox-portable');
+    return binary;
+  }
+
+  if (platform === 'win32') {
+    const exe = path.join(downloadDir(), 'firefox-portable-setup.exe');
+    await downloadTo(url, exe);
+    // NSIS /D must be the final argument and uses a custom directory instead
+    // of the registered Program Files location.
+    execSync(`"${exe}" /S /D=${dest}`, {stdio: 'inherit'});
+    const binary = path.join(dest, 'firefox.exe');
+    if (!fs.existsSync(binary)) throw new Error(`portable Firefox binary not found: ${binary}`);
+    return binary;
+  }
+
+  if (platform === 'darwin') {
+    const dmg = path.join(downloadDir(), 'firefox-portable.dmg');
+    await downloadTo(url, dmg);
+    const out = execSync(`hdiutil attach -nobrowse -readonly "${dmg}"`).toString();
+    const mount = out
+      .split('\n')
+      .map(line => line.slice(line.indexOf('/Volumes/')).trim())
+      .find(line => line.startsWith('/Volumes/'));
+    const device = (out.match(/\/dev\/disk\S+/g) || [])[0];
+    try {
+      if (!mount) throw new Error(`cannot find Firefox DMG mount point: ${out}`);
+      execSync(`cp -R "${mount}/Firefox.app" "${dest}/"`);
+    } finally {
+      if (device || mount) execSync(`hdiutil detach "${device || mount}"`);
+    }
+    const binary = path.join(dest, 'Firefox.app', 'Contents', 'MacOS', 'firefox');
+    if (!fs.existsSync(binary)) throw new Error(`portable Firefox binary not found: ${binary}`);
+    return binary;
+  }
+
+  throw new Error(`unsupported portable Firefox platform: ${platform}`);
+}
+
 /** Download an official dmg, mount it, and copy the app into /Applications. */
 async function installDmg(url, appName) {
   const dmg = path.join(downloadDir(), `${appName.replace(/\.app$/, '')}.dmg`);
@@ -386,6 +431,17 @@ export async function installBrowser(browser, platform = process.platform) {
         (def.page ? ` — manual install only (official page: ${def.page})` : '')
     );
   }
+  if (browser === 'firefox' && process.env.PORTABLE_BROWSER_DIR) {
+    const url = recipe.tarball || recipe.url;
+    const binary = await installPortableFirefox(
+      url,
+      key === 'win' ? 'win32'
+      : key === 'mac' ? 'darwin'
+      : 'linux'
+    );
+    console.log(`  ${browser} installed portably: ${binary}`);
+    return binary;
+  }
   if (recipe.tarball) {
     const binary = await installTarball(recipe.tarball, browser);
     console.log(`  ${browser} installed from official tarball: ${binary}`);
@@ -431,7 +487,8 @@ async function main() {
 
 Installs <browser> for the current OS (or --os) using its official download
 recipe, then prints the resolved binary path and, in GitHub Actions, sets
-FIREFOX_BINARY via $GITHUB_ENV. With --url, prints the download URL instead
+FIREFOX_BINARY via $GITHUB_ENV. Set PORTABLE_BROWSER_DIR to install Firefox
+Release into a custom directory instead of a system location. With --url, prints the download URL instead
 (used to key the CI download cache).`);
     process.exit(browser ? 0 : 1);
   }

--- a/test/e2e/shared/downloads.mjs
+++ b/test/e2e/shared/downloads.mjs
@@ -20,7 +20,7 @@
  * official download page instead; the CLI fails with a clear message.
  */
 
-import {execSync} from 'node:child_process';
+import {execSync, spawnSync} from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -230,8 +230,7 @@ async function resolveLatestUrl({api, pick, url}) {
 }
 
 /** Download an official Mozilla tarball and extract it; returns the binary path. */
-async function installTarball(url, browser) {
-  const dest = process.env.PORTABLE_BROWSER_DIR || path.join(os.homedir(), 'firefox-app');
+async function installTarball(url, browser, dest = path.join(os.homedir(), 'firefox-app')) {
   const archive = path.join(downloadDir(), `firefox-${browser}.tar.xz`);
   fs.mkdirSync(dest, {recursive: true});
 
@@ -342,7 +341,7 @@ async function installPortableFirefox(url, platform) {
   fs.mkdirSync(dest, {recursive: true});
 
   if (platform === 'linux') {
-    const binary = await installTarball(url, 'firefox-portable');
+    const binary = await installTarball(url, 'firefox-portable', dest);
     return binary;
   }
 
@@ -351,7 +350,13 @@ async function installPortableFirefox(url, platform) {
     await downloadTo(url, exe);
     // NSIS /D must be the final argument and uses a custom directory instead
     // of the registered Program Files location.
-    execSync(`"${exe}" /S /D=${dest}`, {stdio: 'inherit'});
+    // Pass the destination as one argv item. Quoting the value inside the
+    // /D= argument preserves spaces in runner.temp paths for NSIS.
+    const result = spawnSync(exe, ['/S', `/D="${dest}"`], {stdio: 'inherit'});
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`Firefox portable installer exited with code ${result.status}`);
+    }
     const binary = path.join(dest, 'firefox.exe');
     if (!fs.existsSync(binary)) throw new Error(`portable Firefox binary not found: ${binary}`);
     return binary;

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -14,12 +14,14 @@ const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-downloads.mjs')).href;
 const {
   collectDrift,
+  collectValidatedDrift,
   compareBaseline,
   formatAge,
   issueBody,
   issueTitle,
   parseContentRange,
   sha256File,
+  VALIDATED_BROWSERS,
 } = await import(scriptUrl);
 
 test('compareBaseline: first run, new version, unchanged', () => {
@@ -41,6 +43,38 @@ test('collectDrift: unchanged baseline yields no drift', () => {
     Object.entries(baseline).map(([browser, entry]) => [browser, entry.version])
   );
   assert.deepEqual(collectDrift(baseline, versions), []);
+});
+
+test('VALIDATED_BROWSERS: exactly the hard-gate browser legs', () => {
+  assert.deepEqual(VALIDATED_BROWSERS, ['firefox', 'firefox-dev']);
+});
+
+test('collectValidatedDrift: matching record yields no drift', () => {
+  const validated = {
+    browsers: {'firefox': {version: '154.0.1'}, 'firefox-dev': {version: '155.0b3'}},
+  };
+  const versions = {'firefox': '154.0.1', 'firefox-dev': '155.0b3'};
+  assert.deepEqual(collectValidatedDrift(validated.browsers, versions), []);
+});
+
+test('collectValidatedDrift: a new release, a missing record, and a lookup failure are flagged', () => {
+  const validated = {firefox: {version: '153.0'}};
+  const versions = {
+    'firefox': '154.0.1', // validated 153.0 → drift
+    'firefox-dev': '155.0b3', // never validated → drift (even though current)
+  };
+  const drift = collectValidatedDrift(validated, versions);
+  assert.ok(
+    drift.some(d => d.includes('firefox: E2E validated 153.0, current release is 154.0.1'))
+  );
+  assert.ok(drift.some(d => d.includes('firefox-dev: never validated')));
+  assert.equal(drift.length, 2);
+});
+
+test('collectValidatedDrift: version lookup failure is flagged', () => {
+  const validated = {'firefox': {version: '154.0.1'}, 'firefox-dev': {version: '155.0b3'}};
+  const drift = collectValidatedDrift(validated, {'firefox': '154.0.1', 'firefox-dev': ''});
+  assert.deepEqual(drift, ['firefox-dev: version lookup failed']);
 });
 
 test('collectDrift: a new version, a missing baseline, and a lookup failure are flagged', () => {

--- a/test/unit/tools/check-gate-coverage.test.mjs
+++ b/test/unit/tools/check-gate-coverage.test.mjs
@@ -200,3 +200,43 @@ test('parseJobs: counts verify-gate uses per job', () => {
   assert.equal(jobs.get('changes').verifyGateUses, 0);
   assert.equal(jobs.get('snapshot').verifyGateUses, 0);
 });
+
+// ── post-gate contract (#4): jobs that run AFTER the gate (need it) are
+// exempt from needs-coverage but pinned by their own rules.
+const WITH_POST_GATE = FIXTURE.replace(
+  '  e2e-gate:',
+  `  record-validation:\n    needs: e2e-gate\n    if: always()\n    runs-on: ubuntu-latest\n  e2e-gate:`
+);
+const POST_GATE_CONTRACT = {...CONTRACT, postGate: ['record-validation']};
+
+test('checkWorkflow: a post-gate job (needs the gate) passes needs-coverage', () => {
+  // Without the postGate exemption the recorder would be flagged as bypassing
+  // the gate (it is deliberately NOT in the gate's needs).
+  const exempt = checkWorkflow(WITH_POST_GATE, POST_GATE_CONTRACT);
+  assert.deepEqual(exempt, []);
+  const flagged = checkWorkflow(WITH_POST_GATE, CONTRACT);
+  assert.ok(flagged.some(e => e.includes('record-validation') && e.includes('bypass the gate')));
+});
+
+test('checkWorkflow: a post-gate job must exist', () => {
+  const errors = checkWorkflow(FIXTURE, POST_GATE_CONTRACT);
+  assert.ok(errors.some(e => e.includes("post-gate job 'record-validation' not found")));
+});
+
+test('checkWorkflow: a post-gate job must need the gate', () => {
+  const broken = WITH_POST_GATE.replace(
+    '  record-validation:\n    needs: e2e-gate',
+    '  record-validation:'
+  );
+  const errors = checkWorkflow(broken, POST_GATE_CONTRACT);
+  assert.ok(errors.some(e => e.includes("'record-validation' must need 'e2e-gate'")));
+});
+
+test('checkWorkflow: a post-gate job in the gate needs would be a cycle', () => {
+  const cyclic = WITH_POST_GATE.replace(
+    'needs: [changes, snapshot, installer]',
+    'needs: [changes, snapshot, installer, record-validation]'
+  );
+  const errors = checkWorkflow(cyclic, POST_GATE_CONTRACT);
+  assert.ok(errors.some(e => e.includes('record-validation') && e.includes('cycle')));
+});

--- a/test/unit/tools/check-gate-coverage.test.mjs
+++ b/test/unit/tools/check-gate-coverage.test.mjs
@@ -240,3 +240,14 @@ test('checkWorkflow: a post-gate job in the gate needs would be a cycle', () => 
   const errors = checkWorkflow(cyclic, POST_GATE_CONTRACT);
   assert.ok(errors.some(e => e.includes('record-validation') && e.includes('cycle')));
 });
+
+test('checkWorkflow: a post-gate job in verify-gate results is rejected', () => {
+  const broken = WITH_POST_GATE.replace(
+    '            snapshot:${{ needs.snapshot.result }}',
+    '            snapshot:${{ needs.snapshot.result }}\n            record-validation:${{ needs.record-validation.result }}'
+  );
+  const errors = checkWorkflow(broken, POST_GATE_CONTRACT);
+  assert.ok(
+    errors.some(e => e.includes("results must not include post-gate job 'record-validation'"))
+  );
+});

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -268,7 +268,12 @@ export function collectValidatedDrift(validated, versions) {
     const curr = versions[browser];
     if (curr === undefined || curr === null || curr === '') {
       drift.push(`${browser}: version lookup failed`);
-    } else if (!entry) {
+    } else if (
+      !entry ||
+      entry.version === undefined ||
+      entry.version === null ||
+      entry.version === ''
+    ) {
       drift.push(`${browser}: never validated — no successful E2E run recorded this version`);
     } else if (String(entry.version) !== String(curr)) {
       drift.push(`${browser}: E2E validated ${entry.version}, current release is ${curr}`);

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -64,6 +64,13 @@ const RANGE_BYTES = 1024;
 /** Browsers the E2E map installs or tracks — each must resolve its version. */
 const BROWSERS = ['firefox', 'firefox-dev', 'librewolf', 'floorp', 'zen', 'waterfox'];
 
+/**
+ * Browsers whose current version must be covered by a successful E2E run before
+ * a prod publish (the hard-gated `updater` legs on all 3 OSes). Fork legs are
+ * advisory, so they stay on the watchdog-baseline check only.
+ */
+export const VALIDATED_BROWSERS = ['firefox', 'firefox-dev'];
+
 const VERSION_APIS = {
   'firefox': {
     // Mozilla product-details: the canonical "current stable version" endpoint.
@@ -107,7 +114,7 @@ async function getJson(url) {
 }
 
 /** Resolve the current release version for a browser from its vendor API. */
-async function resolveVersion(browser) {
+export async function resolveVersion(browser) {
   const {url, parse} = VERSION_APIS[browser];
   const version = parse(await getJson(url));
   if (!version) {
@@ -235,6 +242,36 @@ export function collectDrift(baseline, versions) {
       drift.push(`${browser}: not in baseline (first run — run the watchdog first)`);
     } else if (String(prev.version) !== String(curr)) {
       drift.push(`${browser}: ${prev.version} → ${curr}`);
+    }
+  }
+  return drift;
+}
+
+/**
+ * Diff the validated-versions record (written only by successful browser E2E
+ * runs, see tools/ci/record-validated-versions.mjs) against freshly resolved
+ * versions. Returns a list of human-readable drift strings; empty = the current
+ * releases are exactly what E2E validated.
+ *
+ * Unlike collectDrift, a browser missing from the record is drift even on a
+ * "first run": the prod pre-flight must never pass on an absent validation.
+ *
+ * @param {Record<string, {version: string} | undefined>} validated
+ * @param {Record<string, string | undefined>} versions current version per
+ *   browser
+ * @returns {string[]}
+ */
+export function collectValidatedDrift(validated, versions) {
+  const drift = [];
+  for (const browser of VALIDATED_BROWSERS) {
+    const entry = validated[browser];
+    const curr = versions[browser];
+    if (curr === undefined || curr === null || curr === '') {
+      drift.push(`${browser}: version lookup failed`);
+    } else if (!entry) {
+      drift.push(`${browser}: never validated — no successful E2E run recorded this version`);
+    } else if (String(entry.version) !== String(curr)) {
+      drift.push(`${browser}: E2E validated ${entry.version}, current release is ${curr}`);
     }
   }
   return drift;
@@ -388,6 +425,48 @@ export async function main() {
       process.exit(1);
     }
     console.log('No browser version drift — baseline matches current releases.');
+
+    // Second gate (#4): the watchdog baseline can be refreshed without any
+    // test run, so a prod publish additionally requires the hard-gate
+    // browsers' CURRENT versions to be covered by the validated-versions
+    // record — written only by successful browser-specific E2E runs.
+    if (process.argv.includes('--require-validated')) {
+      // VALIDATED_DIR: where the publish pre-flight restored the E2E-written
+      // record (kept separate from the watchdog baseline's BASELINE_DIR).
+      const validatedDir = process.env.VALIDATED_DIR || baselineDir;
+      const validatedFile = path.join(validatedDir, 'validated.json');
+      if (!fs.existsSync(validatedFile)) {
+        console.error(
+          'validation: no validated-versions record found — dispatch the E2E ' +
+            'workflow on main (it records validated browser versions on success), ' +
+            'then re-dispatch publish.'
+        );
+        process.exit(1);
+      }
+      const validated = JSON.parse(fs.readFileSync(validatedFile, 'utf-8'));
+      const versionsNow = {};
+      for (const browser of VALIDATED_BROWSERS) {
+        try {
+          versionsNow[browser] = String(await resolveVersion(browser));
+        } catch (err) {
+          console.log(`  ${browser}: version lookup failed: ${err.message}`);
+        }
+      }
+      const validatedDrift = collectValidatedDrift(validated, versionsNow);
+      if (validatedDrift.length > 0) {
+        console.error('Browser versions not covered by a successful E2E run:');
+        for (const d of validatedDrift) console.error(`  - ${d}`);
+        console.error(
+          'Dispatch the E2E workflow on main (re-records validated versions on ' +
+            'success), then re-dispatch publish.'
+        );
+        process.exit(1);
+      }
+      console.log(
+        'Validated-versions record matches current releases ' +
+          `(recorded ${validated.recordedAt || 'unknown'}).`
+      );
+    }
     process.exit(0);
   }
 

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -452,7 +452,9 @@ export async function main() {
           console.log(`  ${browser}: version lookup failed: ${err.message}`);
         }
       }
-      const validatedDrift = collectValidatedDrift(validated, versionsNow);
+      // The record wraps the per-browser map under `browsers` (alongside
+      // recordedAt/runId/sha metadata) — pass only the map to the diff.
+      const validatedDrift = collectValidatedDrift(validated.browsers || {}, versionsNow);
       if (validatedDrift.length > 0) {
         console.error('Browser versions not covered by a successful E2E run:');
         for (const d of validatedDrift) console.error(`  - ${d}`);

--- a/tools/check-gate-coverage.mjs
+++ b/tools/check-gate-coverage.mjs
@@ -293,6 +293,11 @@ export function checkWorkflow(text, contract) {
       errors.push(`${file}: ${gate} needs '${name}' but its verify-gate results do not include it`);
     }
   }
+  for (const name of postGate) {
+    if (results.includes(name)) {
+      errors.push(`${file}: ${gate} results must not include post-gate job '${name}'`);
+    }
+  }
   for (const name of results) {
     if (!classified.includes(name)) {
       errors.push(

--- a/tools/check-gate-coverage.mjs
+++ b/tools/check-gate-coverage.mjs
@@ -27,6 +27,11 @@
  * - verify-gate-uses: the gate job invokes ./.github/actions/verify-gate exactly
  *   once, and ONLY that step's `with:` block is parsed as gate wiring (another
  *   action's inputs must not satisfy the contract).
+ * - post-gate: jobs declared in the contract's `postGate` list run AFTER the gate
+ *   (they `needs:` it — e.g. the E2E workflow's validated-versions recorder,
+ *   #4). They cannot bypass the gate, so they are exempt from needs-coverage,
+ *   but they must exist, must need the gate, and must not be wired into the
+ *   gate's verify-gate results (that would create a cycle).
  *
  * Exit code 0 = contract holds. Run via `pnpm check:gates` (part of the
  * `checks` CI job). The parser is deliberately small — the workflow files are
@@ -184,11 +189,12 @@ export function parseJobs(text) {
  *   gatedIfs?: Record<string, string>;
  *   noJobIf?: string[];
  *   applicability?: string[];
+ *   postGate?: string[];
  * }} contract
  * @returns {string[]}
  */
 export function checkWorkflow(text, contract) {
-  const {file, gate, gatedIfs = {}, noJobIf = [], applicability = []} = contract;
+  const {file, gate, gatedIfs = {}, noJobIf = [], applicability = [], postGate = []} = contract;
   const errors = [];
   const jobs = parseJobs(text);
   const gateJob = jobs.get(gate);
@@ -199,10 +205,28 @@ export function checkWorkflow(text, contract) {
 
   for (const name of jobs.keys()) {
     if (name === gate) continue;
+    // post-gate jobs run AFTER the gate (they need it) and are checked by
+    // their own rules below — exempting them here is the point of postGate.
+    if (postGate.includes(name)) continue;
     if (!gateJob.needs.includes(name)) {
       errors.push(
         `${file}: job '${name}' is not in ${gate}'s needs — it would bypass the gate silently`
       );
+    }
+  }
+  for (const name of postGate) {
+    const job = jobs.get(name);
+    if (!job) {
+      errors.push(`${file}: post-gate job '${name}' not found`);
+      continue;
+    }
+    if (gateJob.needs.includes(name)) {
+      errors.push(
+        `${file}: post-gate job '${name}' must not be in ${gate}'s needs (it already needs the gate — a cycle)`
+      );
+    }
+    if (!job.needs.includes(gate)) {
+      errors.push(`${file}: post-gate job '${name}' must need '${gate}'`);
     }
   }
   for (const name of gateJob.needs) {
@@ -309,6 +333,9 @@ const CONTRACTS = [
         "needs.changes.outputs.updater == 'true' || needs.changes.outputs.core == 'true'",
     },
     applicability: ['snapshot', 'installer', 'helper', 'updater', 'browser-matrix'],
+    // Runs after e2e-gate: records the validated browser versions (#4) only
+    // when every browser leg passed.
+    postGate: ['record-validation'],
   },
   {
     file: '.github/workflows/ci.yml',

--- a/tools/ci/record-validated-versions.mjs
+++ b/tools/ci/record-validated-versions.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * tools/ci/record-validated-versions.mjs — write the validated-versions record
+ * (.watchdog/validated.json) after a successful browser-specific E2E run.
+ *
+ * The prod publish pre-flight (pages.yml `pre-publish`) checks browser-version
+ * drift against the URL watchdog's baseline — but a baseline refresh alone can
+ * satisfy that check without any test run ever seeing the new version (issue
+ * #4). This script closes the gap: the E2E workflow's final job calls it only
+ * after every browser leg passed, recording the exact firefox / firefox-dev
+ * versions the run validated. `check-browser-downloads.mjs --drift
+ * --require-validated` then blocks a prod publish until the current releases
+ * are covered by this record.
+ *
+ * Only the hard-gated browsers (firefox, firefox-dev — VALIDATED_BROWSERS in
+ * check-browser-downloads.mjs) are recorded: fork legs are advisory, so they
+ * stay on the watchdog-baseline drift check.
+ *
+ * Usage (inside the E2E workflow's record-validation job):
+ *
+ * node tools/ci/record-validated-versions.mjs
+ *
+ * Env: VALIDATED_DIR (where to write; defaults to .watchdog/), GITHUB_RUN_ID,
+ * GITHUB_SHA (record metadata), GITHUB_STEP_SUMMARY (optional human summary).
+ * Exits 1 if a version lookup fails — a record with holes would silently weaken
+ * the publish gate.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {REPO_ROOT, VALIDATED_BROWSERS, resolveVersion} from '../check-browser-downloads.mjs';
+
+async function main() {
+  const outDir = process.env.VALIDATED_DIR || path.join(REPO_ROOT, '.watchdog');
+  const outFile = path.join(outDir, 'validated.json');
+
+  const record = {
+    recordedAt: new Date().toISOString(),
+    runId: process.env.GITHUB_RUN_ID || null,
+    runUrl:
+      process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY ?
+        `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID || ''}`
+      : null,
+    sha: process.env.GITHUB_SHA || null,
+    browsers: {},
+  };
+
+  for (const browser of VALIDATED_BROWSERS) {
+    const version = await resolveVersion(browser);
+    record.browsers[browser] = {version};
+    console.log(`  ${browser}: ${version}`);
+  }
+
+  fs.mkdirSync(outDir, {recursive: true});
+  fs.writeFileSync(outFile, JSON.stringify(record, null, 2) + '\n');
+  console.log(`validated-versions record written: ${outFile}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const lines = [
+      '### Validated browser versions recorded',
+      '',
+      '| Browser | Version |',
+      '| --- | --- |',
+      ...VALIDATED_BROWSERS.map(b => `| ${b} | ${record.browsers[b].version} |`),
+      '',
+      `Run: ${record.runUrl || 'local'} · commit: ${record.sha || 'n/a'}`,
+    ];
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+  }
+}
+
+main().catch(err => {
+  console.error(`✗ Error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Part of #4 (v1.0 release gate). Stacked on #89.

## Problem

The prod pre-flight checks browser-version drift against the URL-watchdog baseline — but a baseline refresh alone satisfies that check without any test run ever seeing the new version. A Firefox release could ship untested.

## Solution

A **validated-versions record** (`.watchdog/validated.json`) written *only* by the E2E workflow after every hard-gate browser leg passed, and required by the prod publish pre-flight:

- **`tools/ci/record-validated-versions.mjs`** — records the exact `firefox` / `firefox-dev` versions a successful E2E run validated (with run id + commit for auditability). Fork legs stay advisory, so they are not recorded.
- **`tools/check-browser-downloads.mjs`** — new `collectValidatedDrift()` + `--require-validated` mode: prod publish fails unless the *current* releases are covered by the record ("never validated" is drift, even on first run).
- **`e2e.yml`** — post-gate `record-validation` job: runs only when the E2E gate passed on a `main` dispatch, saves the record via Actions cache (same rotating-key pattern as the watchdog baseline).
- **`pages.yml`** — publish pre-flight restores the record to its own dir (never clobbered by the baseline) and runs the drift check with `--require-validated`. Dev publishes keep the non-blocking warning path.
- **`tools/check-gate-coverage.mjs`** — new `postGate` contract field: a job that runs *after* the gate is exempt from needs-coverage but must need the gate (it can never bypass it — and wiring it into the gate would be a cycle). Four new unit tests pin the rules.

## Validation

- `pnpm test` — 133 passed, 0 failed (8 new tests: 4 gate-contract, 4 validated-drift)
- `pnpm lint` / `pnpm format` — clean
- `pnpm check:gates` — contracts hold (e2e.yml: 9 jobs)

Fixes part of #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Added validation tracking for Firefox and Firefox Developer Edition browser versions after successful end-to-end checks.
  - Production publishing now blocks when browser versions are missing validation or have changed since validation.

- **CI/CD**
  - Added automated recording and caching of validated browser versions.
  - Added safeguards ensuring post-validation workflow jobs run only after the required checks.

- **Testing**
  - Expanded coverage for browser-version drift and post-gate workflow validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->