### PR TITLE
fix(review): fail soft on non-object model replies (null crash)

### DIFF
--- a/test/unit/publish/ai-review.test.mjs
+++ b/test/unit/publish/ai-review.test.mjs
@@ -319,3 +319,45 @@ test('treats invalid JSON from the model as a per-file skip', async () => {
   assert.equal(result.rdjson.diagnostics.length, 0);
   assert.match(result.summary[0], /invalid JSON/);
 });
+
+test('treats a bare null reply as a per-file skip (JSON.parse("null") succeeds)', async () => {
+  // Observed live: a provider returned content "null" once; JSON.parse turned
+  // it into null and the summary line crashed on parsed.summary, killing the
+  // whole run. Must fail soft like invalid JSON instead.
+  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
+  const fileDiffs = new Map([['a.js', 'diff a']]);
+  const requestImpl = async () => ({
+    kind: 'success',
+    body: {choices: [{message: {content: 'null'}}]},
+  });
+  const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
+  assert.equal(result.rdjson.diagnostics.length, 0);
+  assert.match(result.summary[0], /invalid JSON/);
+});
+
+test('treats non-object JSON replies (numbers, strings) as per-file skips', async () => {
+  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
+  const fileDiffs = new Map([
+    ['a.js', 'diff a'],
+    ['b.js', 'diff b'],
+  ]);
+  const bodies = ['42', '"just a string"'];
+  const requestImpl = async () => ({
+    kind: 'success',
+    body: {choices: [{message: {content: bodies.shift()}}]},
+  });
+  const result = await reviewFiles({files: ['a.js', 'b.js'], fileDiffs, providers, requestImpl});
+  assert.equal(result.rdjson.diagnostics.length, 0);
+  assert.equal(result.summary.length, 2);
+  assert.match(result.summary[0], /invalid JSON/);
+  assert.match(result.summary[1], /invalid JSON/);
+});
+
+test('treats missing message content as a per-file skip, not a crash', async () => {
+  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
+  const fileDiffs = new Map([['a.js', 'diff a']]);
+  const requestImpl = async () => ({kind: 'success', body: {choices: [{message: {}}]}});
+  const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
+  assert.equal(result.rdjson.diagnostics.length, 0);
+  assert.match(result.summary[0], /invalid JSON/);
+});

--- a/test/unit/publish/ai-review.test.mjs
+++ b/test/unit/publish/ai-review.test.mjs
@@ -317,7 +317,7 @@ test('treats invalid JSON from the model as a per-file skip', async () => {
   });
   const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
   assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.match(result.summary[0], /invalid JSON/);
+  assert.match(result.summary[0], /JSON reply/);
 });
 
 test('treats a bare null reply as a per-file skip (JSON.parse("null") succeeds)', async () => {
@@ -332,7 +332,7 @@ test('treats a bare null reply as a per-file skip (JSON.parse("null") succeeds)'
   });
   const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
   assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.match(result.summary[0], /invalid JSON/);
+  assert.match(result.summary[0], /JSON reply/);
 });
 
 test('treats non-object JSON replies (numbers, strings) as per-file skips', async () => {
@@ -349,8 +349,8 @@ test('treats non-object JSON replies (numbers, strings) as per-file skips', asyn
   const result = await reviewFiles({files: ['a.js', 'b.js'], fileDiffs, providers, requestImpl});
   assert.equal(result.rdjson.diagnostics.length, 0);
   assert.equal(result.summary.length, 2);
-  assert.match(result.summary[0], /invalid JSON/);
-  assert.match(result.summary[1], /invalid JSON/);
+  assert.match(result.summary[0], /JSON reply/);
+  assert.match(result.summary[1], /JSON reply/);
 });
 
 test('treats missing message content as a per-file skip, not a crash', async () => {
@@ -359,5 +359,5 @@ test('treats missing message content as a per-file skip, not a crash', async () 
   const requestImpl = async () => ({kind: 'success', body: {choices: [{message: {}}]}});
   const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
   assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.match(result.summary[0], /invalid JSON/);
+  assert.match(result.summary[0], /JSON reply/);
 });

--- a/tools/ai-review.mjs
+++ b/tools/ai-review.mjs
@@ -438,7 +438,7 @@ export async function reviewFiles({
       parsed = JSON.parse(content);
     } catch {
       summaries.push(
-        `### \`${r.file}\` — ${r.providerName}\nModel returned invalid JSON; findings skipped.`
+        `### \`${r.file}\` — ${r.providerName}\nModel returned an invalid or unusable JSON reply; findings skipped.`
       );
       continue;
     }
@@ -448,7 +448,7 @@ export async function reviewFiles({
       // which then crashed the whole run at parsed.summary. Fail soft: same
       // per-file skip as invalid JSON.
       summaries.push(
-        `### \`${r.file}\` — ${r.providerName}\nModel returned invalid JSON; findings skipped.`
+        `### \`${r.file}\` — ${r.providerName}\nModel returned an invalid or unusable JSON reply; findings skipped.`
       );
       continue;
     }

--- a/tools/ai-review.mjs
+++ b/tools/ai-review.mjs
@@ -442,6 +442,16 @@ export async function reviewFiles({
       );
       continue;
     }
+    if (typeof parsed !== 'object' || parsed === null) {
+      // JSON.parse('null') (and '42', '"text"', …) succeeds but yields no
+      // object to read — observed live when a provider returned a bare null,
+      // which then crashed the whole run at parsed.summary. Fail soft: same
+      // per-file skip as invalid JSON.
+      summaries.push(
+        `### \`${r.file}\` — ${r.providerName}\nModel returned invalid JSON; findings skipped.`
+      );
+      continue;
+    }
     summaries.push(
       `### \`${r.file}\` — ${r.providerName}\n${parsed.summary || 'No summary provided.'}`
     );


### PR DESCRIPTION
`tools/ai-review.mjs` crashed during a live `review:local` run (observed while reviewing #116):

```
TypeError: Cannot read properties of null (reading 'summary')
    at reviewFiles (tools/ai-review.mjs:446:56)
```

The per-file loop handles provider failure (`r.failed` → skip note) and invalid JSON (catch → skip note), but `JSON.parse("null")` **succeeds** — a provider that returns a bare `null` (or any non-object JSON) slipped past the catch and threw at `parsed.summary`, killing the entire run instead of skipping one file. The retry succeeded, which is why it never reproduced before.

## Change

After the parse, `parsed` that is not a non-null object is folded into the existing invalid-JSON path — same per-file "Model returned invalid JSON; findings skipped" summary, run continues. Missing `message.content` (`undefined`) lands on the same path via the parse throw.

## Tests

Four cases in `test/unit/publish/ai-review.test.mjs`, all asserting a skip summary + zero diagnostics instead of a throw: bare `null` (the observed shape), `42`, `"just a string"`, and missing `message.content`. Suite: 139 pass / 0 fail; lint ✓; format ✓.

🤖 This PR was created by an agent (Codebuff).
