### PR TITLE
chore(coderabbit): disable review status comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,6 +7,9 @@
 # local `cr` CLI for batched combined-branch reviews). Groq (ai-review.yml)
 # covers the always-on advisory pass instead.
 reviews:
+  # No status comments (e.g. "Review skipped / looks good") while auto_review
+  # is off — keep PRs free of bot chatter; `@coderabbitai review` still works.
+  review_status: false
   auto_review:
     enabled: false
   path_filters:


### PR DESCRIPTION
Fixes #118

## What

Add `review_status: false` under `reviews:` in `.coderabbit.yaml`.

## Why

`auto_review.enabled: false` stops reviews but CodeRabbit still posts a status comment on every PR ("Review skipped" / "looks good" variants) — bot chatter with no review behind it. `review_status: false` suppresses those comments while keeping on-demand `@coderabbitai review` fully functional. Key verified against the [configuration reference](https://docs.coderabbit.ai/reference/configuration-template).

## Scope

3 lines, config-only. No code paths touched — no test added (nothing executable changed).

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>