### PR TITLE
docs(plan): retire docs/local_plan — absorb unfinished items into main docs

### DIFF
--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -15,8 +15,7 @@ description:
    (`installer/web/`), publish tooling (`tools/publish/`), or docs (`docs/`).
 2. **Read the relevant docs** — `docs/DEVELOPING.md` first (structure, build, tests, CI);
    `docs/auto-updater.md` / `docs/status-logic.md` for the updater; the decision log
-   `docs/decisions/index.md` (steering veto list) before any architectural or design change;
-   `docs/local_plan/` drafts when they cover the area.
+   `docs/decisions/index.md` (steering veto list) before any architectural or design change.
 3. **Load a matching skill** from `.agents/skills/` — `ai-review` (PR review step),
    `generated-files` (regeneration), `publishing` (releases). This workflow covers the rest.
 4. **Check whether the affected files are generated** — generated files are gitignored and never
@@ -55,7 +54,6 @@ explain why (CI gate tracked in issue #30).
 
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
-- `docs/local_plan/` changes remain in its own repository;
 - no unrelated files were modified;
 - failed/unavailable validation is reported;
 - when the PR is ready for review, run the ADR 0020 review step (see the `ai-review` skill).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ Architecture deep dive: `docs/DEVELOPING.md` (structure, installer/updater flow,
 - Preserve upstream provenance in `core/`: files outside `updater/` come from
   xiaoxiaoflood/firefox-scripts (MPL-2.0); `updater/` is custom (MIT). Avoid unrelated changes to
   upstream-derived files.
-- Read the relevant `docs/` (and `docs/local_plan/`, plus the decision log
-  `docs/decisions/index.md`) before architectural or design changes.
+- Read the relevant `docs/`, plus the decision log `docs/decisions/index.md`, before architectural
+  or design changes.
 - Keep `docs/ci-inventory.md` synchronized when changing workflow names, triggers, path filters,
   gates, scheduled jobs, or watchdog behavior. Keep workflow job names and required/advisory status
   semantics accurate.
@@ -174,8 +174,7 @@ is not gated on CI — it can help debug failing checks. Add no CI/repo AI secre
 Before changing code:
 
 1. Identify the affected subsystem.
-2. Read the relevant `docs/` (and `docs/local_plan/`, and the decision log
-   `docs/decisions/index.md`) documentation.
+2. Read the relevant `docs/`, and the decision log `docs/decisions/index.md`.
 3. If a skill in `.agents/skills/` matches the task (review, publishing, generated files), load it.
 4. Check whether the affected files are generated.
 5. Make the smallest appropriate change.
@@ -187,7 +186,6 @@ Before finishing:
 
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
-- `docs/local_plan/` changes remain in its own repository;
 - no unrelated files were modified;
 - failed/unavailable validation is reported.
 

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -7,6 +7,12 @@ hash-based status logic is in `docs/status-logic.md`.
 Each section links to its tracking issue under the
 [Post-v1.0 umbrella (#38)](https://github.com/onemen/firefox-scripts/issues/38).
 
+> **`docs/local_plan/` retired (2026-09-05).** The nested planning repo stopped receiving updates in
+> August 2026 and is no longer used. Its unfinished items were audited against `main` and the phase
+> issues (#3, #4, #38) and are absorbed into this file (§3 note, §6) and `docs/roadmap.md`. A
+> machine-readable handoff — which issues need updates, which to open, and the recommended order —
+> is in `docs/local-plan-gap.local.md` (untracked working notes).
+
 ## 1. Updater end-to-end test list
 
 The updater UI is now a shipped package (ADR
@@ -119,6 +125,13 @@ VM, or a non-elevated user running against an admin-owned install dir. The autom
 - [ ] Publish a `helper_<platform>.sha256` asset alongside the helper binaries and assert the
       downloaded binary matches it (see §2.2 helper-binary trust).
 
+Staging publish target — mostly shipped, remainder folded here: `paths.js` already reads env
+variables over `installer.conf` (`cfg()` precedence) and `--mode=dev` provides the safe dev-build
+channel. Still open from the original plan: a **STAGING banner + guard** when env overrides redirect
+publish targets away from prod (fail or warn loudly), and **`.env-example` documentation of the
+staging keys** (`REPO_OWNER`, `ZIP_PAGES_BRANCH`, `RELEASE_NAME`, `HASHES_URL`, …). Tracked under
+#33 with the pipeline work.
+
 Items below shipped in v1.0 and are kept for reference:
 
 - ~~Compile + upload the installer and helper binaries~~ (shipped: `upload.mjs` builds + uploads all
@@ -159,6 +172,34 @@ sync problem is gone — there is nothing tracked that can drift (see ADR
       (currently requires a live browser).
 - [ ] Re-verify the `skippedHash.*` clearing logic when the remote hash changes or local files
       match.
+
+## 6. Test infrastructure (absorbed from `docs/local_plan`)
+
+Items from the retired planning repo (`tests.plan.md`, `CI.plan.md`, `test-deployment.plan.md`)
+verified **not implemented on `main`** and **not covered** by #3 / #4 / #38 as of 2026-09-05. The
+proposed tracking home is listed per item; see `docs/local-plan-gap.local.md` for the consolidated
+issue-update / issue-creation plan.
+
+- **Installer `--port 0` / `--server-only` test flags** (C: `installer/src/main.c` + Makefile).
+  `--port 0` binds an OS-ephemeral port so parallel CI jobs never collide on `DEFAULT_PORT=8777`;
+  `--server-only` skips the browser scan so the second-instance path (`tcp_listening`) is reachable
+  headless. The installer currently has no such flags. Unblocks: installer API-contract tests,
+  free-port/no-hijack/second-instance coverage. Home: a Phase 4 (#3) child issue.
+- **`env.json` deployment manifest** — the running installer writes port/URLs/hashes/run-id to a
+  file the E2E harness reads (local/CI parity; no port scraping). Not implemented. Home: the same
+  Phase 4 (#3) child issue as the flags (they ship together).
+- **E2E profile/process hygiene** — kill stray installer/browser processes between runs,
+  `removeProfileCompatibilityIni` after profile seeding, tag spawned processes for teardown —
+  deterministic repeats on all three OSes. Not implemented in `test/e2e/`. Home: #3 (Phase 4).
+- **`FIREFOX_BINARY` pinning** — E2E resolves the latest browser release at run time
+  (`downloads.mjs`); a runner-side vendor update can flip a green matrix red with no repo change.
+  Decide a pin/cache policy (URL with pinned version + periodic bump via the URL watchdog). Home: #3
+  now; revisited when the matrix expands (#31).
+- **`msys2/setup-msys2` release caching** — Windows legs run with `update: true`, re-fetching the
+  toolchain every run; `cache: true` would trade freshness for minutes per job (same trade the
+  cached `-fanalyzer` leg already made, PRs #105/#106). Home: #33 (pipeline automation) or as CI
+  polish under #4.
+- ~~**Test runner + layout decision** (`node:test`, type-first `test/`)~~ — settled: PR #52.
 
 ## Historical: Firefox 155 chrome-frame probes (obsolete)
 

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -7,12 +7,6 @@ hash-based status logic is in `docs/status-logic.md`.
 Each section links to its tracking issue under the
 [Post-v1.0 umbrella (#38)](https://github.com/onemen/firefox-scripts/issues/38).
 
-> **`docs/local_plan/` retired (2026-09-05).** The nested planning repo stopped receiving updates in
-> August 2026 and is no longer used. Its unfinished items were audited against `main` and the phase
-> issues (#3, #4, #38) and are absorbed into this file (§3 note, §6) and `docs/roadmap.md`. A
-> machine-readable handoff — which issues need updates, which to open, and the recommended order —
-> is in `docs/local-plan-gap.local.md` (untracked working notes).
-
 ## 1. Updater end-to-end test list
 
 The updater UI is now a shipped package (ADR
@@ -173,12 +167,10 @@ sync problem is gone — there is nothing tracked that can drift (see ADR
 - [ ] Re-verify the `skippedHash.*` clearing logic when the remote hash changes or local files
       match.
 
-## 6. Test infrastructure (absorbed from `docs/local_plan`)
+## 6. Test infrastructure
 
-Items from the retired planning repo (`tests.plan.md`, `CI.plan.md`, `test-deployment.plan.md`)
-verified **not implemented on `main`** and **not covered** by #3 / #4 / #38 as of 2026-09-05. The
-proposed tracking home is listed per item; see `docs/local-plan-gap.local.md` for the consolidated
-issue-update / issue-creation plan.
+Test-infrastructure gaps verified **not implemented on `main`** and **not covered** by #3 / #4 / #38
+as of 2026-09-05. The proposed tracking home is listed per item.
 
 - **Installer `--port 0` / `--server-only` test flags** (C: `installer/src/main.c` + Makefile).
   `--port 0` binds an OS-ephemeral port so parallel CI jobs never collide on `DEFAULT_PORT=8777`;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,15 +16,17 @@ Order matters: installer / updater / tests / CI first, core-file PRs last.
 - **P0-3** E2E speed: browser download map (`test/e2e/shared/downloads.mjs`) + shorter waits.
 - **P1-2** Docs restructure (developer/maintainer vs user docs) + `future-work.md` sync.
 - **P2-1** `userChrome.js` `createElement`: `toggleAttribute` for Firefox 149+ (bug 2008041).
-- **P2-2** `BootstrapLoader`: release the spin wait on load errors (#25, PR #26 — merge pending
-  approval).
+- **P2-2** `BootstrapLoader`: release the spin wait on load errors (#25, PR #26).
 - **P1-6** Test restructure: type-first layout under `test/` (PR #52).
 - **Release gate (#4)** — remove README banner, v1.0 tag, milestone close, env protection for prod
   uploads, zip-the-installer-exe decision, tag move (P0-1).
 
 Remaining Phase 4 gaps are tracked by child issues #35–#37 (Dev Edition leg, installer UI layer,
 install-applies path) and #53–#56 (manual utils install, installer self-update tests, snap legs,
-portable-install legs).
+portable-install legs). Test-infrastructure gaps absorbed from the retired `docs/local_plan`
+planning repo — installer `--port 0`/`--server-only` test flags, an `env.json` deployment manifest,
+profile/process hygiene between E2E runs — are listed in `docs/future-work.md` §6 with their
+proposed issue homes.
 
 ## Post v1.0 (umbrella #38, milestone "Post v1.0")
 
@@ -33,6 +35,10 @@ portable-install legs).
 - Core code test coverage — stub smoke tests + Nightly leg + test-required rule (#30).
 - Browser-matrix expansion — Waterfox / Zen / Nightly (#31).
 - UAC/admin-rights automation (#32), publish-pipeline automation (#33), UI/UX polish (#34).
+- Nightly E2E and nightly publish triggers — publish side needs the staging completion (STAGING
+  banner, guards, `.env-example` keys) first; see `docs/future-work.md` §3 and §6.
+- macOS universal installer binary (arm64 + x86_64) — decide; `dist_mac` currently builds
+  native-arch only (`docs/future-work.md` §6).
 - Detailed backlog: `docs/future-work.md`.
 
 ## How to update

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,10 +23,9 @@ Order matters: installer / updater / tests / CI first, core-file PRs last.
 
 Remaining Phase 4 gaps are tracked by child issues #35–#37 (Dev Edition leg, installer UI layer,
 install-applies path) and #53–#56 (manual utils install, installer self-update tests, snap legs,
-portable-install legs). Test-infrastructure gaps absorbed from the retired `docs/local_plan`
-planning repo — installer `--port 0`/`--server-only` test flags, an `env.json` deployment manifest,
-profile/process hygiene between E2E runs — are listed in `docs/future-work.md` §6 with their
-proposed issue homes.
+portable-install legs). Additional test-infrastructure gaps — installer `--port 0`/`--server-only`
+test flags, an `env.json` deployment manifest, profile/process hygiene between E2E runs — are listed
+in `docs/future-work.md` §6 with their proposed issue homes.
 
 ## Post v1.0 (umbrella #38, milestone "Post v1.0")
 


### PR DESCRIPTION
## Summary

`docs/local_plan/` — a nested git repo of working plans — stopped receiving updates on **2026-08-11** and the maintainer has retired it. This PR absorbs its still-relevant content into the tracked docs so nothing is lost, and removes the agent-facing references to it.

Nothing here changes scope on its own: every absorbed item was **re-verified against current `main` (`c475877`) and issues #3 / #4 / #38** on 2026-09-05, rather than trusting the August draft gap report (`5405ce0` on `docs/local-plan-implementation-gap`), which predates several merges and overstates some gaps.

## What landed where

| File | Change |
|---|---|
| `docs/roadmap.md` | Post-v1.0 list gains two absorbed scope rows — nightly E2E **and publish** triggers (staging precondition noted) and the macOS universal installer decision. Stale "PR #26 merge pending" note fixed (merged 2026-08-26). |
| `docs/future-work.md` | Retirement notice header; §3 note: staging-target remainder (STAGING banner/guard + `.env-example` staging keys → #33 — `paths.js` env precedence and `--mode=dev` already shipped); **new §6** — verified-missing test-infrastructure items (installer `--port 0`/`--server-only` + `env.json` manifest, E2E profile/process hygiene, `FIREFOX_BINARY` pinning, msys2 caching) with proposed issue homes. |
| `AGENTS.md`, `.agents/skills/change-workflow/SKILL.md` | All `docs/local_plan/` references removed. |

## Explicitly not done here (per instruction)

- **No issues created or edited.** The machine-readable handoff — which existing issues need checklist updates (#3, #33, #38), which new issues to open, and the recommended continuation order — is in **`docs/local-plan-gap.local.md`** (untracked, `.local` convention; it does not travel with this PR).
- `docs/local_plan/` itself is untouched and remains in its own repository.

## Already shipped (recorded in the handoff so nobody re-proposes)

Test layout + `node:test` (PR #52) · staging env precedence in `paths.js` + `--mode=dev` · `versionInfo.json` stop-shipping · generated-file sync gate (superseded by ADR 0008) · E2E harness decision (ADR 0015) · loopback-iframe probe (obsolete via ADR 0007) · workflow files + CI jobs.

## Validation

- prettier + eslint clean on all changed files
- `pnpm test`: 207 passed / 0 failed
- docs-only change; no code paths touched

Part of #38 (roadmap/docs upkeep).