### PR TITLE
fix(tools): normalize CRLF when parsing tracked text files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,9 @@ Installer build (Windows: MSYS2 UCRT64 `mingw32-make`): `make dist_win` / `dist_
   `docs/decisions/0000-template.md`; next unused `NNNN` + kebab-case slug; supersede, don't edit.
 - **Error handling:** fail-fast with clear messages; elevation failures distinguish cancel (exit 2);
   network failures surface a banner in the UI, not a silent partial install.
+- **Text files are LF**; a local working-tree copy can linger as CRLF, so when a tool parses a
+  tracked text file, normalize `\r\n` → `\n` at read (`docs/DEVELOPING.md` → Continuous
+  integration).
 
 ## Testing & QA
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -307,6 +307,19 @@ Edition is first-party Mozilla, so it runs as a required leg of the `updater` jo
 advisory matrix. Waterfox has no direct download URL and stays manual (tracked by version only in
 the URL watchdog).
 
+**LF, CRLF and `pnpm check:gates`** — the tree is normalized to LF (`.gitattributes` has
+`* text=auto eol=lf`), so a CRLF file saved by a Windows editor is committed as LF and CI always
+checks an LF checkout. But git will not rewrite an already-CRLF working-tree copy (it deems it
+"equal after normalization" — `git checkout -- <file>` will not restore it either), so a local file
+can linger as CRLF and break the line-sensitive gates: `pnpm check:gates` reports 20+ false
+gate-contract violations and `pnpm format` flags the file. Detect with
+`file .github/workflows/*.yml` (look for "CRLF line terminators"); fix by physically rewriting the
+bytes to LF (e.g.
+`node -e "const fs=require('fs');const p='.github/workflows/e2e.yml';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace(/\r\n/g,'\n'))"`).
+The parsers `tools/check-gate-coverage.mjs`, `tools/check-decisions.mjs` and
+`tools/publish/syncGeneratedFiles.mjs` normalize `\r\n` → `\n` at read so this never false-fails;
+new tools that parse tracked text files should do the same.
+
 **Merge queue** — the workflows trigger on `merge_group` in addition to `pull_request`, so the
 required checks also run on the merge queue's temporary merge-group branch. Enabling the queue
 (Settings → General → merge queue, with branch protection requiring it) makes the queue keep each PR

--- a/test/unit/tools/check-gate-coverage.test.mjs
+++ b/test/unit/tools/check-gate-coverage.test.mjs
@@ -88,6 +88,14 @@ test('checkWorkflow: a compliant workflow passes', () => {
   assert.deepEqual(errors, []);
 });
 
+test('checkWorkflow: CRLF line endings do not break the contract', () => {
+  // A Windows editor can write a workflow file as CRLF locally (git keeps it
+  // CRLF in the working tree even though it is committed as LF). The parser
+  // normalizes CRLF, so no `if:` capture carries a trailing \r.
+  const crlf = FIXTURE.replace(/\n/g, '\r\n');
+  assert.deepEqual(checkWorkflow(crlf, CONTRACT), []);
+});
+
 test('checkWorkflow: job missing from gate needs is flagged', () => {
   const broken = FIXTURE.replace(
     'needs: [changes, snapshot, installer]',

--- a/tools/check-decisions.mjs
+++ b/tools/check-decisions.mjs
@@ -38,7 +38,9 @@ if (!fs.existsSync(decisionsDir)) {
 for (const entry of fs.readdirSync(decisionsDir)) {
   if (!entry.endsWith('.md')) continue;
   const filePath = path.join(decisionsDir, entry);
-  const content = fs.readFileSync(filePath, 'utf8');
+  // Normalize CRLF so a Windows-edited .md cannot smuggle a trailing `\r`
+  // into the Status capture and false-fail the superseded-status check.
+  const content = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
   const lines = content.split('\n');
 
   // Every file: relative links must resolve to an existing file.
@@ -101,7 +103,7 @@ if (!fs.existsSync(indexPath)) {
   console.error(`${INDEX} not found at ${indexPath} — the decision log needs its index`);
   process.exit(1);
 }
-const indexContent = fs.readFileSync(indexPath, 'utf8');
+const indexContent = fs.readFileSync(indexPath, 'utf8').replace(/\r\n/g, '\n');
 for (const record of records) {
   if (!indexContent.includes(record.file)) {
     fail(record.file, `not listed in ${INDEX} (add it to the steering or historical list)`);

--- a/tools/check-gate-coverage.mjs
+++ b/tools/check-gate-coverage.mjs
@@ -76,6 +76,11 @@ const VERIFY_GATE_USES = './.github/actions/verify-gate';
  * >}
  */
 export function parseJobs(text) {
+  // Normalize CRLF → LF so a Windows-edited working-tree workflow file (git
+  // keeps it as CRLF locally even though it is committed/checked out as LF)
+  // cannot smuggle a trailing `\r` into an `if:` capture and false-fail the
+  // contract. Real-world trigger: e2e.yml parsed from a CRLF local copy.
+  text = text.replace(/\r\n/g, '\n');
   const jobs = new Map();
   let current = null;
   let inJobs = false;

--- a/tools/publish/syncGeneratedFiles.mjs
+++ b/tools/publish/syncGeneratedFiles.mjs
@@ -51,9 +51,12 @@ const ROOT = path.resolve(__dirname, '..', '..');
  * references in a value expanded against keys defined earlier (e.g.
  * ZIP_BASE_URL references RELEASE_NAME), and wrapped in the same boilerplate.
  * `.*` in sed captures a trailing CR on CRLF files; JS `(.*)$` behaves the same
- * way.
+ * way, so CRLF is normalized to LF first (below).
  */
 function configHeader(confText) {
+  // Normalize CRLF → LF so a Windows-edited installer.conf cannot bake a
+  // trailing `\r` into the generated `#define` values.
+  confText = confText.replace(/\r\n/g, '\n');
   const out = [
     '// Auto-generated from config/installer.conf. Do not edit.',
     '#ifndef BUILD_CONFIG_H',


### PR DESCRIPTION
## What

A Windows-edited working-tree copy can linger as CRLF even though `.gitattributes` (`* text=auto eol=lf`) keeps commits and CI on LF. That made exact-string parsers false-fail locally: `pnpm check:gates` reported **20 gate violations** purely because `e2e.yml` was CRLF in the working tree (confirmed: CI was green, a fresh LF checkout passed, only the local copy failed).

## Changes

- `tools/check-gate-coverage.mjs` — normalize `\r\n` → `\n` at the top of `parseJobs` (the `if:` capture carried a trailing `\r`).
- `tools/check-decisions.mjs` — normalize `.md` content + `index.md` (the `Status` capture on superseded records would false-fail on CRLF).
- `tools/publish/syncGeneratedFiles.mjs` — normalize `config/installer.conf` in `configHeader` (could bake a trailing `\r` into generated `_config.h`).
- `test/unit/tools/check-gate-coverage.test.mjs` — CRLF regression test for the gate parser.
- `docs/DEVELOPING.md` — LF/CRLF gotcha subsection with detect/fix.
- `AGENTS.md` — one-line convention: normalize `\r\n` → `\n` at read when parsing tracked text files.

## Validation

`pnpm test` 135/0 (incl. new CRLF test), `pnpm check:gates` green, prettier + eslint clean.
