### PR TITLE
docs(worktrees): codify task worktrees under worktrees/ + node_modules link rules

### DIFF
--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -9,6 +9,25 @@ description:
 
 # Making a change
 
+## Worktrees & node_modules
+
+Do task work in a fresh `git worktree add ../<parent>/worktrees/<slug> -b <branch>` (one folder per
+task, trivially deletable, out of the parent dir). A stale-husk sweep after threads exit is just
+`rmdir worktrees/*`. Remove the worktree before finishing (`git worktree remove <path>`; retry the
+empty dir later if a process still holds it as its cwd).
+
+A fresh worktree carries no install. Link the parent's via `tools/publish/refNodeModules.mjs`
+(`import` it and call `linkNodeModules(parentRoot, worktreeRoot)`; it returns null when the parent
+has no install). That is a junction/symlink to the parent's real store, so:
+
+- **safe to _run_ tools through it** (eslint, prettier, the test runner);
+- **never run pnpm-mutating commands inside the worktree** — `pnpm install` / adding a dependency
+  re-homes the parent's `.pnpm` link farm toward the worktree's virtual store, leaving the parent
+  with dangling links the moment the worktree is deleted. Install/update only in the parent
+  checkout, then re-link.
+- clean up with `unlinkNodeModules(worktreeRoot)` **before** `git worktree remove`, so removal never
+  traverses into the shared store.
+
 ## Before editing
 
 1. **Identify the affected subsystem** — installer (`installer/`), chrome scripts (`core/`), web UI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,10 @@ is not gated on CI — it can help debug failing checks. Add no CI/repo AI secre
 
 ## Agent workflow
 
+**Task worktrees:** use `<workspace>/worktrees/<slug>/` (one deletable folder per task) and remove
+them before finishing (`git worktree remove`; retry the empty dir if a process still held it).
+Worktree node_modules link rules live in the `change-workflow` skill.
+
 Before changing code:
 
 1. Identify the affected subsystem.
@@ -187,7 +191,9 @@ Before finishing:
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
 - no unrelated files were modified;
-- failed/unavailable validation is reported.
+- failed/unavailable validation is reported;
+- the task worktree is removed (`git worktree remove`; retry the empty directory if a process still
+  held it).
 
 ## Roadmap tracking
 


### PR DESCRIPTION
## What & why

Parallel agent threads scatter `git worktree add` at the workspace root, leaving empty "husk"
directories whenever a process still holds one at removal time (a known recurring clean-up
friction). This PR standardizes on `<workspace>/worktrees/<slug>/` so each task is one deletable
folder and a stale-husk sweep is a single `rmdir worktrees/*`.

It also documents the `tools/publish/refNodeModules.mjs` junction/symlink contract, which bit us
today: linking a worktree's `node_modules` to the parent's store is safe to **run** tools through,
but **never** run pnpm-mutating commands inside the worktree — pnpm re-homes the parent's `.pnpm`
link farm toward the worktree's virtual store, leaving the parent with dangling links the moment the
worktree is deleted.

## Shape

Kept AGENTS.md a checklist (per its own rule "this file stays a checklist, not a manual") — a 3-line
pointer plus a Before-finishing line about removing the task worktree. The worktree/node_modules
detail moves to the **`change-workflow`** skill, where it's read mid-task.

## Validation

Docs-only. Prettier clean on both files; lint + 212-test suite pass on the parent checkout.

No issue linked (docs-only worktree convention; not part of #3/#4/#38).