### PR TITLE
fix(publish): restore actions:write for the pre-flight cache prune

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ on:
 permissions:
   contents: write # release assets + gh-pages pushes
   actions: write # release-gate cache-prune step deletes stale Actions caches
-  issues: read # job-level default; pre-publish elevates to write (below)
+  issues: write # ADR 0021: the pre-flight's warn-and-continue path opens a deduped notification issue when a fork's version lookup fails
 
 concurrency:
   group: pages-publish
@@ -59,10 +59,6 @@ jobs:
   pre-publish:
     name: check browser version drift
     runs-on: ubuntu-latest
-    # ADR 0021: this job's warn-and-continue path opens a deduped notification
-    # issue when a fork's version lookup fails — the only job that needs it.
-    permissions:
-      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
One-line revert of CodeRabbit finding #3 on #123 (zizmor excessive-permissions): scoping `issues: write` to the `pre-publish` job made that job's `permissions:` block **replace** the workflow-level one, silently dropping `actions: write`. The release-gate `Prune stale Actions caches` step then 403s (`Resource not accessible by integration`) — first hit on [run 33953091944](https://github.com/onemen/firefox-scripts/actions/runs/33953091944), and it would block **every** prod publish.

Verified live: the same prune with a PAT deletes fine (204); only the scoped job's `GITHUB_TOKEN` gets 403. Also drained the current cache backlog locally (25 deleted) so the next publish isn't blocked while this merges.

Restores the pre-#123 semantics: workflow-level `issues: write`, no job-level block — the capability is still only exercised by the pre-flight notification path (ADR 0021).