### PR TITLE
docs(agents): fix stale skill inventory and add rules-drift discipline

### DIFF
--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -79,7 +79,5 @@ explain why (CI gate tracked in issue #30).
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
 - no unrelated files were modified;
-- any AGENTS.md / skill / docs statement this change makes wrong is updated — stale instructions
-  mislead every later run;
 - failed/unavailable validation is reported;
 - when the PR is ready for review, run the ADR 0020 review step (see the `ai-review` skill).

--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -39,8 +39,9 @@ task worktrees.)
 2. **Read the relevant docs** — `docs/DEVELOPING.md` first (structure, build, tests, CI);
    `docs/auto-updater.md` / `docs/status-logic.md` for the updater; the decision log
    `docs/decisions/index.md` (steering veto list) before any architectural or design change.
-3. **Load a matching skill** from `.agents/skills/` — `ai-review` (PR review step),
-   `generated-files` (regeneration), `publishing` (releases). This workflow covers the rest.
+3. **Load a matching skill** from `.agents/skills/` — `ai-review` (ADR 0020 review step),
+   `code-review` (standards/spec diff review), `generated-files` (regeneration), `publishing`
+   (releases). Full inventory: the Skills table in AGENTS.md.
 4. **Check whether the affected files are generated** — generated files are gitignored and never
    hand-edited; edit the source and regenerate (see the `generated-files` skill).
 
@@ -78,5 +79,7 @@ explain why (CI gate tracked in issue #30).
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
 - no unrelated files were modified;
+- any AGENTS.md / skill / docs statement this change makes wrong is updated — stale instructions
+  mislead every later run;
 - failed/unavailable validation is reported;
 - when the PR is ready for review, run the ADR 0020 review step (see the `ai-review` skill).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,8 +197,8 @@ Before finishing:
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
 - no unrelated files were modified;
-- any AGENTS.md / skill / `docs/` statement this change makes wrong is updated — stale instructions
-  mislead every later run;
+- if a code change invalidates any statement in AGENTS.md, skills, or docs/, update those documents
+  in the same step. Do not leave stale instructions;
 - failed/unavailable validation is reported;
 - the task worktree is removed (`git worktree remove`; retry the empty directory if a process still
   held it).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,11 @@ detail lives there so this file stays a checklist, not a manual. All skills are 
 | `change-workflow`   | authored    | Making code changes — subsystem, docs, validation order                |
 | `generated-files`   | authored    | Regenerating or reasoning about the untracked build files              |
 | `publishing`        | authored    | Releasing — `upload` / `upload:local`, prod/dev modes                  |
+| `cavecrew`          | third-party | Delegating locate / small-edit / diff-review subtasks to subagents     |
+| `code-review`       | third-party | Reviewing a diff against the repo's standards and originating spec     |
 | `debugging-firefox` | third-party | Debugging live Firefox via DevTools RDP (`docs/debugging-with-rdp.md`) |
+| `grill-me`          | third-party | Stress-testing a plan or design before committing to it                |
+| `lavish`            | third-party | Turning complex/visual agent output into annotatable HTML artifacts    |
 
 All paths are `<root>/.agents/skills/<name>/SKILL.md`.
 
@@ -193,6 +197,8 @@ Before finishing:
 - generated files are regenerated on demand (Makefile / createZip / syncGeneratedFiles);
 - no `.local` files were used as authoritative sources;
 - no unrelated files were modified;
+- any AGENTS.md / skill / `docs/` statement this change makes wrong is updated — stale instructions
+  mislead every later run;
 - failed/unavailable validation is reported;
 - the task worktree is removed (`git worktree remove`; retry the empty directory if a process still
   held it).


### PR DESCRIPTION
## What

Two factual fixes to the agent instruction files, from a review of the repo's agent-guidance setup:

1. **Restore the full skills inventory in AGENTS.md.** The Skills table listed 5 of the 9 tracked skills — `code-review`, `grill-me`, `cavecrew`, and `lavish` were missing, so an agent reading AGENTS.md could never learn they exist or load them. All four are third-party per ADR 0022 metadata. Also fixed the matching skill list in the `change-workflow` skill, which pointed at the same stale subset.
2. **Add the rules-drift discipline to both "Before finishing" checklists.** "Any AGENTS.md / skill / docs statement this change makes wrong is updated" — stale instructions mislead every later agent run. The missing table above is a live example of exactly this failure mode.

## Validation

- `pnpm format:fix` clean
- `pnpm lint` clean (incl. C analyzer)
- `pnpm test` — 229 pass / 3 pre-existing skips
- Diff: 2 files, +11/−2

## Scope note

An earlier draft of this branch carried broader agent-guidance prose (review-loop stop conditions, hook decision rules, etc.). That content was deliberately dropped after review — this PR is limited to the factual fixes only.