### PR TITLE
docs(roadmap): Phase 4 E2E matrix complete — snap leg merged (#55)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,11 +21,11 @@ Order matters: installer / updater / tests / CI first, core-file PRs last.
 - **Release gate (#4)** — remove README banner, v1.0 tag, milestone close, env protection for prod
   uploads, zip-the-installer-exe decision, tag move (P0-1).
 
-Remaining Phase 4 gaps are tracked by child issues #35–#37 (Dev Edition leg, installer UI layer,
-install-applies path) and #53–#56 (manual utils install, installer self-update tests, snap legs,
-portable-install legs). Additional test-infrastructure gaps — installer `--port 0`/`--server-only`
-test flags, an `env.json` deployment manifest, profile/process hygiene between E2E runs — are listed
-in `docs/future-work.md` §6 with their proposed issue homes.
+Phase 4 (installer + updater E2E matrix) is complete on `main`: the browser-matrix legs (#35–#37,
+#53, #54), the portable-Firefox legs (#56), and the snap Firefox leg (#55, merged via PR #142) all
+run in CI. Remaining test-infrastructure gaps — profile/process hygiene (#130), browser download
+pinning (#131), publish zip-verification tests (#133) — are tracked by issues and listed in
+`docs/future-work.md` §6.
 
 ## Post v1.0 (umbrella #38, milestone "Post v1.0")
 


### PR DESCRIPTION
Updates `docs/roadmap.md` now that the Phase 4 E2E matrix is complete on `main` (per AGENTS.md "Roadmap tracking" — the roadmap is updated only in the PR that changes scope).

**What changed**

- The stale "Remaining Phase 4 gaps" paragraph (#35–#37, #53–#56, all now closed) is replaced with the completed matrix: browser-matrix legs, portable-Firefox legs (#56), and the snap Firefox leg (#55, merged via PR #142).
- The remaining gaps are the open test-infrastructure issues #130 / #131 / #133, still listed in `docs/future-work.md` §6.

**Also in this change (issues, no PR needed)**

- [x] Issue #55's four checklist items ticked (item 4 marked done with a note: no separate deb/rpm leg — Ubuntu's apt `firefox` is a snap transitional package, so the tarball legs remain the non-snap comparison). #55 was auto-closed by PR #142 but its checklist was never ticked.
- [x] Umbrella #3: snap row moved to Done, intro sentence updated ("Phase 4 hard-gate matrix is complete on `main`"), closes-when condition noted as met, and the #129 infra row ticked (merged via PR #141).

Docs-only change; no code paths affected.

Closes #55 · Part of #3