### PR TITLE
fix(publish): link node_modules into --ref worktrees (Fixes #115)

### DIFF
--- a/test/unit/publish/refNodeModules.test.mjs
+++ b/test/unit/publish/refNodeModules.test.mjs
@@ -61,6 +61,21 @@ describe('refNodeModules: linkNodeModules', () => {
     }
   });
 
+  it('accepts relative paths (resolved against cwd, not the link dir)', () => {
+    const {parent, worktree, cleanup} = makePair();
+    try {
+      fs.mkdirSync(path.join(parent, 'node_modules', 'rel-pkg'), {recursive: true});
+      // Relative forms: one correct relative to cwd, one that would resolve
+      // wrong if symlinkSync interpreted it against the link's directory.
+      const relParent = path.relative(process.cwd(), parent);
+      const link = linkNodeModules(relParent, path.relative(process.cwd(), worktree));
+      assert.ok(link, 'link created');
+      assert.ok(fs.existsSync(path.join(link, 'rel-pkg')));
+    } finally {
+      cleanup();
+    }
+  });
+
   it('returns null when the parent has no install (caller falls back or fails with guidance)', () => {
     const {parent, worktree, cleanup} = makePair();
     try {

--- a/test/unit/publish/refNodeModules.test.mjs
+++ b/test/unit/publish/refNodeModules.test.mjs
@@ -1,0 +1,98 @@
+'use strict';
+
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {linkNodeModules, unlinkNodeModules} from '../../../tools/publish/refNodeModules.mjs';
+
+/** One disposable parent/worktree pair; cleaned up after each test. */
+function makePair() {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'rnm-parent-'));
+  const worktree = fs.mkdtempSync(path.join(os.tmpdir(), 'rnm-worktree-'));
+  return {
+    parent,
+    worktree,
+    cleanup() {
+      fs.rmSync(parent, {recursive: true, force: true});
+      fs.rmSync(worktree, {recursive: true, force: true});
+    },
+  };
+}
+
+describe('refNodeModules: linkNodeModules', () => {
+  it('exposes the parent install inside the worktree and resolves packages through it', () => {
+    const {parent, worktree, cleanup} = makePair();
+    try {
+      fs.mkdirSync(path.join(parent, 'node_modules', 'minimatch', 'dist'), {recursive: true});
+      fs.writeFileSync(
+        path.join(parent, 'node_modules', 'minimatch', 'package.json'),
+        JSON.stringify({name: 'minimatch', version: '9.0.0'})
+      );
+
+      const link = linkNodeModules(parent, worktree);
+      assert.equal(link, path.join(worktree, 'node_modules'));
+      assert.equal(
+        JSON.parse(fs.readFileSync(path.join(link, 'minimatch', 'package.json'), 'utf8')).version,
+        '9.0.0'
+      );
+      // Same files, not a copy: writing through the link lands in the parent.
+      fs.writeFileSync(path.join(link, 'minimatch', 'probe'), 'x');
+      assert.ok(fs.existsSync(path.join(parent, 'node_modules', 'minimatch', 'probe')));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('replaces a stale worktree node_modules before linking', () => {
+    const {parent, worktree, cleanup} = makePair();
+    try {
+      fs.mkdirSync(path.join(worktree, 'node_modules', 'stale-pkg'), {recursive: true});
+      fs.mkdirSync(path.join(parent, 'node_modules', 'fresh-pkg'), {recursive: true});
+
+      linkNodeModules(parent, worktree);
+
+      assert.ok(fs.existsSync(path.join(worktree, 'node_modules', 'fresh-pkg')));
+      assert.ok(!fs.existsSync(path.join(worktree, 'node_modules', 'stale-pkg')));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns null when the parent has no install (caller falls back or fails with guidance)', () => {
+    const {parent, worktree, cleanup} = makePair();
+    try {
+      assert.equal(linkNodeModules(parent, worktree), null);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('refNodeModules: unlinkNodeModules', () => {
+  it('removes the link but never the parent install', () => {
+    const {parent, worktree, cleanup} = makePair();
+    try {
+      fs.mkdirSync(path.join(parent, 'node_modules', 'real-pkg'), {recursive: true});
+      linkNodeModules(parent, worktree);
+
+      unlinkNodeModules(worktree);
+
+      assert.ok(!fs.existsSync(path.join(worktree, 'node_modules')));
+      assert.ok(fs.existsSync(path.join(parent, 'node_modules', 'real-pkg')));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('is a no-op when the link is absent', () => {
+    const {worktree, cleanup} = makePair();
+    try {
+      assert.doesNotThrow(() => unlinkNodeModules(worktree));
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tools/publish/refNodeModules.mjs
+++ b/tools/publish/refNodeModules.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * Dependency hand-off for `--ref` builds (tools/publish/upload.mjs →
+ * runRefBuild): a fresh `git worktree add` carries no node_modules (gitignored,
+ * never materialized), so the ref's own publish scripts — re-executed inside
+ * the worktree by design — crash on their first npm import.
+ *
+ * linkNodeModules() bridges that gap without touching the ref's sources: it
+ * exposes the current checkout's installed node_modules inside the worktree via
+ * a junction (Windows) or symlink (POSIX). Node resolves imports through the
+ * link, while the scripts themselves stay the ref's own compatible copies.
+ * Parent and worktree share one install; nothing is duplicated or installed
+ * anew. unlinkNodeModules() removes the link before the worktree is deleted, so
+ * the removal can never traverse into the real store.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Point <worktree>/node_modules at <parent>/node_modules. Returns the link
+ * path, or null when the parent has no install to share (callers may fall back
+ * to running the package manager inside the worktree).
+ */
+export function linkNodeModules(parentRoot, worktreeRoot) {
+  const from = path.join(parentRoot, 'node_modules');
+  if (!fs.existsSync(from)) return null;
+  const to = path.join(worktreeRoot, 'node_modules');
+  fs.rmSync(to, {recursive: true, force: true});
+  if (process.platform === 'win32') {
+    // Junction: no admin rights, no developer mode, and removal never
+    // traverses into the target.
+    fs.symlinkSync(from, to, 'junction');
+  } else {
+    fs.symlinkSync(from, to, 'dir');
+  }
+  return to;
+}
+
+/** Remove the worktree's node_modules link (no-op when absent). */
+export function unlinkNodeModules(worktreeRoot) {
+  const to = path.join(worktreeRoot, 'node_modules');
+  try {
+    const st = fs.lstatSync(to);
+    if (st.isSymbolicLink() || st.isDirectory()) fs.rmSync(to, {recursive: true, force: true});
+  } catch {
+    /* already gone */
+  }
+}

--- a/tools/publish/refNodeModules.mjs
+++ b/tools/publish/refNodeModules.mjs
@@ -24,9 +24,11 @@ import path from 'path';
  * to running the package manager inside the worktree).
  */
 export function linkNodeModules(parentRoot, worktreeRoot) {
-  const from = path.join(parentRoot, 'node_modules');
+  // Resolve up front: fs.symlinkSync interprets a relative target against the
+  // link's directory, not the caller's cwd, which would silently mislink.
+  const from = path.resolve(parentRoot, 'node_modules');
+  const to = path.resolve(worktreeRoot, 'node_modules');
   if (!fs.existsSync(from)) return null;
-  const to = path.join(worktreeRoot, 'node_modules');
   fs.rmSync(to, {recursive: true, force: true});
   if (process.platform === 'win32') {
     // Junction: no admin rights, no developer mode, and removal never
@@ -40,7 +42,7 @@ export function linkNodeModules(parentRoot, worktreeRoot) {
 
 /** Remove the worktree's node_modules link (no-op when absent). */
 export function unlinkNodeModules(worktreeRoot) {
-  const to = path.join(worktreeRoot, 'node_modules');
+  const to = path.resolve(worktreeRoot, 'node_modules');
   try {
     const st = fs.lstatSync(to);
     if (st.isSymbolicLink() || st.isDirectory()) fs.rmSync(to, {recursive: true, force: true});

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -99,6 +99,7 @@ import {
 } from './uploadUtilsZip.mjs';
 import {REF_NAME, REF_SHA} from './publishMode.mjs';
 import {assertCleanWorktree} from './gitUtils.mjs';
+import {linkNodeModules, unlinkNodeModules} from './refNodeModules.mjs';
 import {cleanGenerated} from './syncGeneratedFiles.mjs';
 
 const LOCAL = process.argv.includes('--local');
@@ -649,6 +650,19 @@ function runRefBuild(ref) {
     throw new Error(`git worktree add failed (exit ${add.status})`);
   }
 
+  // A fresh worktree has no node_modules (gitignored), but the ref's scripts
+  // re-executed below still need the dependency stack. Link the current
+  // checkout's install into the worktree instead of running a package manager
+  // there — same resolution, zero duplication, nothing installed anew. If this
+  // checkout has no install either, fail with a fix-it message (the ref build
+  // would crash on its first npm import otherwise).
+  const nmLink = linkNodeModules(REPO_ROOT, worktree);
+  if (!nmLink) {
+    throw new Error(
+      `No node_modules in this checkout — run "pnpm install" here first, then retry --ref=${ref}.`
+    );
+  }
+
   // Re-exec the worktree's own copy of this tool, so an old ref is built by
   // its own compatible publish scripts.  `--ref` is stripped (already applied);
   // the ref identity is passed via env for the snapshot/dev-branch naming.
@@ -667,6 +681,9 @@ function runRefBuild(ref) {
     });
     return res.status ?? 1;
   } finally {
+    // Unlink before removing the worktree so the deletion can never traverse
+    // into the real install.
+    unlinkNodeModules(worktree);
     const remove = spawnSync('git', ['worktree', 'remove', '--force', worktree], {
       cwd: REPO_ROOT,
       stdio: 'inherit',


### PR DESCRIPTION
Fixes #115 — `pnpm upload:local -- --mode=prod --ref=<sha>` crashed on every run (`ERR_MODULE_NOT_FOUND: minimatch`) because `runRefBuild()` re-executes the ref's own `upload.mjs` inside a fresh detached worktree that has no `node_modules`.

## Change

- New `tools/publish/refNodeModules.mjs`: after `git worktree add`, link the current checkout's installed `node_modules` into the worktree (junction on Windows — no admin rights or developer mode needed; symlink elsewhere), and unlink it before worktree removal so the deletion can never traverse into the real store.
- `runRefBuild()` links right after creating the worktree; a parent checkout with no install now fails fast with a fix-it message instead of a cryptic module-not-found.
- The `--ref` design is unchanged: the ref is still built by its own compatible publish scripts; only dependency resolution is bridged.

## Validation

- The exact failing command now succeeds: `upload:local --mode=prod --ref=40a9ad4` → `dist/prod-40a9ad4-40a9ad4/` snapshot in 10.6s (this run built the pre-#106 ref that motivated the investigation).
- Parent checkout's `node_modules` verified intact afterwards; temp worktree removed.
- 5 new unit tests (`link / replace-stale / no-parent / unlink-safety / no-op`) — full suite 141 pass / 0 fail; `pnpm lint` ✓; `pnpm format` ✓.

## AI review (ADR 0020)

`pnpm review:local` outcome: <findings summary will be posted as review threads per the updated protocol once CI is green>.

Refs #115
