### PR TITLE
fix(ci): correct the meta-issue comment API path in record-validation

### DIFF
--- a/tools/ci/record-validated-versions.mjs
+++ b/tools/ci/record-validated-versions.mjs
@@ -208,16 +208,19 @@ async function notifyMetaIssue(record) {
       console.log('meta issue not found yet — validation comment deferred to the watchdog');
       return;
     }
+    // The comment endpoints are scoped under /repos/{owner}/{repo}/issues/{n}
+    // (issue comments, not repository comments) — matching the watchdog's own
+    // GitHub calls in check-browser-downloads.mjs.
     const comments = await ghJson(
       token,
-      `/repos/${meta.number}/comments?per_page=5&sort=created&direction=desc`
+      `/repos/${repo}/issues/${meta.number}/comments?per_page=5&sort=created&direction=desc`
     );
     const last = comments.find(c => c.body?.startsWith('Validated by E2E:'));
     if (last && last.body.includes(versions)) {
       console.log(`meta issue already shows ${versions} — no comment`);
       return;
     }
-    await ghJson(token, `/repos/${meta.number}/comments`, {
+    await ghJson(token, `/repos/${repo}/issues/${meta.number}/comments`, {
       method: 'POST',
       body: {body},
     });


### PR DESCRIPTION
Fixes a bug surfaced by the first live full-dispatch record after #137: `notifyMetaIssue` (in `tools/ci/record-validated-versions.mjs`) built its comment URLs as `/repos/{issue-number}/comments` — the issue number in the *repository* slot — instead of `/repos/{owner}/{repo}/issues/{n}/comments`. Every attempt 404'd:

```
meta issue notification failed (non-fatal): GitHub API GET /repos/136/comments?...: HTTP 404 Not Found
```

So the "Validated by E2E: firefox=X · firefox-dev=Y — [run](…)" comment never landed on the `[url-watchdog] status` meta issue (the notification is non-fatal, which is why the job and record still succeeded).

Fix: both the GET (dedup check) and POST now use `/repos/${repo}/issues/${meta.number}/comments`, matching the watchdog's own GitHub calls in `check-browser-downloads.mjs`.

Verified: lint, format, and the record-validated-versions unit tests pass.