### PR TITLE
fix(ci): keep record-validation running when installer legs are filtered

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -548,8 +548,17 @@ jobs:
     # e2e-gate success already proves every hard-gate leg ran and passed
     # (the gate is if: always() and reports all results), so no additional
     # changed-paths condition: a core-only change still records validation.
+    #
+    # `always() &&` intentionally overrides the needs-graph skip rules. The
+    # gate itself runs via if: always() and can succeed while a path-filtered
+    # sibling (installer legs) was skipped; since ~2026-08-29 a needs entry
+    # in state 'skipped' then makes THIS job skip too, even though its own
+    # condition holds (byte-identical workflow ran the job on 08-29 12:40 and
+    # 17:01, skipped ever since — GitHub-side evaluation change). With
+    # always() the gate-success comparison below still decides the outcome,
+    # so the job records only fully green runs.
     if: >-
-      needs.e2e-gate.result == 'success' && github.event_name != 'pull_request'
+      always() && needs.e2e-gate.result == 'success' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Problem

The prod publish dispatch today was blocked — but not only by the expected browser-version drift. While preparing the release I found that the `record validated browser versions` job has **silently skipped on every main push since 2026-08-29**, so the validated-versions record (`browser-validated-*` cache → `validated.json`) that the publish pre-flight requires (`check-browser-downloads.mjs --drift --require-validated`, from #4 / #92) is stale and can never be refreshed by a merge.

## Evidence

- The job ran and wrote its cache in exactly two runs: [33253118421](https://github.com/onemen/firefox-scripts/actions/runs/33253118421) (08-29 12:40) and [33264542953](https://github.com/onemen/firefox-scripts/actions/runs/33264542953) (08-29 17:01) — both `push` to `main` where the installer E2E legs **ran**.
- It skipped in the five subsequent runs (08-29 17:08, 17:20, 18:28, and today's push + `workflow_dispatch` on the same commit) — all runs where the installer legs were path-filtered to `skipped`, with `e2e-gate` **succeeding** via `if: always()`.
- The workflow file is byte-identical across all seven runs (`git diff` empty between b796dbf..main); the `if` is plain ASCII; no annotations explain the skip.
- Reproduced on `workflow_dispatch` today: [33879458523](https://github.com/onemen/firefox-scripts/actions/runs/33879458523) — every updater/browser leg green, gate green, record job skipped.

## Cause

GitHub's needs-graph skip evaluation now propagates a `skipped` member of `needs` (the path-filtered `installer` job) into this job, even though `e2e-gate` itself reports `success`. Earlier the same day, the identical workflow bytes evaluated the same condition to `true` — a GitHub-side behavior change, not a repo regression.

## Fix

One line: `if: always() && needs.e2e-gate.result == 'success' && …`. `always()` overrides the needs-graph skip chain; the explicit `result == 'success'` comparison still guarantees the record is written only after a fully green gate, so the gate's meaning is unchanged. `pnpm test` (incl. the `check-gate-coverage` contract tests) and `pnpm lint`/`format` pass.

## After merge

Dispatch E2E on `main` → record job writes `validated.json` covering the current firefox 155.0 / firefox-dev 156.0b2 → re-dispatch the prod publish (the watchdog baseline was already refreshed today).