### PR TITLE
watchdog: add a short intro paragraph to the [url-watchdog] status meta issue

### DIFF
--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -397,6 +397,9 @@ test('buildMetaIssueBody: status table + history, no date in the header', () => 
     history: '- [Sep 5](u) — update: firefox 155.0 → 155.0.1 · 87.5 MB · `27a24f…`',
   });
   assert.match(body, /^## Watchdog status\n\n/);
+  // static intro: describes the watchdog, sits between the heading and the table
+  assert.match(body, /^## Watchdog status\n\nThis is the status page for the \*\*URL watchdog\*\*/);
+  assert.match(body, /bot-maintained/);
   assert.match(body, /## Version history \(runs with real updates\)/);
   assert.doesNotMatch(body, /\d{4}-\d{2}-\d{2}/); // header carries no run date — body changes only with content
   const bare = buildMetaIssueBody({table, history: ''});

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -514,13 +514,26 @@ export function renderHistory(history) {
 }
 
 /**
- * Meta-issue body: the status table + the version history. No run date in the
- * header on purpose — the body must only change when the table or the history
- * changes, so fully-green no-op runs do not churn the issue.
+ * Static intro for the meta issue: what the watchdog is and that the body is
+ * bot-maintained. Constant, so it never churns the body on its own — the body
+ * still only changes when the table or the history changes.
+ */
+const WATCHDOG_INTRO = `This is the status page for the **URL watchdog** — the weekly workflow
+(.github/workflows/url-watchdog.yml) that re-resolves every browser's latest version from its
+vendor API, verifies the download endpoint, and re-baselines the SHA-256 ledger on new releases
+(each new release also dispatches the browser E2E). The table and history below are bot-maintained
+and rewritten each run; download failures and size changes open separate [url-watchdog] issues that
+auto-close once the browser checks green again.`;
+
+/**
+ * Meta-issue body: the static intro + the status table + the version history.
+ * No run date in the header on purpose — the body must only change when the
+ * table or the history changes, so fully-green no-op runs do not churn the
+ * issue.
  */ export function buildMetaIssueBody({table, history}) {
   const historyBlock =
     history ? `\n\n## Version history (runs with real updates)\n\n${history}\n` : '';
-  return `## Watchdog status\n\n${table}${historyBlock}`;
+  return `## Watchdog status\n\n${WATCHDOG_INTRO}\n\n${table}${historyBlock}`;
 }
 
 /**


### PR DESCRIPTION
The `[url-watchdog] status` meta issue (#136) now opens with a short description of what the watchdog is and does, so the auto-generated dashboard is self-explanatory.

**Why the generator, not a hand-edit:** `syncMetaIssue` PATCHes the entire body on any content change, so a manually added description on the issue would be wiped on the next weekly run. The intro is instead a constant (`WATCHDOG_INTRO`) rendered by `buildMetaIssueBody` between the heading and the table — static, so the body still only changes when the table or the version history changes (no churn on no-op runs).

- Adds `WATCHDOG_INTRO` to `tools/check-browser-downloads.mjs` (2 sentences: what the weekly workflow does + that the body is bot-maintained and failures auto-close).
- Extends the `buildMetaIssueBody` unit test to pin the intro's position and the bot-maintained wording.
- Issue #136 was updated in place with the identical generated body, so it's visible now and preserved by the next run.

Docs: no new file — the watchdog is already documented in `docs/DEVELOPING.md` (URL watchdog section) and `docs/ci-inventory.md` (workflow rows + behavior/gates table), and the issue intro now points at the workflow file.