### PR TITLE
Watchdog status issue: download-time column + always-on cache cell

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -264,6 +264,27 @@ pnpm ci:download -- librewolf-155.0-1-windows-x86_64-setup.exe
 pnpm ci:download -- "Waterfox Setup 6.7.1.1.exe" --version 6.7.1.1
 ```
 
+#### Download timeouts for slow runners (`test/e2e/shared/downloads.mjs`)
+
+`downloadTo` — used by every CI installer fetch and the watchdog's full-download verification — is
+**progress-aware** (issue #143): it streams to disk and aborts only when **no bytes advance for the
+stall window**, never on a healthy-but-slow transfer (the same 158 MB LibreWolf installer took 13 s
+from CI runners and 5.5 min over a home link). Interrupted attempts resume via a Range request
+instead of restarting from byte 0, and a 10 MB-interval heartbeat (`MB downloaded (KB/s)`) in the
+log shows the transfer is alive.
+
+Three environment variables tune it — the defaults fit every observed runner; override only for an
+unusually slow CI link:
+
+| Variable                    | Default          | Meaning                                                                                                                                                 |
+| --------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DOWNLOAD_STALL_TIMEOUT_MS` | 60000            | Abort the attempt when no bytes arrive for this long. A 0.3 MB/s trickle delivers a chunk every ~2 s and is never killed — only a dead stream trips it. |
+| `DOWNLOAD_TOTAL_BUDGET_MS`  | 1200000 (20 min) | Wall-clock budget across all 5 attempts (retries resume, so slow links still complete). Must stay below the watchdog job's `timeout-minutes: 30`.       |
+| `DOWNLOAD_RETRY_BACKOFF_MS` | 5000             | Wait between attempts.                                                                                                                                  |
+
+Each is read per call, so a workflow step can set one (e.g. `env: DOWNLOAD_TOTAL_BUDGET_MS: 3000000`
+on a known-slow runner) without touching the others.
+
 The script creates the fixed-tag **`ci-downloads`** release on demand, uploads the asset under the
 resolver's expected name, and dispatches `e2e.yml` with `browser` (+ optional `version`) — a
 single-browser updater-E2E run. CI's `cleanup-ci-downloads` job deletes the consumed asset

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -282,8 +282,9 @@ unusually slow CI link:
 | `DOWNLOAD_TOTAL_BUDGET_MS`  | 1200000 (20 min) | Wall-clock budget across all 5 attempts (retries resume, so slow links still complete). Must stay below the watchdog job's `timeout-minutes: 30`.       |
 | `DOWNLOAD_RETRY_BACKOFF_MS` | 5000             | Wait between attempts.                                                                                                                                  |
 
-Each is read per call, so a workflow step can set one (e.g. `env: DOWNLOAD_TOTAL_BUDGET_MS: 3000000`
-on a known-slow runner) without touching the others.
+Each is read per call, so a workflow step can set one (e.g. `env: DOWNLOAD_TOTAL_BUDGET_MS: 1500000`
+— 25 min, still inside the watchdog job's 30-minute timeout — on a known-slow runner) without
+touching the others.
 
 The script creates the fixed-tag **`ci-downloads`** release on demand, uploads the asset under the
 resolver's expected name, and dispatches `e2e.yml` with `browser` (+ optional `version`) — a

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -20,6 +20,7 @@ const {
   compareBaseline,
   formatAge,
   formatCheck,
+  formatDownloadMs,
   formatRunDate,
   formatSize,
   isFailureIssueTitle,
@@ -230,14 +231,21 @@ test('buildStatusTable: six rows, short links, fallback on failed browsers', () 
   const table = buildStatusTable({results, baseline});
   const lines = table.split('\n');
   assert.equal(lines.length, 8); // header + separator + 6 browsers
+  assert.match(
+    table,
+    /^\| Browser \| Last verified \| Size · SHA-256 \| Last check \| Status \| Fallback \(CI cache\) \| Download time \| E2E validated \|/
+  );
   const firefox = lines.find(l => l.startsWith('| firefox '));
   assert.match(
     firefox,
-    /\| 155\.0\.1 \| 87\.5 MB · `27a24f…` \| \[Sep 5\]\(https:\/\/github\.com\/onemen\/firefox-scripts\/actions\/runs\/1\) \| ✅ up to date \| — \| ⏳ none \|/
+    /\| 155\.0\.1 \| 87\.5 MB · `27a24f…` \| \[Sep 5\]\(https:\/\/github\.com\/onemen\/firefox-scripts\/actions\/runs\/1\) \| ✅ up to date \| cached: 155\.0\.1 \| — \| ⏳ none \|/
   );
   const librewolf = lines.find(l => l.startsWith('| librewolf '));
   assert.match(librewolf, /\| 154\.0\.1-2 \| 158\.2 MB · `1d9fe9…` \| \[Aug 31\]\(/);
-  assert.match(librewolf, /\| ❌ lookup failed \| cached: 154\.0\.1-2 · \[Aug 31\]/);
+  assert.match(
+    librewolf,
+    /\| ❌ lookup failed \| cached: 154\.0\.1-2 · \[Aug 31\]\([^)]+\) \| — \|/
+  );
   assert.match(librewolf, /\| — \|$/); // advisory fork → no E2E cell
 
   // A failed full-download verification must render as failed with the
@@ -255,11 +263,49 @@ test('buildStatusTable: six rows, short links, fallback on failed browsers', () 
     },
   });
   const zen = tableDl.split('\n').find(l => l.startsWith('| zen '));
-  assert.match(zen, /\| ⚠️ download failed \| cached: 1\.21\.15b · Aug 25 \|/);
+  assert.match(zen, /\| ⚠️ download failed \| cached: 1\.21\.15b · Aug 25 \| — \|/);
   const dev = lines.find(l => l.startsWith('| firefox-dev '));
   assert.match(dev, /\| 🆕 new version \|/);
   const waterfox = lines.find(l => l.startsWith('| waterfox '));
-  assert.match(waterfox, /\| — \| — · — \| — \| ✅ up to date \| — \| — \|/);
+  assert.match(waterfox, /\| — \| — · — \| — \| ✅ up to date \| — \| — \| — \|/);
+});
+
+test('buildStatusTable: fallback shows cached version on green runs, download time when known', () => {
+  // Green run + a recorded downloadMs: the cache column still shows what CI
+  // would fall back to (the version IS in the cache), and the transfer time
+  // of the verified download appears (issue #136).
+  const withData = buildStatusTable({
+    results: {librewolf: {status: 'ok'}},
+    baseline: {
+      librewolf: {
+        version: '155.0.1-1',
+        size: 165783376,
+        sha256: 'd01c3b0e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4',
+        downloadMs: 12900,
+        checkedAt: '2026-09-06T11:13:17Z',
+        checkedUrl: 'https://github.com/o/r/actions/runs/1',
+      },
+    },
+  });
+  const row = withData.split('\n').find(l => l.startsWith('| librewolf '));
+  assert.match(row, /\| ✅ up to date \| cached: 155\.0\.1-1 \| 13s \| — \|$/);
+
+  // Green run, no downloadMs yet (pre-baseline entry): em dash, never '0s'.
+  const noTime = buildStatusTable({
+    results: {zen: {status: 'ok'}},
+    baseline: {zen: {version: '1.22b', size: 114152784, sha256: 'ab12cd'}},
+  });
+  const zenRow = noTime.split('\n').find(l => l.startsWith('| zen '));
+  assert.match(zenRow, /\| cached: 1\.22b \| — \| — \|$/);
+});
+
+test('formatDownloadMs: human durations, unknown stays an em dash', () => {
+  assert.equal(formatDownloadMs(12900), '13s');
+  assert.equal(formatDownloadMs(252_000), '4m 12s');
+  assert.equal(formatDownloadMs(335_400), '5m 35s');
+  assert.equal(formatDownloadMs(0), '—');
+  assert.equal(formatDownloadMs(undefined), '—');
+  assert.equal(formatDownloadMs(null), '—');
 });
 
 test('validatedCell / E2E validated column: match, stale, none, fork', () => {
@@ -291,7 +337,7 @@ test('updateHistory: appends and caps at the max', () => {
 
 test('seedHistoryFromBaseline: baseline-only seed until real updates exist', () => {
   const baseline = {
-    firefox: {version: '155.0.1', size: 91715344, sha256: '27a24f'},
+    firefox: {version: '155.0.1', size: 91715344, sha256: '27a24f', downloadMs: 900},
   };
   const seed = seedHistoryFromBaseline(baseline);
   assert.equal(seed.length, 1);
@@ -301,6 +347,7 @@ test('seedHistoryFromBaseline: baseline-only seed until real updates exist', () 
     version: '155.0.1',
     size: 91715344,
     sha256: '27a24f',
+    downloadMs: 900,
   });
   assert.deepEqual(seedHistoryFromBaseline({}), []);
 });
@@ -315,11 +362,12 @@ test('renderHistory: baseline seed vs real update entries', () => {
           version: '155.0.1',
           size: 91715344,
           sha256: '27a24fcdde805cb6a34c5c102e98ebfe5f0302078202376d2828f8797ed80298',
+          downloadMs: 12900,
         },
       ],
     },
   ]);
-  assert.match(baseline, /^- baseline: firefox 155\.0\.1 · 87\.5 MB · `27a24f…`$/);
+  assert.match(baseline, /^- baseline: firefox 155\.0\.1 · 87\.5 MB · `27a24f…` · 13s$/);
   const update = renderHistory([
     {
       date: '2026-09-05T07:36:11Z',
@@ -331,13 +379,14 @@ test('renderHistory: baseline seed vs real update entries', () => {
           newVersion: '156.0b3',
           size: 93298280,
           sha256: '3e53b343e7d8bd109b217a0fd279ee5cadd7d9a8434d7c185dc65e88e80ffe9e',
+          downloadMs: 252_000,
         },
       ],
     },
   ]);
   assert.match(
     update,
-    /^- \[Sep 5\]\(https:\/\/github\.com\/o\/r\/actions\/runs\/1\) — update: firefox-dev 156\.0b2 → 156\.0b3 · 89\.0 MB · `3e53b3…`$/
+    /^- \[Sep 5\]\(https:\/\/github\.com\/o\/r\/actions\/runs\/1\) — update: firefox-dev 156\.0b2 → 156\.0b3 · 89\.0 MB · `3e53b3…` · 4m 12s$/
   );
 });
 

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -26,10 +26,10 @@
  *   4. META ISSUE — one `[url-watchdog] status` issue is kept current after every
  *        run: a per-browser status table (last verified version, size +
  *        SHA-256, the run that last checked it, a status tag, the CI-cache
- *        fallback version for failed browsers, and the E2E-validated version
- *        for the hard-gate browsers) plus a version history that only grows on
- *        runs with real version updates — the durable SHA-256 ledger (search
- *        `label:url-watchdog` for it).
+ *        fallback version, the full-download transfer time, and the
+ *        E2E-validated version for the hard-gate browsers) plus a version
+ *        history that only grows on runs with real version updates — the
+ *        durable SHA-256 ledger (search `label:url-watchdog` for it).
  *   5. ERROR ISSUES — rot and same-version size changes still open their own issue,
  *        deduped per browser (the exact issue title is matched against open
  *        issues carrying the `url-watchdog` label); the watchdog auto-closes
@@ -236,10 +236,11 @@ export async function sha256File(file) {
  */
 async function verifyFullDownload(url, browser) {
   const tmp = path.join(os.tmpdir(), `watchdog-${browser}-${process.pid}.exe`);
+  const startedAt = Date.now();
   try {
     await downloadTo(url, tmp);
     const sha256 = await sha256File(tmp);
-    return {ok: true, size: fs.statSync(tmp).size, sha256};
+    return {ok: true, size: fs.statSync(tmp).size, sha256, downloadMs: Date.now() - startedAt};
   } catch (err) {
     return {ok: false, reason: `full download failed: ${err.message}`};
   } finally {
@@ -411,6 +412,18 @@ export function validatedCell(browser, entry, validated) {
 }
 
 /**
+ * Human-readable duration for the meta-issue download-time cell ('13s', '4m
+ * 12s'); '—' when unknown (browser never fully downloaded this version).
+ */
+export function formatDownloadMs(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return '—';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+/**
  * Markdown status table for the meta issue. `baseline` is the per-browser
  * record AFTER this run — a browser that failed keeps its previous entry, which
  * is exactly what the version-aware CI installer cache still serves (the
@@ -427,13 +440,23 @@ export function buildStatusTable({results, baseline, validated}) {
     const version = entry.version || '—';
     const sizeSha = `${formatSize(entry.size)} · ${shortSha(entry.sha256)}`;
     const lastCheck = formatCheck(entry.checkedAt, entry.checkedUrl);
-    const fallback = failed ? `cached: ${version} · ${lastCheck}` : '—';
+    // The CI cache always holds the last verified version, green run or not —
+    // show it unconditionally (the staleness suffix matters only on failure,
+    // where it tells the operator how old the fallback is).
+    const fallback =
+      version === '—' ? '—'
+      : failed ? `cached: ${version} · ${lastCheck}`
+      : `cached: ${version}`;
+    // Download time of the last VERIFIED full download — the transfer-speed
+    // history for the vendor hosts (issue #136). Unknown until a browser's
+    // version has been fully downloaded at least once.
+    const downloadTime = formatDownloadMs(entry.downloadMs);
     const e2e = validatedCell(browser, entry, validated);
-    return `| ${browser} | ${version} | ${sizeSha} | ${lastCheck} | ${statusTag(res.status)} | ${fallback} | ${e2e} |`;
+    return `| ${browser} | ${version} | ${sizeSha} | ${lastCheck} | ${statusTag(res.status)} | ${fallback} | ${downloadTime} | ${e2e} |`;
   });
   return [
-    '| Browser | Last verified | Size · SHA-256 | Last check | Status | Fallback (CI cache) | E2E validated |',
-    '| --- | --- | --- | --- | --- | --- | --- |',
+    '| Browser | Last verified | Size · SHA-256 | Last check | Status | Fallback (CI cache) | Download time | E2E validated |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
     ...rows,
   ].join('\n');
 }
@@ -460,6 +483,7 @@ export function seedHistoryFromBaseline(baseline) {
     version: baseline[b].version,
     size: baseline[b].size,
     sha256: baseline[b].sha256,
+    downloadMs: baseline[b].downloadMs,
   }));
   return changes.length ? [{kind: 'baseline', changes}] : [];
 }
@@ -471,10 +495,12 @@ export function renderHistory(history) {
       const items = h.changes
         .map(c => {
           const sha = shortSha(c.sha256);
+          const dl =
+            formatDownloadMs(c.downloadMs) === '—' ? '' : ` · ${formatDownloadMs(c.downloadMs)}`;
           if (h.kind === 'baseline') {
-            return `${c.browser} ${c.version} · ${formatSize(c.size)} · ${sha}`;
+            return `${c.browser} ${c.version} · ${formatSize(c.size)} · ${sha}${dl}`;
           }
-          return `${c.browser} ${c.prevVersion} → ${c.newVersion} · ${formatSize(c.size)} · ${sha}`;
+          return `${c.browser} ${c.prevVersion} → ${c.newVersion} · ${formatSize(c.size)} · ${sha}${dl}`;
         })
         .join(' · ');
       const label =
@@ -987,6 +1013,7 @@ export async function main() {
         version,
         size: verified.size,
         sha256: verified.sha256,
+        downloadMs: verified.downloadMs,
         checkedAt: new Date().toISOString(),
         checkedUrl: runUrl,
       };
@@ -999,6 +1026,7 @@ export async function main() {
           newVersion: version,
           size: verified.size,
           sha256: verified.sha256,
+          downloadMs: verified.downloadMs,
         });
       } else {
         console.log('  first run — baseline recorded');
@@ -1021,6 +1049,7 @@ export async function main() {
       // version bumps (which re-verifies via a full download).
       size: sizeChanged ? prev.size : total || prev.size || null,
       sha256: prev.sha256 || null,
+      downloadMs: prev.downloadMs ?? null,
       checkedAt: new Date().toISOString(),
       checkedUrl: runUrl,
     };
@@ -1102,6 +1131,7 @@ export async function main() {
         newVersion: f.newVersion,
         size: f.size,
         sha256: f.sha256,
+        downloadMs: f.downloadMs,
       })),
     });
   }

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -239,8 +239,11 @@ async function verifyFullDownload(url, browser) {
   const startedAt = Date.now();
   try {
     await downloadTo(url, tmp);
+    // Capture the transfer time BEFORE hashing — the metric is download
+    // duration; hashing (1-2s for a 158 MB installer) is verification.
+    const downloadMs = Date.now() - startedAt;
     const sha256 = await sha256File(tmp);
-    return {ok: true, size: fs.statSync(tmp).size, sha256, downloadMs: Date.now() - startedAt};
+    return {ok: true, size: fs.statSync(tmp).size, sha256, downloadMs};
   } catch (err) {
     return {ok: false, reason: `full download failed: ${err.message}`};
   } finally {


### PR DESCRIPTION
## Why

Two gaps in the `[url-watchdog] status` meta issue (#136), surfaced while reviewing it after #143/#145:

1. **Fallback (CI cache) was only shown for failed browsers** — every row of a fully green run rendered `—`, hiding the fact that the cache always holds the last verified version. The column's original job ("what CI falls back to when the vendor is down") made the cell conditional, but the data is version-agnostic.
2. **No transfer-speed history.** After the Sep 6 incident (same 158 MB installer: 13 s from CI, 5.5 min over a home link, #143) there is no per-vendor record of how long the verified downloads actually take — useful for spotting a degrading vendor CDN before it bites.

Also: the progress-aware download knobs (`DOWNLOAD_STALL_TIMEOUT_MS` / `DOWNLOAD_TOTAL_BUDGET_MS` / `DOWNLOAD_RETRY_BACKOFF_MS`) existed only in code comments — operators had no documented way to tune them for slow runners.

## What

**`tools/check-browser-downloads.mjs`**
- `verifyFullDownload` records elapsed wall time; the baseline persists it as `downloadMs` per browser (same-version runs keep the previous value; version history entries carry it too).
- Status table: **Fallback (CI cache)** now always shows `cached: <version>` when a version is known — the staleness date suffix stays only on failed rows, where it matters. New **Download time** column (`formatDownloadMs`: `13s`, `4m 12s`, `—` until first full download).
- Version history lines append the download time when known (`librewolf 155.0-1 → 155.0.1-1 · 158.1 MB · \`d01c3b…\` · 13s`).
- Docstring updated.

**`docs/DEVELOPING.md`** — new "Download timeouts for slow runners" subsection under the E2E configuration: what progress-aware means, the three env knobs with defaults and semantics (incl. the budget < `timeout-minutes: 30` coupling).

**Tests** — 3 new/extended unit tests: green-run cache cell + download-time cell, `formatDownloadMs` durations, history/seed entries carry `downloadMs`. Existing table assertions updated for the new column.

## Notes

- The **E2E validated** column stays fork-sparse by design: the validated-versions record is written only by the full dispatch's record-validation job (firefox/firefox-dev legs); partial single-browser dispatches deliberately cannot fabricate coverage (ADR 0021).
- Pre-baseline browsers (no `downloadMs` yet) render `—`, never `0s`; the meta issue only PATCHes when content changes, so green no-op runs still don't churn it.

Part of #143, #136

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>