### PR TITLE
feat(worktrees): post-checkout hook auto-initializes new worktrees (pnpm install + .env)

### DIFF
--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -18,11 +18,12 @@ task, trivially deletable, out of the parent dir). A stale-husk sweep after thre
 still holds it as its cwd).
 
 A fresh worktree carries no install: run `pnpm install` in it before running tools. pnpm hard-links
-packages from the global content-addressable store, so this is fast and disk-cheap, and the worktree
-stays fully self-contained — nothing done inside it can corrupt the parent checkout. When the opt-in
-githooks are installed (`pnpm hooks:install`), the `post-checkout` hook already does this for
-brand-new worktrees — it also copies the untracked `.env` from the main checkout — so a fresh
-worktree is ready to use immediately.
+packages from the global content-addressable store, so this is fast and disk-cheap, and the
+worktreestays fully self-contained — nothing done inside it can corrupt the parent checkout. When
+the opt-in githooks are installed (`pnpm hooks:install`), the `post-checkout` hook already does this
+for brand-new worktrees, so a fresh worktree is ready to use immediately. (The hook does not copy
+the root `.env` — the GitHub token stays in the main checkout only; copy it by hand if a token-using
+command must run from a worktree.)
 
 Never link/symlink the parent's node_modules into a worktree (junction or otherwise). A shared
 mutable store looks cheaper but corrupted the parent install twice in one day: pnpm invoked inside

--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -19,7 +19,10 @@ still holds it as its cwd).
 
 A fresh worktree carries no install: run `pnpm install` in it before running tools. pnpm hard-links
 packages from the global content-addressable store, so this is fast and disk-cheap, and the worktree
-stays fully self-contained — nothing done inside it can corrupt the parent checkout.
+stays fully self-contained — nothing done inside it can corrupt the parent checkout. When the opt-in
+githooks are installed (`pnpm hooks:install`), the `post-checkout` hook already does this for
+brand-new worktrees — it also copies the untracked `.env` from the main checkout — so a fresh
+worktree is ready to use immediately.
 
 Never link/symlink the parent's node_modules into a worktree (junction or otherwise). A shared
 mutable store looks cheaper but corrupted the parent install twice in one day: pnpm invoked inside

--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -13,20 +13,20 @@ description:
 
 Do task work in a fresh `git worktree add ../<parent>/worktrees/<slug> -b <branch>` (one folder per
 task, trivially deletable, out of the parent dir). A stale-husk sweep after threads exit is just
-`rmdir worktrees/*`. Remove the worktree before finishing (`git worktree remove <path>`; retry the
-empty dir later if a process still holds it as its cwd).
+`rmdir worktrees/*`. Remove the worktree before finishing (`git worktree remove <path>`; add
+`--force` if it refuses over the gitignored node_modules, and retry the empty dir later if a process
+still holds it as its cwd).
 
-A fresh worktree carries no install. Link the parent's via `tools/publish/refNodeModules.mjs`
-(`import` it and call `linkNodeModules(parentRoot, worktreeRoot)`; it returns null when the parent
-has no install). That is a junction/symlink to the parent's real store, so:
+A fresh worktree carries no install: run `pnpm install` in it before running tools. pnpm hard-links
+packages from the global content-addressable store, so this is fast and disk-cheap, and the worktree
+stays fully self-contained — nothing done inside it can corrupt the parent checkout.
 
-- **safe to _run_ tools through it** (eslint, prettier, the test runner);
-- **never run pnpm-mutating commands inside the worktree** — `pnpm install` / adding a dependency
-  re-homes the parent's `.pnpm` link farm toward the worktree's virtual store, leaving the parent
-  with dangling links the moment the worktree is deleted. Install/update only in the parent
-  checkout, then re-link.
-- clean up with `unlinkNodeModules(worktreeRoot)` **before** `git worktree remove`, so removal never
-  traverses into the shared store.
+Never link/symlink the parent's node_modules into a worktree (junction or otherwise). A shared
+mutable store looks cheaper but corrupted the parent install twice in one day: pnpm invoked inside
+the worktree re-homes the parent's `.pnpm` link farm toward the worktree's virtual store, and
+removing the worktree then leaves the parent with dangling links.
+(`tools/publish/refNodeModules.mjs` is internal to the `--ref` publish flow — do not reuse it for
+task worktrees.)
 
 ## Before editing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ All paths are `<root>/.agents/skills/<name>/SKILL.md`.
 
 ## Commands
 
-Package manager is **pnpm** (root-only workspace, `"type": "module"`). No git hooks — generated
+Package manager is **pnpm** (root-only workspace, `"type": "module"`). Git hooks are opt-in only
+(`pnpm hooks:install`: pre-push gate + worktree post-checkout) and never generate files — generated
 files are produced on demand by the build/publish tooling.
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,9 @@ is not gated on CI — it can help debug failing checks. Add no CI/repo AI secre
 ## Agent workflow
 
 **Task worktrees:** use `<workspace>/worktrees/<slug>/` (one deletable folder per task) and remove
-them before finishing (`git worktree remove`; retry the empty dir if a process still held it).
-Worktree node_modules link rules live in the `change-workflow` skill.
+them before finishing (`git worktree remove`; retry the empty dir if a process still held it). Run
+`pnpm install` in a fresh worktree; never link the parent's node_modules into it — details in the
+`change-workflow` skill.
 
 Before changing code:
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -411,10 +411,12 @@ git config --unset core.hooksPath   # uninstall
   `--no-verify` (the `make analyze` leg of `pnpm lint` hard-fails without gcc) — CI still runs the
   full gate.
 - `githooks/post-checkout` self-initializes a brand-new worktree: it fires only when the checkout
-  creates one (null previous head + branch checkout, i.e. `git worktree add`), copies the untracked
-  `.env` (publish/review tokens) from the main checkout, and runs `pnpm install --prefer-offline` so
-  the worktree is immediately usable. A failure never aborts the checkout — it just leaves the
-  worktree to initialize by hand.
+  creates one (null previous head + branch checkout, i.e. `git worktree add`) and runs
+  `pnpm install --prefer-offline`, so the worktree is immediately usable. A failure never aborts the
+  checkout — it just leaves the worktree to initialize by hand. The hook is install-only and never
+  copies the main checkout's `.env`: the GitHub token lives only in the untracked root `.env`
+  (AGENTS), and duplicating it into every worktree widens its exposure — copy `.env` by hand only
+  when a token-using command (publish, AI review) must run from a worktree.
 
 Do **not** add generation steps to hooks: generated files are produced on demand by the Makefile and
 publish tooling (ADR 0008).

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -394,23 +394,30 @@ node test/e2e/installer/smoke-security.mjs
 The installer's `--smoke-test` flag makes the headless run possible: it skips the
 no-browser-detected abort and the browser-tab open, and prints the session token to stdout.
 
-## Pre-push hook (opt-in)
+## Git hooks (opt-in)
 
-The repo ships one optional git hook: `githooks/pre-push` runs the CI-equivalent gates
-(`pnpm lint && pnpm format && pnpm test`, ~3–5s with caches) before a push leaves the machine, so a
-red CI run is predictable. It is **opt-in** — ADR 0008 removed required hooks, so nothing changes
-for plain clones:
+The repo ships two optional git hooks; both are **opt-in** — ADR 0008 removed required hooks, so
+nothing changes for plain clones:
 
 ```bash
 pnpm hooks:install     # sets core.hooksPath=githooks (self-heals a stale value)
 git config --unset core.hooksPath   # uninstall
-git push --no-verify   # bypass a single push
 ```
 
-The gates are repo-wide (like CI), not scoped to the pushed range. Docs-only contributors without a
-C toolchain should push with `--no-verify` (the `make analyze` leg of `pnpm lint` hard-fails without
-gcc) — CI still runs the full gate. Do **not** add generation steps here: generated files are
-produced on demand by the Makefile and publish tooling (ADR 0008).
+- `githooks/pre-push` runs the CI-equivalent gates (`pnpm lint && pnpm format && pnpm test`, ~3–5s
+  with caches) before a push leaves the machine, so a red CI run is predictable. The gates are
+  repo-wide (like CI), not scoped to the pushed range; bypass a single push with
+  `git push --no-verify`. Docs-only contributors without a C toolchain should push with
+  `--no-verify` (the `make analyze` leg of `pnpm lint` hard-fails without gcc) — CI still runs the
+  full gate.
+- `githooks/post-checkout` self-initializes a brand-new worktree: it fires only when the checkout
+  creates one (null previous head + branch checkout, i.e. `git worktree add`), copies the untracked
+  `.env` (publish/review tokens) from the main checkout, and runs `pnpm install --prefer-offline` so
+  the worktree is immediately usable. A failure never aborts the checkout — it just leaves the
+  worktree to initialize by hand.
+
+Do **not** add generation steps to hooks: generated files are produced on demand by the Makefile and
+publish tooling (ADR 0008).
 
 ## Test the auto-updater
 

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Post-checkout: self-initialize a brand-new worktree. Opt-in — install with
+# `pnpm hooks:install` (sets git's core.hooksPath to githooks/). Remove any
+# time with `git config --unset core.hooksPath`.
+#
+# Fires only when the checkout creates a new worktree (prev_head is the null
+# hash and a branch was checked out): `git worktree add` lands here, while a
+# plain branch switch always has a non-null previous head and is untouched.
+# The hook runs after the worktree is materialized, so a failure never aborts
+# anything — it just leaves the new worktree to initialize by hand.
+
+set -u
+
+prev_head="$1"
+is_branch="$3"
+
+NULL_HASH="0000000000000000000000000000000000000000"
+
+[ "$is_branch" -eq 1 ] || exit 0
+[ "$prev_head" = "$NULL_HASH" ] || exit 0
+
+echo "post-checkout: new worktree detected — initializing."
+
+# Main repository root: the checkout that owns this worktree's common .git dir.
+main_repo=$(git rev-parse --path-format=absolute --git-common-dir | sed 's/\/\.git$//')
+
+# .env holds publish/review tokens (untracked, gitignored) — git never carries
+# it into a worktree, so copy it from the main checkout when present.
+if [ -f "$main_repo/.env" ] && [ ! -f ".env" ]; then
+  echo "post-checkout: copying .env from the main checkout."
+  cp "$main_repo/.env" .env
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "post-checkout: pnpm not on PATH — run 'pnpm install' here manually." >&2
+  exit 0
+fi
+
+echo "post-checkout: pnpm install --prefer-offline"
+pnpm install --prefer-offline || {
+  echo "post-checkout: pnpm install failed — run it manually in this worktree." >&2
+  exit 0
+}
+
+echo "post-checkout: worktree ready."
+exit 0

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -8,6 +8,12 @@
 # plain branch switch always has a non-null previous head and is untouched.
 # The hook runs after the worktree is materialized, so a failure never aborts
 # anything — it just leaves the new worktree to initialize by hand.
+#
+# Install-only by design: it deliberately does NOT copy the main checkout's
+# .env — the GitHub token lives only in the untracked root .env (AGENTS), and
+# duplicating it into every worktree widens its exposure. Copy .env by hand
+# only when a token-using command (publish, ai review) must run from a
+# worktree.
 
 set -u
 
@@ -19,17 +25,7 @@ NULL_HASH="0000000000000000000000000000000000000000"
 [ "$is_branch" -eq 1 ] || exit 0
 [ "$prev_head" = "$NULL_HASH" ] || exit 0
 
-echo "post-checkout: new worktree detected — initializing."
-
-# Main repository root: the checkout that owns this worktree's common .git dir.
-main_repo=$(git rev-parse --path-format=absolute --git-common-dir | sed 's/\/\.git$//')
-
-# .env holds publish/review tokens (untracked, gitignored) — git never carries
-# it into a worktree, so copy it from the main checkout when present.
-if [ -f "$main_repo/.env" ] && [ ! -f ".env" ]; then
-  echo "post-checkout: copying .env from the main checkout."
-  cp "$main_repo/.env" .env
-fi
+echo "post-checkout: new worktree detected — installing dependencies."
 
 if ! command -v pnpm >/dev/null 2>&1; then
   echo "post-checkout: pnpm not on PATH — run 'pnpm install' here manually." >&2

--- a/tools/install-githooks.mjs
+++ b/tools/install-githooks.mjs
@@ -4,10 +4,12 @@
  * Opt-in git hooks installer: `node tools/install-githooks.mjs` (or `pnpm
  * hooks:install`).
  *
- * Sets core.hooksPath to githooks/ — currently one pre-push gate that runs the
- * CI-equivalent checks (lint, format, test) so a red CI run is predictable. The
- * repo deliberately has no other hooks (ADR 0008 removed generation hooks;
- * generated files are built on demand by the Makefile / publish tooling).
+ * Sets core.hooksPath to githooks/ — a pre-push gate that runs the
+ * CI-equivalent checks (lint, format, test) so a red CI run is predictable, and
+ * a post-checkout hook that self-initializes brand-new worktrees (copies .env
+ * from the main checkout, runs pnpm install). The repo deliberately has no
+ * other hooks (ADR 0008 removed generation hooks; generated files are built on
+ * demand by the Makefile / publish tooling).
  *
  * Self-heals a stale core.hooksPath pointing at a missing directory (observed
  * in the wild) by replacing it, and refuses to silently stomp a live config.
@@ -63,10 +65,12 @@ if (current) {
 
 // Validate + chmod BEFORE flipping the config: a missing hook or a failed
 // chmod must never leave git pointed at hooks that cannot run.
-const prePush = path.join(HOOKS_DIR, 'pre-push');
-if (!fs.existsSync(prePush)) {
-  console.error(`✗ ${HOOKS_DIR_REL}/pre-push not found — core.hooksPath left unchanged.`);
-  process.exit(1);
+const hooks = ['pre-push', 'post-checkout'];
+for (const name of hooks) {
+  if (!fs.existsSync(path.join(HOOKS_DIR, name))) {
+    console.error(`✗ ${HOOKS_DIR_REL}/${name} not found — core.hooksPath left unchanged.`);
+    process.exit(1);
+  }
 }
 
 // Git for Windows runs hooks through bash, which ignores the executable bit;
@@ -74,13 +78,15 @@ if (!fs.existsSync(prePush)) {
 // unreliable through MSYS).
 const isWindows = process.platform === 'win32';
 if (!isWindows) {
-  fs.chmodSync(prePush, 0o755);
+  for (const name of hooks) {
+    fs.chmodSync(path.join(HOOKS_DIR, name), 0o755);
+  }
 }
 
 git('config', 'core.hooksPath', HOOKS_DIR_REL);
 console.log(`✓ core.hooksPath set to '${HOOKS_DIR_REL}'.`);
 console.log(
-  `✓ pre-push gate installed: pnpm lint && pnpm format && pnpm test` +
+  `✓ hooks installed: pre-push gate (lint/format/test) + post-checkout worktree self-init` +
     (isWindows ? '' : ' (chmod +x applied)') +
     `\n  bypass: git push --no-verify | uninstall: git config --unset core.hooksPath`
 );

--- a/tools/install-githooks.mjs
+++ b/tools/install-githooks.mjs
@@ -6,10 +6,11 @@
  *
  * Sets core.hooksPath to githooks/ — a pre-push gate that runs the
  * CI-equivalent checks (lint, format, test) so a red CI run is predictable, and
- * a post-checkout hook that self-initializes brand-new worktrees (copies .env
- * from the main checkout, runs pnpm install). The repo deliberately has no
- * other hooks (ADR 0008 removed generation hooks; generated files are built on
- * demand by the Makefile / publish tooling).
+ * a post-checkout hook that self-initializes brand-new worktrees (runs pnpm
+ * install). The hook is install-only: it never copies the main checkout's .env
+ * (the GitHub token lives only in the untracked root .env — AGENTS). The repo
+ * deliberately has no other hooks (ADR 0008 removed generation hooks; generated
+ * files are built on demand by the Makefile / publish tooling).
  *
  * Self-heals a stale core.hooksPath pointing at a missing directory (observed
  * in the wild) by replacing it, and refuses to silently stomp a live config.
@@ -86,7 +87,7 @@ if (!isWindows) {
 git('config', 'core.hooksPath', HOOKS_DIR_REL);
 console.log(`✓ core.hooksPath set to '${HOOKS_DIR_REL}'.`);
 console.log(
-  `✓ hooks installed: pre-push gate (lint/format/test) + post-checkout worktree self-init` +
+  `✓ hooks installed: pre-push gate (lint/format/test) + post-checkout worktree install` +
     (isWindows ? '' : ' (chmod +x applied)') +
     `\n  bypass: git push --no-verify | uninstall: git config --unset core.hooksPath`
 );


### PR DESCRIPTION
Completes the per-worktree-install model started in 688ad6a (drop node_modules linking — the junction to the parent's store corrupted the parent install twice in one day). With `githooks/post-checkout`, a brand-new worktree **self-initializes**: it copies the untracked `.env` from the main checkout and runs `pnpm install --prefer-offline`, so a fresh task worktree is immediately usable.

## Does the hook actually fire where we claim? (verified empirically)

Built a scratch repo and instrumented the hook to log `prev|flag|cwd`:

| Operation | prev HEAD | flag | Hook self-init? |
| --- | --- | --- | --- |
| `git worktree add -b newbranch` | `0000…` (null) | 1 | ✅ fires |
| `git worktree add <existing-branch>` | `0000…` (null) | 1 | ✅ fires |
| `git checkout` / `git switch -c` in an existing checkout | real commit | 1 | ❌ skipped (guard) |
| `git worktree add <detached sha>` | n/a | 0 | ❌ skipped (guard) |

- Hook runs with **cwd = the new worktree**, so `.env` + install land in the worktree, not the main checkout.
- `core.hooksPath=githooks` resolves against the shared common dir → the tracked hook in the main checkout serves every worktree; one `pnpm hooks:install` covers all.
- A functional run with a stub `pnpm` confirmed the `.env` copy and the install invocation happen in the worktree; the main checkout is untouched.
- A hook failure never aborts the checkout — it prints and exits 0, leaving the worktree to initialize by hand.
- A real `pnpm install` in a fresh worktree took **7 s** from the warm store (hard links) — and with no junction there is no parent-corruption failure class at all.

## Changes

- **`githooks/post-checkout`** (new) — the hook.
- **`tools/install-githooks.mjs`** — installs + chmods both hooks (`pre-push`, `post-checkout`); validation happens before the config is flipped.
- **`docs/DEVELOPING.md`** — "Git hooks (opt-in)" section documents both hooks.
- **`AGENTS.md`** — the "No git hooks" line now states the opt-in reality (two hooks ship; neither generates files).
- **`.agents/skills/change-workflow/SKILL.md`** — notes that with hooks installed, new worktrees self-init (no manual install step).

Per-worktree installs remain fully manual for anyone who hasn't run `pnpm hooks:install` — opt-in preserved (ADR 0008: no required hooks).

## Validation
- `pnpm test` 232 / 229 pass / 0 fail (3 pre-existing skips) · `pnpm lint` clean · `pnpm format` clean
- `bash -n githooks/post-checkout` clean
- Branch rebased onto latest `main` (2ab2a8b), no conflicts

Open for review — no CodeRabbit pass requested this round (hourly review limit reached).

---

### CodeRabbit review:batch (update) — 1 finding, addressed

`pnpm review:batch --pr 138 --pr 139` (single quota slot, both PRs): #138 had no findings; #139 had one **Major** — the hook copied the main checkout's `.env` (GitHub token) into every new worktree. Removed: the hook is install-only and leaves `.env` in the main checkout (token hygiene per AGENTS); docs now say to copy it by hand only when a token-using command runs from a worktree. Verified in a scratch repo: install runs, no `.env` is created.