### PR TITLE
docs(ai-review): fix PR review workflow wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,17 +224,11 @@ the core smoke tests — see issue #30.)
 ## AI review of PRs
 
 Per [ADR 0020](./docs/decisions/0020-local-agent-ai-review.md), AI review is a local, agent-run
-step, not a CI bot. Before opening a PR, the agent:
-
-1. Runs `pnpm review:local` locally on the PR branch (default `main...HEAD`; `--provider` /
-   `--model` override the **first-available** provider — Gemini 3.6 Flash by default).
-2. **Assesses each finding as right / wrong / useless** against the actual code (the audit
-   methodology): drop findings that are vague, unverifiable, or false positives.
-3. Posts the accepted findings as a PR review comment via `gh` (e.g. `gh pr review <n> --comment`),
-   fixing any real findings before opening the PR.
-
-This replaces the retired CI bot (`.github/workflows/ai-review.yml`, removed) — add no CI/repo AI
-secret. CodeRabbit `review:batch` remains an optional deep ~1-review/hour pass.
+step. When a PR is ready for review, the agent that created it runs `pnpm review:local`, assesses
+each finding right / wrong / useless, and posts the accepted ones as a PR review via
+`gh pr review <n> --comment` (never `gh pr comment`), resolving every review thread before merging
+(main requires conversation resolution). The review is not gated on CI — it can help debug failing
+checks. Add no CI/repo AI secret; CodeRabbit `review:batch` remains an optional deep pass.
 
 ## Agent workflow
 

--- a/docs/decisions/0020-local-agent-ai-review.md
+++ b/docs/decisions/0020-local-agent-ai-review.md
@@ -19,9 +19,16 @@ a cloud API (Gemini 3.6 Flash through Google AI Studio, 1,500 requests/day, no c
 
 AI review is a **local, agent-run step**, not a CI bot:
 
-- The agent that opens a PR runs `pnpm review:local` (`node tools/ai-review.mjs`) on the branch it
-  just produced, then **assesses each finding** (right / wrong / useless, per the audit methodology)
-  and posts the accepted ones as a PR review comment via `gh`.
+- When a PR is ready for review, the agent that created it runs `pnpm review:local`
+  (`node tools/ai-review.mjs`) on the branch, then **assesses each finding** (right / wrong /
+  useless, per the audit methodology) and posts the accepted ones as a **PR review**:
+  `gh pr review <n> --comment -b "<text>"` (or `-F <file>`), where the text is the assessed findings
+  — a one-line header (provider/model, files, counts) plus each finding as
+  `file:line — severity — why`. Reviews have a body, not a title. `gh pr comment` (an issue comment)
+  is never used for findings — it leaves no review record, and the agent verifies the review landed
+  with `gh pr view <n> --json reviews`. `main` requires conversation resolution, so every review
+  thread (agent- or bot-created) must be resolved before merging.
+
 - The review command is **local**, but the model is a **cloud provider**: the reviewed diff is sent
   to the configured endpoint's HTTPS API (e.g. Gemini, which is hosted by Google). This is the same
   data-handling expectation as any LLM review — diff text leaves the workstation for the provider to


### PR DESCRIPTION
## What

Fix the AI-review workflow wording in `AGENTS.md` and [ADR 0020](./docs/decisions/0020-local-agent-ai-review.md):

- **Sequencing contradiction** — the text said run `review:local` *before opening a PR* yet also *post as a PR review*; it now reads "**when a PR is ready for review**", so the PR exists before anything is posted to it.
- **Not gated on CI** — explicitly states the review can help debug failing checks, so it isn't held for green CI.
- **De-duplication** — `AGENTS.md` is slimmed to a compact mandate; the body-format/verification detail lives only in the ADR.

## Validation

Prettier-clean; `check:decisions` OK. Docs + ADR only — no code paths change.
