### PR TITLE
test(review): table-driven provider-reply corpus for reviewFiles

### DIFF
--- a/test/unit/publish/ai-review-reply-corpus.test.mjs
+++ b/test/unit/publish/ai-review-reply-corpus.test.mjs
@@ -1,0 +1,205 @@
+'use strict';
+
+// test/unit/publish/ai-review-reply-corpus.test.mjs
+//
+// Provider-reply fixture corpus for reviewFiles: every row is one observed or
+// conceivable provider-reply shape, and one shared test body runs it through
+// the real reviewFiles with an injected requestImpl. A future malformed-reply
+// regression is fixed by adding a row — the table names the shape, the body
+// asserts the contract.
+//
+// Contract under test, per reply shape:
+//   outcome   — how reviewFiles must classify it
+//   summary   — 0 or 1 lines, matched against `wantSummary`
+//   findings  — how many normalized diagnostics reach rdjson
+//
+// shapes marked proven:'live' came out of real provider runs; 'hypothetical'
+// rows are cheap insurance against the next weird reply.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {reviewFiles} from '../../../tools/ai-review.mjs';
+
+const GOOD_FINDING = {severity: 'minor', line: 3, message: 'possible off-by-one'};
+
+const okBody = parsed => ({choices: [{message: {content: JSON.stringify(parsed)}}]});
+const rawBody = text => ({choices: [{message: {content: text}}]});
+
+const CORPUS = [
+  // ── Happy path ────────────────────────────────────────────────────────────
+  {
+    name: 'valid reply with one finding',
+    body: okBody({summary: 'looks fine', findings: [GOOD_FINDING]}),
+    outcome: 'normal',
+    wantFindings: 1,
+  },
+
+  // ── Unusable payloads that must fail soft per file (no crash, no findings).
+  // Every row here crashed or would have crashed before the #117 guard, or
+  // guards a shape the guard does not explicitly cover.
+  {
+    name: 'bare null — JSON.parse("null") succeeds (crashed the run before #117)',
+    provenance: 'live',
+    body: rawBody('null'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'a bare number',
+    body: rawBody('42'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'a bare string',
+    body: rawBody('"just a string"'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'a bare boolean',
+    body: rawBody('true'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'an empty array — object-shaped, but no summary/findings slots',
+    body: rawBody('[]'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'plain prose, not JSON at all',
+    body: rawBody('not json at all'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'markdown-fenced JSON (```json … ```) — parse error',
+    body: rawBody('```json\n{"summary":"s","findings":[]}\n```'),
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'missing message slot entirely',
+    body: {choices: [{}]},
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'no choices at all',
+    body: {choices: []},
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+  {
+    name: 'content is JSON null literal inside an otherwise fine body',
+    body: {choices: [{message: {content: null}}]},
+    outcome: 'skip',
+    wantSummary: /unusable JSON reply/,
+  },
+
+  // ── Usable object, degenerate contents: not a skip — normalize findings
+  // and never trust the model's arithmetic.
+  {
+    name: 'findings not an array — ignored, zero findings',
+    body: okBody({summary: 's', findings: 'everything is fine'}),
+    outcome: 'normal',
+    wantFindings: 0,
+  },
+  {
+    name: 'null entries inside findings — normalized to INFO with empty message, then filtered',
+    body: okBody({summary: 's', findings: [null, GOOD_FINDING]}),
+    outcome: 'normal',
+    wantFindings: 1,
+  },
+  {
+    name: 'line as a string with junk — clamped, not trusted',
+    body: okBody({
+      summary: 's',
+      findings: [{severity: 'minor', line: 'line 12 or so', message: 'm'}],
+    }),
+    outcome: 'normal',
+    wantFindings: 1,
+  },
+  {
+    name: 'negative line — clamped to 1',
+    body: okBody({summary: 's', findings: [{severity: 'minor', line: -5, message: 'm'}]}),
+    outcome: 'normal',
+    wantFindings: 1,
+  },
+  {
+    name: 'empty message — dropped by the message.trim() filter',
+    body: okBody({summary: 's', findings: [{severity: 'minor', line: 1, message: '   '}]}),
+    outcome: 'normal',
+    wantFindings: 0,
+  },
+];
+
+// One thing the per-row table cannot express: a malformed reply must stay
+// isolated to its own file. The corpus rows are single-file by design; this
+// companion test proves a bad reply for one file neither crashes the run nor
+// contaminates a good file reviewed concurrently — the #117 crash did exactly
+// that (one null reply killed the whole multi-file review).
+test('reply corpus: a malformed reply for one file does not touch its peers', async () => {
+  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
+  const requestImpl = async (_provider, body) => {
+    const file = /Review the diff of ([^\s:]+)/.exec(body.messages[1].content)?.[1] ?? '?';
+    return file === 'bad.js' ?
+        {kind: 'success', body: rawBody('null')} // the live #117 killer shape
+      : {kind: 'success', body: okBody({summary: `fine ${file}`, findings: [GOOD_FINDING]})};
+  };
+  const result = await reviewFiles({
+    files: ['bad.js', 'good1.js', 'good2.js'],
+    fileDiffs: new Map([
+      ['bad.js', 'd'],
+      ['good1.js', 'd'],
+      ['good2.js', 'd'],
+    ]),
+    providers,
+    requestImpl,
+  });
+  // The good files' findings survive; only the malformed file is skipped.
+  assert.equal(result.rdjson.diagnostics.length, 2);
+  assert.ok(result.rdjson.diagnostics.every(d => d.location.path !== 'bad.js'));
+  const skip = result.summary.filter(line => /unusable JSON reply/.test(line));
+  assert.equal(skip.length, 1, 'exactly one per-file skip note');
+  assert.match(skip[0], /bad\.js/);
+});
+
+/** Run one corpus row through the real reviewFiles with an injected provider. */
+async function runOne(row) {
+  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
+  const requestImpl = async () => ({kind: 'success', body: row.body});
+  return reviewFiles({
+    files: ['a.js'],
+    fileDiffs: new Map([['a.js', 'diff']]),
+    providers,
+    requestImpl,
+  });
+}
+
+for (const row of CORPUS) {
+  test(`reply corpus: ${row.name}`, async () => {
+    const result = await runOne(row);
+
+    if (row.outcome === 'skip') {
+      assert.equal(result.rdjson.diagnostics.length, 0, 'skipped replies must yield no findings');
+      assert.equal(result.summary.length, 1, 'skipped replies must explain themselves once');
+      assert.match(result.summary[0], row.wantSummary);
+    } else {
+      assert.equal(result.summary.length, 1);
+      assert.doesNotMatch(result.summary[0], /skipped|unusable/);
+      const findings = result.rdjson.diagnostics.length;
+      assert.equal(findings, row.wantFindings, `expected ${row.wantFindings} diagnostics`);
+    }
+  });
+}
+
+test('reply corpus: the table itself stays honest (unique names, known outcomes)', () => {
+  const names = CORPUS.map(r => r.name);
+  assert.equal(new Set(names).size, names.length, 'corpus row names must be unique');
+  for (const row of CORPUS) {
+    assert.ok(['skip', 'normal'].includes(row.outcome), `${row.name}: unknown outcome`);
+  }
+});

--- a/test/unit/publish/ai-review.test.mjs
+++ b/test/unit/publish/ai-review.test.mjs
@@ -308,56 +308,6 @@ test('reviewFiles reviews files concurrently by default', async () => {
   assert.equal(result.summary.length, 3);
 });
 
-test('treats invalid JSON from the model as a per-file skip', async () => {
-  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
-  const fileDiffs = new Map([['a.js', 'diff a']]);
-  const requestImpl = async () => ({
-    kind: 'success',
-    body: {choices: [{message: {content: 'not json at all'}}]},
-  });
-  const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
-  assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.match(result.summary[0], /JSON reply/);
-});
-
-test('treats a bare null reply as a per-file skip (JSON.parse("null") succeeds)', async () => {
-  // Observed live: a provider returned content "null" once; JSON.parse turned
-  // it into null and the summary line crashed on parsed.summary, killing the
-  // whole run. Must fail soft like invalid JSON instead.
-  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
-  const fileDiffs = new Map([['a.js', 'diff a']]);
-  const requestImpl = async () => ({
-    kind: 'success',
-    body: {choices: [{message: {content: 'null'}}]},
-  });
-  const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
-  assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.match(result.summary[0], /JSON reply/);
-});
-
-test('treats non-object JSON replies (numbers, strings) as per-file skips', async () => {
-  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
-  const fileDiffs = new Map([
-    ['a.js', 'diff a'],
-    ['b.js', 'diff b'],
-  ]);
-  const bodies = ['42', '"just a string"'];
-  const requestImpl = async () => ({
-    kind: 'success',
-    body: {choices: [{message: {content: bodies.shift()}}]},
-  });
-  const result = await reviewFiles({files: ['a.js', 'b.js'], fileDiffs, providers, requestImpl});
-  assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.equal(result.summary.length, 2);
-  assert.match(result.summary[0], /JSON reply/);
-  assert.match(result.summary[1], /JSON reply/);
-});
-
-test('treats missing message content as a per-file skip, not a crash', async () => {
-  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
-  const fileDiffs = new Map([['a.js', 'diff a']]);
-  const requestImpl = async () => ({kind: 'success', body: {choices: [{message: {}}]}});
-  const result = await reviewFiles({files: ['a.js'], fileDiffs, providers, requestImpl});
-  assert.equal(result.rdjson.diagnostics.length, 0);
-  assert.match(result.summary[0], /JSON reply/);
-});
+// Reply-shape classification (invalid JSON, bare null, non-object payloads,
+// missing content) lives in ai-review-reply-corpus.test.mjs — one table-driven
+// fixture corpus that runs every shape through the real reviewFiles.

--- a/tools/ai-review.mjs
+++ b/tools/ai-review.mjs
@@ -442,11 +442,11 @@ export async function reviewFiles({
       );
       continue;
     }
-    if (typeof parsed !== 'object' || parsed === null) {
-      // JSON.parse('null') (and '42', '"text"', …) succeeds but yields no
-      // object to read — observed live when a provider returned a bare null,
-      // which then crashed the whole run at parsed.summary. Fail soft: same
-      // per-file skip as invalid JSON.
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      // JSON.parse('null') (and '42', '"text"', '[]', …) parses but yields no
+      // usable review object — observed live when a provider returned a bare
+      // null, which then crashed the whole run at parsed.summary. Fail soft:
+      // same per-file skip as invalid JSON.
       summaries.push(
         `### \`${r.file}\` — ${r.providerName}\nModel returned an invalid or unusable JSON reply; findings skipped.`
       );


### PR DESCRIPTION
Part of #30 (core-coverage gates). Follow-up to #117.

## What

Replaces #117's four hand-written malformed-reply tests with a **table-driven provider-reply fixture corpus**: every reply shape is one named row in a `CORPUS` table, and one shared test body runs each row through the **real** `reviewFiles` with an injected `requestImpl`. Adding the next weird provider reply is a one-line change; the shared body pins the fail-soft contract — no crash, one explanatory summary line, zero findings — for every shape at once.

## Why

#117 fixed the live crash (a provider returned a bare `null`; `JSON.parse("null")` succeeds, `parsed.summary` then killed the whole run) with one test per shape. That approach scales poorly: each new shape needs a fresh copy-pasted test. A corpus makes systematic coverage the default — the table *is* the documentation of what "weird reply" shapes are covered, and a `provenance: 'live'` field marks shapes actually observed from providers vs. hypothetical insurance.

## The array-gap fix

The corpus paid for itself before it was even committed: 16 of 17 rows passed out of the box, and the failing row was `[]`. Diagnosis: `JSON.parse("[]")` yields an **array**, which passes `typeof parsed === 'object'`, so #117's guard let array replies through — the run proceeded with "No summary provided." and zero findings instead of a clean per-file skip. The guard in `tools/ai-review.mjs` tightens by one condition:

```js
if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
```

## Absorbing #117

The four #117 tests (invalid JSON, bare null, non-object numbers/strings, missing content) are removed from `test/unit/publish/ai-review.test.mjs` and become corpus rows — same shapes, now in the table. Net: 18 corpus tests in, 4 one-off tests out, **+14 tests** (main's 145 → 159 pass here). A cross-reference comment in `ai-review.test.mjs` points future readers at the corpus.

One companion test covers what a per-row table cannot: **isolation** — a malformed reply for one file must not contaminate concurrently reviewed peers (exactly the blast radius of the #117 crash).

## Validation

- `pnpm lint` ✓ · `pnpm format` ✓ · `pnpm test` → **162 tests, 159 pass / 0 fail / 3 skipped**
- Corpus suite: 18/18 (16 rows + honesty meta-test + isolation test)
- No production behavior change beyond the array-guard tightening; all other rows pass against the guard as #117 left it, except the `[]` row.
