### PR TITLE
Guard against AV false positives on installer_win.exe (PE metadata + scan gate + stable toolchain)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -4,6 +4,11 @@
 # GitHub token with repo scope (contents:write for Pages/branch pushes).
 GITHUB_TOKEN_VAR=ghp_your_token_here
 
+# Optional: VirusTotal API key for the multi-engine scan of built binaries
+# (tools/scan-vt.mjs, pnpm scan:vt, and the publish gate).  Free tier is fine;
+# without it the VirusTotal scan is skipped with a warning.
+# VT_API_KEY=your_virustotal_key_here
+
 # Optional local AI review provider keys. Never commit real keys.
 # Gemini is the default provider for tools/ai-review.mjs (local runs only).
 # GEMINI_API_KEY=your_google_ai_studio_key

--- a/.env-example
+++ b/.env-example
@@ -8,6 +8,9 @@ GITHUB_TOKEN_VAR=ghp_your_token_here
 # (tools/scan-vt.mjs, pnpm scan:vt, and the publish gate).  Free tier is fine;
 # without it the VirusTotal scan is skipped with a warning.
 # VT_API_KEY=your_virustotal_key_here
+# Optional tunables for the VirusTotal gate:
+# VT_FAIL_THRESHOLD=3   # fail when this many engines report malicious
+# VT_VETO_ENGINES=Microsoft  # engines whose malicious verdict alone fails the publish
 
 # Optional local AI review provider keys. Never commit real keys.
 # Gemini is the default provider for tools/ai-review.mjs (local runs only).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
               - 'config/installer.conf'
               - 'installer/**'
               - 'tools/publish/**'
+              # The publish AV/VT scan tools run inside upload.mjs (the gate's
+              # `upload:local` rehearsal), so edits to them must re-trigger it.
+              - 'tools/scan-av.mjs'
+              - 'tools/scan-vt.mjs'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - '.github/actions/**'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -165,10 +165,17 @@ jobs:
         with:
           install: 'false'
       - name: Set up MSYS2 toolchain (make + gcc)
+        # update: false — no pacman -Syu on every publish.  A full system
+        # upgrade mid-cycle changed the gcc version (16.1.0 → 16.2.0,
+        # published to MSYS2 repos 2026-09-04) and the rebuilt installer_win.exe
+        # was falsely flagged by Defender's ML (Program:Script/Wacapew.A!ml) the
+        # next day.  Skipping the system upgrade keeps the toolchain stable; the
+        # upload AV gate (tools/scan-av.mjs) is the enforcement that a rebuild
+        # with any new toolchain still scans clean before it ships.
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
-          update: true
+          update: false
           install: >-
             mingw-w64-ucrt-x86_64-gcc make
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -184,6 +184,10 @@ jobs:
           path: ${{ runner.temp }}/baseline/
       - run: pnpm install --frozen-lockfile
       - shell: bash
+        env:
+          # Optional: multi-engine VirusTotal scan of the built binaries before
+          # upload (tools/scan-vt.mjs).  Absent ⇒ skipped with a warning.
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=win"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
@@ -206,6 +210,8 @@ jobs:
           name: baseline-hashes
           path: ${{ runner.temp }}/baseline/
       - shell: bash
+        env:
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=linux"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
@@ -226,6 +232,8 @@ jobs:
           name: baseline-hashes
           path: ${{ runner.temp }}/baseline/
       - shell: bash
+        env:
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
         run: |
           ARGS="--mode=${{ inputs.mode }} --platform=mac"
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ inspection).
    - `installer_linux` — Linux
    - `installer_mac` — macOS
 
-   Windows binaries are code-signed by the [SignPath Foundation](https://signpath.org/), the
-   open-source code-signing program.
-
 2. **Run** the downloaded installer. It connects to a running Firefox-family browser (Firefox,
    Waterfox, Zen Browser, LibreWolf, or Floorp), opens an install screen in a browser tab, and lets
    you pick which browser to set up.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ inspection).
    - `installer_win.exe` — Windows
    - `installer_linux` — Linux
    - `installer_mac` — macOS
+
+   Windows binaries are code-signed by the [SignPath Foundation](https://signpath.org/), the
+   open-source code-signing program.
+
 2. **Run** the downloaded installer. It connects to a running Firefox-family browser (Firefox,
    Waterfox, Zen Browser, LibreWolf, or Floorp), opens an install screen in a browser tab, and lets
    you pick which browser to set up.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,11 @@ Please search existing issues first — your problem may already be reported.
 
 ### License
 
-[MIT](LICENSE.md) © 2026 ONEMEN <tabmix.onemen@gmail.com>
+[MIT](LICENSE.md) © 2026 ONEMEN <tabmix.onemen@gmail.com> — `SPDX-License-Identifier: MIT`
+
+Applies to the whole repository **except** the upstream-derived `core/` tree (files outside
+`core/chrome/utils/updater/`), which is
+[Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/) per
+[`core/LICENSE`](core/LICENSE) — `SPDX-License-Identifier: MPL-2.0`. The custom in-browser updater
+(`core/chrome/utils/updater/`) is MIT like the rest of the repo. See
+[Original Scripts and Core Folders](#original-scripts-and-core-folders).

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -167,10 +167,10 @@ The publish flow also runs every built binary through VirusTotal when `VT_API_KE
 (GitHub secret on CI; root `.env` for a local `pnpm upload`). The publish fails when ≥
 `VT_FAIL_THRESHOLD` (default 3) engines report a binary as malicious **or** when a veto engine
 (`VT_VETO_ENGINES`, default `Microsoft`) reports it as malicious at any count — a Microsoft/Defender
-verdict must never ship, even alone. 1–2 hits from non-veto engines warn but do not block (the
-known-FP band). The run log names the flagging engines. Without a key it just skips with a warning,
-and an analysis VirusTotal has not finished when the poll times out is reported as a skip — never as
-clean.
+verdict must never ship, even alone. Hits below the configured threshold from non-veto engines warn
+but do not block (the known-FP band at the default of 3). The run log names the flagging engines.
+Without a key it just skips with a warning, and an analysis VirusTotal has not finished when the
+poll times out is reported as a skip — never as clean.
 
 ### False-positive handling
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -164,9 +164,13 @@ pnpm scan:vt -- dist/installer/installer_win.exe
 ```
 
 The publish flow also runs every built binary through VirusTotal when `VT_API_KEY` is present
-(GitHub secret on CI; root `.env` for a local `pnpm upload`), failing only when ≥
-`VT_FAIL_THRESHOLD` (default 3) engines report a binary as malicious. Without a key it just skips
-with a warning.
+(GitHub secret on CI; root `.env` for a local `pnpm upload`). The publish fails when ≥
+`VT_FAIL_THRESHOLD` (default 3) engines report a binary as malicious **or** when a veto engine
+(`VT_VETO_ENGINES`, default `Microsoft`) reports it as malicious at any count — a Microsoft/Defender
+verdict must never ship, even alone. 1–2 hits from non-veto engines warn but do not block (the
+known-FP band). The run log names the flagging engines. Without a key it just skips with a warning,
+and an analysis VirusTotal has not finished when the poll times out is reported as a skip — never as
+clean.
 
 ### False-positive handling
 
@@ -177,9 +181,11 @@ with a warning.
   <https://www.microsoft.com/en-us/wdsi/filesubmission> — select “Your app or file was incorrectly
   detected as malware” and attach the flagged binary. Microsoft can clear the hash/family in
   Defender’s cloud, which also clears it for users.
-- A durable long-term fix is **code signing** (e.g. Azure Trusted Signing); it is the only measure
-  that systematically improves AV/OS reputation, but it costs money — the measures above are the
-  zero-cost alternative.
+- A durable long-term fix is **code signing**; it is the only measure that systematically improves
+  AV/OS reputation. Paid options exist (Azure Trusted Signing), and the **SignPath Foundation**
+  sponsors free Authenticode signing for accepted open-source projects (Windows binaries only —
+  exactly the flagged artifacts here). The measures above are the zero-cost alternative while the
+  signing application is pending.
 
 ## Making changes
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -156,6 +156,18 @@ pnpm scan:av -- dist/installer/installer_win.exe dist/installer/helper_win.exe
 # exit 0 = clean, exit 1 = detection, exit 2 = usage
 ```
 
+### Multi-engine check (optional — VirusTotal)
+
+```bash
+# put VT_API_KEY=... in the root .env (gitignored), then:
+pnpm scan:vt -- dist/installer/installer_win.exe
+```
+
+The publish flow also runs every built binary through VirusTotal when `VT_API_KEY` is present
+(GitHub secret on CI; root `.env` for a local `pnpm upload`), failing only when ≥
+`VT_FAIL_THRESHOLD` (default 3) engines report a binary as malicious. Without a key it just skips
+with a warning.
+
 ### False-positive handling
 
 - If a scanner flags a freshly built binary, do **not** publish it — investigate first. Local builds

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -111,8 +111,9 @@ sudo apt install gcc
 make all                      # builds dist/installer/installer_linux
 
 # Windows cross-compile from Linux/WSL
-sudo apt install gcc-mingw-w64-x86-64-posix
-make dist_win CC=x86_64-w64-mingw32-gcc   # builds dist/installer/installer_win.exe
+sudo apt install gcc-mingw-w64-x86-64-posix binutils-mingw-w64-x86-64
+make dist_win CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres
+#   builds dist/installer/installer_win.exe with the PE version resource
 ```
 
 ### macOS

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -427,18 +427,18 @@ Exit code 0 means every package's JS hash matches the C binary's (computed with 
 **PR path filtering** — every E2E job (`.github/workflows/e2e.yml`: the `snapshot` build, the
 installer/updater matrices, the `helper` elevated-copy test, and the `browser-matrix` fork legs) and
 the publish gate (`build` in `.github/workflows/ci.yml`) run only when a changed file can affect
-them (`core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, `test/e2e/**`,
-`package.json`, `pnpm-lock.yaml`, the workflows/actions). Docs-only / tooling-only PRs skip all of
-them; `changes`, `checks`, `ci-gate` and `e2e-gate` always run, so the required checks keep
-reporting. The aggregate gates share one engine — `.github/actions/verify-gate` (required / advisory
-/ skip-guard / always-report checks) — and `pnpm check:gates` statically enforces the contract:
-every workflow job is listed in its gate's `needs:`, path-filter `if:`s stay in place, and
-always-report jobs carry no job-level `if:`. The `browser-matrix` fork legs (LibreWolf, Floorp, Zen
-— downloaded from third-party hosts: librewolf.dev's package registry and GitHub release assets) are
-advisory when they run: failures warn in the gate instead of failing the PR. Firefox Developer
-Edition is first-party Mozilla, so it runs as a required leg of the `updater` job (#35), not in the
-advisory matrix. Waterfox has no direct download URL and stays manual (tracked by version only in
-the URL watchdog).
+them (`core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, `tools/scan-av.mjs`,
+`tools/scan-vt.mjs`, `test/e2e/**`, `package.json`, `pnpm-lock.yaml`, the workflows/actions).
+Docs-only / tooling-only PRs skip all of them; `changes`, `checks`, `ci-gate` and `e2e-gate` always
+run, so the required checks keep reporting. The aggregate gates share one engine —
+`.github/actions/verify-gate` (required / advisory / skip-guard / always-report checks) — and
+`pnpm check:gates` statically enforces the contract: every workflow job is listed in its gate's
+`needs:`, path-filter `if:`s stay in place, and always-report jobs carry no job-level `if:`. The
+`browser-matrix` fork legs (LibreWolf, Floorp, Zen — downloaded from third-party hosts:
+librewolf.dev's package registry and GitHub release assets) are advisory when they run: failures
+warn in the gate instead of failing the PR. Firefox Developer Edition is first-party Mozilla, so it
+runs as a required leg of the `updater` job (#35), not in the advisory matrix. Waterfox has no
+direct download URL and stays manual (tracked by version only in the URL watchdog).
 
 **Agent file-change hooks (recommended, per-workstation)** — agent clients (Codebuff, Claude Code,
 …) can run a command after each file edit and feed the output back to the agent in the same turn.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -122,6 +122,52 @@ xcode-select --install
 make dist_mac   # builds dist/installer/installer_mac
 ```
 
+## AV false positives and the AV scan gate
+
+The installer/helper binaries are unsigned, stripped, statically-linked PEs — the classic profile
+for antivirus **machine-learning** false positives. `installer_win.exe` was once flagged by Windows
+Defender (`Program:Script/Wacapew.A!ml`) while every local build of the same source scanned clean.
+The confirmed root cause was a **toolchain bump, not a code change**: the publish workflow ran
+`msys2/setup-msys2` with `update: true`, and a full `pacman -Syu` on 2026-09-05 pulled the gcc
+16.1.0 → 16.2.0 package update (published to MSYS2 repos the day before). The rebuilt artifact's
+bytes landed inside the `!ml` model's detection pocket (the near-identical dev-mode build and all
+local 16.1.0 builds scanned clean). `!ml` models are byte-sensitive and change over time, so the
+workflow now skips the system upgrade (`update: false`) — the AV gate below is what enforces that a
+rebuild with any new toolchain still scans clean before it ships. Three structural measures keep
+this in check:
+
+1. **PE metadata** — `installer/src/installer.rc` + `installer.manifest` (compiled by `windres` on
+   the Windows build) give the exe a version resource (FileDescription/CompanyName/ProductName), an
+   asInvoker manifest and Win10/11 compatibility GUIDs. A stripped PE with _no_ version info is the
+   #1 ML false-positive profile; this mirrors what `installer/src/helper/version.rc` already did for
+   `helper_win.exe`.
+2. **The AV scan gate** — `tools/scan-av.mjs` scans built binaries before they are published
+   (Windows: Windows Defender via `MpCmdRun.exe`; Linux/macOS: ClamAV `clamscan`). The publish flow
+   (`tools/publish/upload.mjs`) scans the EXACT bytes about to be uploaded and refuses to publish
+   when any engine reports a detection. A missing engine is only a warning (GitHub Windows runners
+   often run Defender in passive mode), so the gate degrades gracefully but never ships a flagged
+   artifact silently.
+
+### Local scan (after `make dist_win`)
+
+```bash
+pnpm scan:av -- dist/installer/installer_win.exe dist/installer/helper_win.exe
+# exit 0 = clean, exit 1 = detection, exit 2 = usage
+```
+
+### False-positive handling
+
+- If a scanner flags a freshly built binary, do **not** publish it — investigate first. Local builds
+  and the CI artifact differ (toolchain version), so a clean local scan does not guarantee the CI
+  build is clean; the upload gate is what enforces that.
+- Report confirmed false positives to Microsoft (Defender/other Microsoft engines):
+  <https://www.microsoft.com/en-us/wdsi/filesubmission> — select “Your app or file was incorrectly
+  detected as malware” and attach the flagged binary. Microsoft can clear the hash/family in
+  Defender’s cloud, which also clears it for users.
+- A durable long-term fix is **code signing** (e.g. Azure Trusted Signing); it is the only measure
+  that systematically improves AV/OS reputation, but it costs money — the measures above are the
+  zero-cost alternative.
+
 ## Making changes
 
 1. **Chrome scripts** (`core/chrome/utils/`): edit JS files.

--- a/docs/ci-inventory.md
+++ b/docs/ci-inventory.md
@@ -25,13 +25,13 @@ change.
 
 ### Filter ownership
 
-| Output              | Intended paths                                                                                                                              |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `publish`           | `core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, packaging dependencies, `.github/actions/**`, and CI workflow files |
-| `installer`         | Installer implementation/web/API files and `test/e2e/installer/**`                                                                          |
-| `updater`           | `core/chrome/utils/updater/**`, `installer/src/helper/**`, updater shared helpers/tests, and updater workflow/action files                  |
-| `core`              | Browser-chrome/core files and core smoke tests; shared E2E infrastructure may conservatively select all affected groups                     |
-| `browser-downloads` | `test/e2e/shared/downloads.mjs`, watchdog tooling, and watchdog workflow files                                                              |
+| Output              | Intended paths                                                                                                                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `publish`           | `core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, the AV/VT scan tools (`tools/scan-av.mjs`, `tools/scan-vt.mjs`), packaging dependencies, `.github/actions/**`, and CI workflow files |
+| `installer`         | Installer implementation/web/API files and `test/e2e/installer/**`                                                                                                                                           |
+| `updater`           | `core/chrome/utils/updater/**`, `installer/src/helper/**`, updater shared helpers/tests, and updater workflow/action files                                                                                   |
+| `core`              | Browser-chrome/core files and core smoke tests; shared E2E infrastructure may conservatively select all affected groups                                                                                      |
+| `browser-downloads` | `test/e2e/shared/downloads.mjs`, watchdog tooling, and watchdog workflow files                                                                                                                               |
 
 `installer/src/helper/**` belongs to the updater group because the helper binary is used by updater
 installation flows. Its helper E2E remains a separate job, but shares the updater filter.

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,4 +1,8 @@
 CC ?= gcc
+# Overridable windres (binutils).  Native Windows builds default to `windres`
+# (MSYS2 UCRT64); cross-compiles (`make dist_win CC=x86_64-w64-mingw32-gcc`)
+# pass WINDRES=x86_64-w64-mingw32-windres so the PE resource is still linked.
+WINDRES ?= windres
 # Size-optimized: -Os, strip symbols, and emit each function into its own
 # section so the linker's section GC (GC_FLAGS below) can drop dead code.
 # Note: -fdata-sections is deliberately NOT used — with it, mingw-w64 gcc
@@ -87,7 +91,7 @@ $(TARGET): $(SRC_DIR)/resources.h $(SRC_DIR)/_config.h $(WIN_RES)
 
 # Compile the Windows version resource + manifest into a COFF object.
 $(SRC_DIR)/installer.res: $(SRC_DIR)/installer.rc $(SRC_DIR)/installer.manifest
-	windres $(SRC_DIR)/installer.rc -O coff -o $@
+	$(WINDRES) $(SRC_DIR)/installer.rc -O coff -o $@
 
 # Publish mode for the generated config: see tools/publish/publishMode.mjs.
 # Empty (default) = prod; MODE=dev rewrites _config.h / updater-config.sys.mjs
@@ -142,9 +146,13 @@ $(SRC_DIR)/resources.h: embed.mjs $(WEB_DIR)/index.html $(WEB_DIR)/style.css $(W
 # Windows build (cross-compile or native on Windows)
 # -mwindows: link as GUI subsystem so double-click from Explorer doesn't open a terminal
 # --verbose / --log-console flag re-attaches to parent console when run from terminal
-dist_win: resources config $(WIN_RES)
+# dist_win is the win target on ANY host (native or cross-compile), so the PE
+# resource must be built + linked here regardless of $(WIN_RES), which is only
+# set on a Windows host (for `make all` via $(TARGET)).  Cross-compiles pass
+# WINDRES=x86_64-w64-mingw32-windres.
+dist_win: resources config $(SRC_DIR)/installer.res
 	$(MKDIR)
-	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(WIN_RES) -o $(DIST_DIR)/installer_win$(ASSET_SUFFIX).exe $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) \
+	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(SRC_DIR)/installer.res -o $(DIST_DIR)/installer_win$(ASSET_SUFFIX).exe $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) \
 		-lws2_32 -lshell32 -luser32 -lcrypt32 -lbcrypt -static -static-libgcc \
 		-mwindows
 

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -42,10 +42,17 @@ ifeq ($(OS),Windows_NT)
   # console when run from a terminal for diagnostic output.
   # The all target also depends on 'config' which generates _config.h from installer.conf.
   WIN_LIBS = -lws2_32 -lshell32 -luser32 -lcrypt32 -lbcrypt -static -static-libgcc -mwindows
+  # Windows PE version resource + manifest (installer.rc/.manifest): gives the
+  # exe a proper Properties dialog and legitimacy metadata for AV machine
+  # learning — a stripped unsigned PE with no version info is the classic
+  # false-positive profile (Defender: Program:Script/Wacapew.A!ml).  Mirrors
+  # the helper's src/helper/version.rc.  Empty on non-Windows targets.
+  WIN_RES = $(SRC_DIR)/installer.res
   # Section GC: drop unreferenced functions/data emitted by -ffunction-sections.
   GC_FLAGS = -Wl,--gc-sections
 else
   WIN_LIBS =
+  WIN_RES =
   UNAME_S := $(shell uname -s)
   ifeq ($(UNAME_S),Darwin)
     TARGET = $(DIST_DIR)/installer_mac
@@ -74,9 +81,13 @@ endif
 all: resources config $(TARGET)
 
 # Native target rule - maps $(TARGET) to the actual build command
-$(TARGET): $(SRC_DIR)/resources.h $(SRC_DIR)/_config.h
+$(TARGET): $(SRC_DIR)/resources.h $(SRC_DIR)/_config.h $(WIN_RES)
 	$(MKDIR)
-	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) -o $(TARGET) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) $(WIN_LIBS)
+	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(WIN_RES) -o $(TARGET) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) $(WIN_LIBS)
+
+# Compile the Windows version resource + manifest into a COFF object.
+$(SRC_DIR)/installer.res: $(SRC_DIR)/installer.rc $(SRC_DIR)/installer.manifest
+	windres $(SRC_DIR)/installer.rc -O coff -o $@
 
 # Publish mode for the generated config: see tools/publish/publishMode.mjs.
 # Empty (default) = prod; MODE=dev rewrites _config.h / updater-config.sys.mjs
@@ -131,9 +142,9 @@ $(SRC_DIR)/resources.h: embed.mjs $(WEB_DIR)/index.html $(WEB_DIR)/style.css $(W
 # Windows build (cross-compile or native on Windows)
 # -mwindows: link as GUI subsystem so double-click from Explorer doesn't open a terminal
 # --verbose / --log-console flag re-attaches to parent console when run from terminal
-dist_win: resources config
+dist_win: resources config $(WIN_RES)
 	$(MKDIR)
-	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) -o $(DIST_DIR)/installer_win$(ASSET_SUFFIX).exe $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) \
+	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(WIN_RES) -o $(DIST_DIR)/installer_win$(ASSET_SUFFIX).exe $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) \
 		-lws2_32 -lshell32 -luser32 -lcrypt32 -lbcrypt -static -static-libgcc \
 		-mwindows
 
@@ -204,6 +215,6 @@ verify: $(TARGET)
 
 # Clean build artifacts
 clean:
-	rm -f $(SRC_DIR)/resources.h $(SRC_DIR)/_config.h
+	rm -f $(SRC_DIR)/resources.h $(SRC_DIR)/_config.h $(SRC_DIR)/installer.res
 	rm -f $(SRC_DIR)/helper/version.res
 	rm -rf $(DIST_DIR)

--- a/installer/src/installer.manifest
+++ b/installer/src/installer.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="TabMixPlus.FirefoxScripts.Installer" type="win32"/>
+  <description>Firefox Scripts Installer</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/installer/src/installer.rc
+++ b/installer/src/installer.rc
@@ -1,0 +1,42 @@
+#include <windows.h>
+
+// Windows version resource for the installer executable.  The helper binary
+// (src/helper/version.rc) already carries one; without it the installer is a
+// stripped, unsigned PE with no metadata — the exact profile AV machine-learning
+// engines flag as suspicious (Defender: Program:Script/Wacapew.A!ml).
+// Keep FILEVERSION/PRODUCTVERSION in sync with VERSION in config/installer.conf.
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     1,0,0,0
+PRODUCTVERSION  1,0,0,0
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       0
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "Comments",         "Installs and updates the Firefox Scripts helper packages (fx-folder + utils)\0"
+            VALUE "CompanyName",      "Tab Mix Plus\0"
+            VALUE "FileDescription",  "Firefox Scripts Installer\0"
+            VALUE "FileVersion",      "1.0.0\0"
+            VALUE "InternalName",     "installer_win.exe\0"
+            VALUE "LegalCopyright",   "Copyright 2026 Tab Mix Plus\0"
+            VALUE "OriginalFilename", "installer_win.exe\0"
+            VALUE "ProductName",      "Firefox Scripts\0"
+            VALUE "ProductVersion",   "1.0.0\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+// Application manifest: explicit asInvoker (no UAC prompt for the installer
+// itself — the standalone helper elevates), DPI-aware, and Win10/11
+// compatibility GUIDs.  A manifest is a standard legitimacy signal for
+// non-elevating GUI tools.
+1 RT_MANIFEST "installer.manifest"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:decisions": "node tools/check-decisions.mjs",
     "check:gates": "node tools/check-gate-coverage.mjs",
     "test:hash": "node installer/test/test_hash.mjs && node installer/test/test_self_update.mjs",
+    "scan:av": "node tools/scan-av.mjs",
     "test:e2e": "node test/e2e/shared/run.mjs",
     "test:e2e:installer": "node test/e2e/shared/run.mjs --installer",
     "test:e2e:updater": "node test/e2e/shared/run.mjs --updater",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:gates": "node tools/check-gate-coverage.mjs",
     "test:hash": "node installer/test/test_hash.mjs && node installer/test/test_self_update.mjs",
     "scan:av": "node tools/scan-av.mjs",
+    "scan:vt": "node --env-file-if-exists=.env tools/scan-vt.mjs",
     "test:e2e": "node test/e2e/shared/run.mjs",
     "test:e2e:installer": "node test/e2e/shared/run.mjs --installer",
     "test:e2e:updater": "node test/e2e/shared/run.mjs --updater",

--- a/test/unit/tools/scan-vt.test.mjs
+++ b/test/unit/tools/scan-vt.test.mjs
@@ -1,12 +1,45 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import {vtFailThreshold, vtVerdict} from '../../../tools/scan-vt.mjs';
+import {
+  analysisComplete,
+  enginesReported,
+  vtFailThreshold,
+  vtVerdict,
+} from '../../../tools/scan-vt.mjs';
 
 test('vtVerdict: clean when no malicious engines', () => {
   assert.equal(vtVerdict({malicious: 0, suspicious: 2, harmless: 60}, 3), 'clean');
   assert.equal(vtVerdict({}, 3), 'clean');
   assert.equal(vtVerdict(undefined, 3), 'clean');
+});
+
+test('enginesReported: counts every engine category, zero for empty', () => {
+  assert.equal(enginesReported({}), 0);
+  assert.equal(enginesReported(undefined), 0);
+  assert.equal(
+    enginesReported({
+      malicious: 2,
+      suspicious: 0,
+      harmless: 60,
+      undetected: 5,
+      timeout: 3,
+      failure: 1,
+    }),
+    71
+  );
+});
+
+test('analysisComplete: only a finished analysis with engine results counts', () => {
+  assert.equal(analysisComplete('completed', {malicious: 0, harmless: 60}), true);
+  assert.equal(analysisComplete('completed', {malicious: 2}), true);
+  // The CI bug: a timed-out poll left status 'queued' with empty stats,
+  // which used to be reported as "clean".
+  assert.equal(analysisComplete('queued', {}), false);
+  assert.equal(analysisComplete('queued', {malicious: 2}), false);
+  assert.equal(analysisComplete('completed', {}), false);
+  assert.equal(analysisComplete('completed', undefined), false);
+  assert.equal(analysisComplete(undefined, {}), false);
 });
 
 test('vtVerdict: warn on a few malicious engines (below threshold)', () => {

--- a/test/unit/tools/scan-vt.test.mjs
+++ b/test/unit/tools/scan-vt.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {vtFailThreshold, vtVerdict} from '../../../tools/scan-vt.mjs';
+
+test('vtVerdict: clean when no malicious engines', () => {
+  assert.equal(vtVerdict({malicious: 0, suspicious: 2, harmless: 60}, 3), 'clean');
+  assert.equal(vtVerdict({}, 3), 'clean');
+  assert.equal(vtVerdict(undefined, 3), 'clean');
+});
+
+test('vtVerdict: warn on a few malicious engines (below threshold)', () => {
+  assert.equal(vtVerdict({malicious: 1}, 3), 'warn');
+  assert.equal(vtVerdict({malicious: 2}, 3), 'warn');
+});
+
+test('vtVerdict: fail at/above the threshold', () => {
+  assert.equal(vtVerdict({malicious: 3}, 3), 'fail');
+  assert.equal(vtVerdict({malicious: 9}, 3), 'fail');
+});
+
+test('vtVerdict: threshold is per-call and not global', () => {
+  assert.equal(vtVerdict({malicious: 1}, 1), 'fail');
+  assert.equal(vtVerdict({malicious: 1}, 5), 'warn');
+});
+
+test('vtFailThreshold: defaults to 3, honors VT_FAIL_THRESHOLD', () => {
+  const before = process.env.VT_FAIL_THRESHOLD;
+  try {
+    delete process.env.VT_FAIL_THRESHOLD;
+    assert.equal(vtFailThreshold(), 3);
+    process.env.VT_FAIL_THRESHOLD = '1';
+    assert.equal(vtFailThreshold(), 1);
+    process.env.VT_FAIL_THRESHOLD = '0'; // invalid ⇒ default
+    assert.equal(vtFailThreshold(), 3);
+    process.env.VT_FAIL_THRESHOLD = 'bogus'; // invalid ⇒ default
+    assert.equal(vtFailThreshold(), 3);
+  } finally {
+    if (before === undefined) delete process.env.VT_FAIL_THRESHOLD;
+    else process.env.VT_FAIL_THRESHOLD = before;
+  }
+});

--- a/test/unit/tools/scan-vt.test.mjs
+++ b/test/unit/tools/scan-vt.test.mjs
@@ -2,11 +2,15 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   analysisComplete,
   enginesReported,
   maliciousEngines,
+  scanVirusTotal,
   vtFailThreshold,
   vtVerdict,
   vtVetoEngines,
@@ -114,6 +118,51 @@ test('vtFailThreshold: defaults to 3, honors VT_FAIL_THRESHOLD', () => {
   } finally {
     if (before === undefined) delete process.env.VT_FAIL_THRESHOLD;
     else process.env.VT_FAIL_THRESHOLD = before;
+  }
+});
+
+test('scanVirusTotal: VT_VETO_ENGINES env reaches the verdict (regression: veto was hardcoded)', async () => {
+  // The env veto must change the gate. Mock the VT API so the file is "known":
+  // POST /files → 409 (duplicate), then GET /files/<sha> twice — once for the
+  // last_analysis_stats, once for the per-engine results (Bkav malicious at
+  // count 1, under threshold 3 — only a Bkav veto can make this 'fail').
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fxs-vt-veto-'));
+  const file = path.join(dir, 'sample.bin');
+  fs.writeFileSync(file, 'vt-veto-regression');
+  const realFetch = globalThis.fetch;
+  const key = process.env.VT_API_KEY;
+  const veto = process.env.VT_VETO_ENGINES;
+  try {
+    process.env.VT_API_KEY = 'test-key';
+    process.env.VT_VETO_ENGINES = 'Bkav';
+    let fileGets = 0;
+    globalThis.fetch = async (url, opts = {}) => {
+      if (String(url).endsWith('/files') && (opts.method ?? 'GET') === 'POST') {
+        return {ok: false, status: 409, json: async () => ({})};
+      }
+      fileGets += 1;
+      const attrs =
+        fileGets === 1 ?
+          {last_analysis_stats: {malicious: 1, suspicious: 0, harmless: 0, undetected: 60}}
+        : {
+            last_analysis_results: {
+              Bkav: {category: 'malicious', result: 'W32.Malware.X'},
+              Microsoft: {category: 'undetected'},
+            },
+          };
+      return {ok: true, status: 200, json: async () => ({data: {attributes: attrs}})};
+    };
+    const {results} = await scanVirusTotal([file]);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].verdict, 'fail', 'Bkav veto from VT_VETO_ENGINES must fail the gate');
+    assert.deepEqual(results[0].flags, ['Bkav']);
+  } finally {
+    globalThis.fetch = realFetch;
+    if (key === undefined) delete process.env.VT_API_KEY;
+    else process.env.VT_API_KEY = key;
+    if (veto === undefined) delete process.env.VT_VETO_ENGINES;
+    else process.env.VT_VETO_ENGINES = veto;
+    fs.rmSync(dir, {recursive: true, force: true});
   }
 });
 

--- a/test/unit/tools/scan-vt.test.mjs
+++ b/test/unit/tools/scan-vt.test.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/test/unit/tools/scan-vt.test.mjs
+++ b/test/unit/tools/scan-vt.test.mjs
@@ -4,8 +4,10 @@ import assert from 'node:assert/strict';
 import {
   analysisComplete,
   enginesReported,
+  maliciousEngines,
   vtFailThreshold,
   vtVerdict,
+  vtVetoEngines,
 } from '../../../tools/scan-vt.mjs';
 
 test('vtVerdict: clean when no malicious engines', () => {
@@ -52,6 +54,45 @@ test('vtVerdict: fail at/above the threshold', () => {
   assert.equal(vtVerdict({malicious: 9}, 3), 'fail');
 });
 
+test('vtVerdict: a veto engine (Microsoft) fails below the threshold', () => {
+  // The CI-built exe: Microsoft + Bkav flag, 2 < threshold 3 — must still fail.
+  const engines = {
+    Microsoft: {category: 'malicious', result: 'Trojan:Win32/Wacatac.C!ml'},
+    Bkav: {category: 'malicious', result: 'W32.Malware.7F00676A'},
+  };
+  assert.equal(vtVerdict({malicious: 2}, 3, engines), 'fail');
+  assert.equal(vtVerdict({malicious: 1}, 3, {Microsoft: {category: 'malicious'}}), 'fail');
+});
+
+test('vtVerdict: non-veto engines keep warn semantics below the threshold', () => {
+  assert.equal(
+    vtVerdict({malicious: 2}, 3, {Bkav: {category: 'malicious'}, Elastic: {category: 'malicious'}}),
+    'warn'
+  );
+  assert.equal(vtVerdict({malicious: 1}, 3, {Bkav: {category: 'malicious'}}), 'warn');
+  // Microsoft present but NOT malicious must not veto.
+  assert.equal(vtVerdict({malicious: 1}, 3, {Microsoft: {category: 'undetected'}}), 'warn');
+});
+
+test('vtVerdict: custom veto list is honored', () => {
+  assert.equal(vtVerdict({malicious: 1}, 3, {Bkav: {category: 'malicious'}}, ['Bkav']), 'fail');
+  assert.equal(vtVerdict({malicious: 1}, 3, {Bkav: {category: 'malicious'}}, []), 'warn');
+});
+
+test('maliciousEngines: lists only engines whose category is malicious', () => {
+  assert.deepEqual(
+    maliciousEngines({
+      Microsoft: {category: 'malicious'},
+      Bkav: {category: 'malicious'},
+      Elastic: {category: 'undetected'},
+      Ikarus: {category: 'failure'},
+    }),
+    ['Microsoft', 'Bkav']
+  );
+  assert.deepEqual(maliciousEngines(undefined), []);
+  assert.deepEqual(maliciousEngines({}), []);
+});
+
 test('vtVerdict: threshold is per-call and not global', () => {
   assert.equal(vtVerdict({malicious: 1}, 1), 'fail');
   assert.equal(vtVerdict({malicious: 1}, 5), 'warn');
@@ -71,5 +112,20 @@ test('vtFailThreshold: defaults to 3, honors VT_FAIL_THRESHOLD', () => {
   } finally {
     if (before === undefined) delete process.env.VT_FAIL_THRESHOLD;
     else process.env.VT_FAIL_THRESHOLD = before;
+  }
+});
+
+test('vtVetoEngines: defaults to Microsoft, honors VT_VETO_ENGINES', () => {
+  const before = process.env.VT_VETO_ENGINES;
+  try {
+    delete process.env.VT_VETO_ENGINES;
+    assert.deepEqual(vtVetoEngines(), ['Microsoft']);
+    process.env.VT_VETO_ENGINES = 'Bkav, Elastic';
+    assert.deepEqual(vtVetoEngines(), ['Bkav', 'Elastic']);
+    process.env.VT_VETO_ENGINES = ','; // empty ⇒ default
+    assert.deepEqual(vtVetoEngines(), ['Microsoft']);
+  } finally {
+    if (before === undefined) delete process.env.VT_VETO_ENGINES;
+    else process.env.VT_VETO_ENGINES = before;
   }
 });

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -396,10 +396,27 @@ async function buildBinaries(platforms, storedHashes) {
   // place). Never rebuild or reuse — derive the built set from what exists on
   // disk so the gates + publish below operate on the signed bytes.
   if (SKIP_BUILD) {
+    // Fail fast: pass 2 is the ONLY pass that runs the AV/VT gates + uploads,
+    // so publishing without the staged bytes for anything this run would
+    // rebuild would silently skip the security gates AND write hashes into
+    // hashes.json that point at binaries never uploaded. Require the staged
+    // file for every in-scope platform whose hash changed (always true in
+    // dev). A genuinely idle prod pass (nothing changed, nothing staged) still
+    // completes — it uploads nothing and leaves the manifest untouched.
+    const missing = [];
     for (const p of platforms) {
-      if (fs.existsSync(installerPath(p))) builtInstallers.push(p);
-      if (fs.existsSync(helperPath(p))) builtHelpers.push(p);
+      if (installerChanged && !fs.existsSync(installerPath(p))) missing.push(installerAssetName(p));
+      if (helperChanged && !fs.existsSync(helperPath(p))) missing.push(helperAssetName(p));
     }
+    if (missing.length > 0) {
+      throw new Error(
+        `--skip-build is missing the staged binaries this run would publish: ` +
+          `${missing.join(', ')} — run pass 1 (--build-only) and preserve ` +
+          `${BUILD_ROOT} before pass 2.`
+      );
+    }
+    if (installerChanged) builtInstallers.push(...platforms);
+    if (helperChanged) builtHelpers.push(...platforms);
     const updated = {};
     if (installerChanged) updated.installer = {hash: installerHash, date: installerDate};
     if (helperChanged) updated.helper = {hash: helperHash, date: helperDate};

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -29,6 +29,15 @@
 //   --no-tag           (prod only) skip moving the 'latest' release tag to the
 //                      uploaded commit (it is force-updated after every
 //                      non-idle prod upload).
+//   --build-only       pass 1 of the SignPath signing flow: build/stage the
+//                      binaries, write dist/.build/build-manifest.json, then
+//                      exit BEFORE the AV/VT gates and publishing. The staging
+//                      tree is kept on disk so the workflow can code-sign the
+//                      staged files between passes.
+//   --skip-build       pass 2 of the SignPath flow: never rebuild (or reuse)
+//                      binaries — treat whatever is staged as the final,
+//                      code-signed artifacts — then run the gates + publish.
+//                      Mutually exclusive with --build-only.
 //   --verbose          per-file zip listings and other detail lines.
 //   --quiet            suppress progress output (errors still print).
 //
@@ -118,6 +127,16 @@ const REF = (() => {
 // GitHub runs normally leave nothing in dist/; --keep-copy additionally writes
 // a prod-copy-<branch>-<hash>/ (or dev-copy-…) snapshot before cleanup.
 const KEEP_COPY = process.argv.includes('--keep-copy');
+// SignPath two-pass flow: pass 1 (--build-only) builds + stages the binaries
+// and writes build-manifest.json so the workflow can code-sign each staged
+// file in place; pass 2 (--skip-build) runs the AV/VT gates + publishing on
+// those signed bytes. The two are exclusive — a build-only pass that also
+// skipped building would have nothing to sign.
+const BUILD_ONLY = process.argv.includes('--build-only');
+const SKIP_BUILD = process.argv.includes('--skip-build');
+if (BUILD_ONLY && SKIP_BUILD) {
+  throw new Error('--build-only and --skip-build are mutually exclusive.');
+}
 // Removed flags fail loudly: an old --dry-run / --packages-only /
 // --binaries-only invocation must never silently turn into a real upload.
 // The offline check is now `--local` (upload:local).
@@ -371,6 +390,22 @@ async function buildBinaries(platforms, storedHashes) {
 
   const builtInstallers = [];
   const builtHelpers = [];
+
+  // Pass 2 of the SignPath flow (--skip-build): the staged binaries ARE the
+  // final artifacts (pass 1 built them, the workflow code-signed them in
+  // place). Never rebuild or reuse — derive the built set from what exists on
+  // disk so the gates + publish below operate on the signed bytes.
+  if (SKIP_BUILD) {
+    for (const p of platforms) {
+      if (fs.existsSync(installerPath(p))) builtInstallers.push(p);
+      if (fs.existsSync(helperPath(p))) builtHelpers.push(p);
+    }
+    const updated = {};
+    if (installerChanged) updated.installer = {hash: installerHash, date: installerDate};
+    if (helperChanged) updated.helper = {hash: helperHash, date: helperDate};
+    return {updated, builtInstallers, builtHelpers};
+  }
+
   // Staging is emptied on every run, so in local mode unchanged binaries are
   // reused from the newest existing snapshot (the continuity baseline) instead
   // of being recompiled.
@@ -407,6 +442,42 @@ async function buildBinaries(platforms, storedHashes) {
   if (installerChanged) updated.installer = {hash: installerHash, date: installerDate};
   if (helperChanged) updated.helper = {hash: helperHash, date: helperDate};
   return {updated, builtInstallers, builtHelpers};
+}
+
+/**
+ * Pass 1 of the SignPath flow (--build-only): record which binaries were staged
+ * and where, so the publish workflow can upload each to SignPath for code
+ * signing and copy the signed result back over the same path before pass 2
+ * (--skip-build) runs the gates + publish. Written into the staging tree
+ * (dist/.build/build-manifest.json), which build-only keeps on disk.
+ */
+function writeBuildManifest(platforms, builtInstallers, builtHelpers) {
+  const files = [
+    ...builtInstallers.map(p => ({
+      role: 'installer',
+      platform: p,
+      asset: installerAssetName(p),
+      absPath: installerPath(p),
+    })),
+    ...builtHelpers.map(p => ({
+      role: 'helper',
+      platform: p,
+      asset: helperAssetName(p),
+      absPath: helperPath(p),
+    })),
+  ];
+  const manifest = {mode: PUBLISH_MODE, platforms, stagingDir: BUILD_ROOT, files};
+  const manifestPath = path.join(BUILD_ROOT, 'build-manifest.json');
+  fs.mkdirSync(BUILD_ROOT, {recursive: true});
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+  if (files.length === 0) {
+    info('  nothing to sign — no binaries needed rebuilding');
+  } else {
+    for (const f of files) {
+      info(`  staged ${yellow(f.role)} ${f.asset} → ${dim(f.absPath)}`);
+    }
+  }
+  info(`  build manifest → ${manifestPath}`);
 }
 
 /**
@@ -697,6 +768,10 @@ function runRefBuild(ref) {
 }
 
 async function main() {
+  // Pass 1 of the SignPath flow (--build-only) hands its staging tree to the
+  // workflow signing step + pass 2, so the finally block below must leave
+  // dist/.build in place on that path.
+  let keepStaging = false;
   try {
     // --ref builds happen in a detached worktree, so the current checkout may
     // stay dirty; the worktree itself starts clean.
@@ -760,6 +835,18 @@ async function main() {
       builtInstallers,
       builtHelpers,
     } = await buildBinaries(platforms, storedHashes);
+
+    // SignPath flow pass 1 (--build-only): stop here with the staged binaries
+    // and the build manifest. The workflow code-signs each staged file, then
+    // re-invokes this tool with --skip-build (pass 2) to run the AV/VT gates
+    // + publishing on the signed bytes. Success keeps the staging tree on
+    // disk (see the finally block below).
+    if (BUILD_ONLY) {
+      writeBuildManifest(platforms, builtInstallers, builtHelpers);
+      keepStaging = true;
+      success('\n✓ Staged binaries ready for code signing (run pass 2 with --skip-build)');
+      return;
+    }
 
     // AV gate: scan the EXACT bytes about to be uploaded and refuse to publish
     // a flagged artifact (installer_win.exe was once falsely flagged by
@@ -867,9 +954,11 @@ async function main() {
     // Leave the working tree like a fresh clone: the run regenerated the
     // untracked generated files with this mode's URLs; delete them so no
     // localhost/dev-baked copies linger (all regenerable on demand). Also
-    // remove the transient staging tree so dist/ holds only snapshots.
+    // remove the transient staging tree so dist/ holds only snapshots —
+    // except after a successful --build-only pass, which keeps its staging
+    // tree for the workflow signing step + the --skip-build pass 2.
     cleanGenerated();
-    fs.rmSync(BUILD_ROOT, {recursive: true, force: true});
+    if (!keepStaging) fs.rmSync(BUILD_ROOT, {recursive: true, force: true});
   }
 }
 

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -787,9 +787,12 @@ async function main() {
     }
 
     // Optional multi-engine scan via VirusTotal (requires VT_API_KEY in the
-    // env — a missing key or a transient API error only warns).  The publish
-    // hard-fails only when >= VT_FAIL_THRESHOLD (default 3) engines report a
-    // binary as malicious: a multi-engine consensus, not a single-engine FP.
+    // env — a missing key, a transient API error, or an analysis that never
+    // completes only warns).  The publish hard-fails when >= VT_FAIL_THRESHOLD
+    // (default 3) engines report a binary as malicious — a multi-engine
+    // consensus, not a single-engine FP — or when a veto engine (default
+    // Microsoft) reports it as malicious at any count.  Any fail verdict
+    // returns BEFORE the Publishing section below, so no asset is uploaded.
     section('VirusTotal scan');
     if (avFiles.length > 0) {
       const {results} = await scanVirusTotal(avFiles);
@@ -803,11 +806,12 @@ async function main() {
         const label =
           `${path.basename(r.file)} — ${malicious} malicious / ${suspicious} suspicious / ` +
           `${harmless} harmless / ${undetected} undetected (threshold ${r.threshold})`;
+        const who = r.flags?.length > 0 ? ` (flagged by ${r.flags.join(', ')})` : '';
         if (r.verdict === 'fail') {
-          error(`VirusTotal DETECTION: ${label}`);
+          error(`VirusTotal DETECTION: ${label}${who}`);
           vtBlocked = true;
         } else if (r.verdict === 'warn') {
-          warn(`VirusTotal flagged: ${label}`);
+          warn(`VirusTotal flagged: ${label}${who}`);
         } else {
           info(`  ${green('clean')} on VirusTotal — ${label}`);
         }

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -79,6 +79,7 @@ import {
 } from './publishCommon.mjs';
 import {pagesIndex, uploadFilesToPages} from './uploadToPages.mjs';
 import {scanBinaries} from '../scan-av.mjs';
+import {scanVirusTotal} from '../scan-vt.mjs';
 import {
   bold,
   detail,
@@ -780,6 +781,40 @@ async function main() {
       }
       if (findings.length > 0) {
         error('Refusing to publish — an AV engine flagged a built binary.');
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    // Optional multi-engine scan via VirusTotal (requires VT_API_KEY in the
+    // env — a missing key or a transient API error only warns).  The publish
+    // hard-fails only when >= VT_FAIL_THRESHOLD (default 3) engines report a
+    // binary as malicious: a multi-engine consensus, not a single-engine FP.
+    section('VirusTotal scan');
+    if (avFiles.length > 0) {
+      const {results} = await scanVirusTotal(avFiles);
+      let vtBlocked = false;
+      for (const r of results) {
+        if (r.error) {
+          warn(`VirusTotal skipped ${path.basename(r.file)}: ${r.error}`);
+          continue;
+        }
+        const {malicious, suspicious, harmless, undetected} = r.stats;
+        const label =
+          `${path.basename(r.file)} — ${malicious} malicious / ${suspicious} suspicious / ` +
+          `${harmless} harmless / ${undetected} undetected (threshold ${r.threshold})`;
+        if (r.verdict === 'fail') {
+          error(`VirusTotal DETECTION: ${label}`);
+          vtBlocked = true;
+        } else if (r.verdict === 'warn') {
+          warn(`VirusTotal flagged: ${label}`);
+        } else {
+          info(`  ${green('clean')} on VirusTotal — ${label}`);
+        }
+      }
+      if (results.length === 0) warn('VirusTotal scan skipped — VT_API_KEY not set (optional).');
+      if (vtBlocked) {
+        error('Refusing to publish — VirusTotal flagged a built binary.');
         process.exitCode = 1;
         return;
       }

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -78,6 +78,7 @@ import {
   REPO_ROOT,
 } from './publishCommon.mjs';
 import {pagesIndex, uploadFilesToPages} from './uploadToPages.mjs';
+import {scanBinaries} from '../scan-av.mjs';
 import {
   bold,
   detail,
@@ -758,6 +759,31 @@ async function main() {
       builtInstallers,
       builtHelpers,
     } = await buildBinaries(platforms, storedHashes);
+
+    // AV gate: scan the EXACT bytes about to be uploaded and refuse to publish
+    // a flagged artifact (installer_win.exe was once falsely flagged by
+    // Defender — see tools/scan-av.mjs).  Best-effort engines: a missing
+    // scanner only warns; a positive detection hard-fails the run.
+    section('AV scan');
+    const avFiles = [...builtInstallers.map(installerPath), ...builtHelpers.map(helperPath)];
+    if (avFiles.length > 0) {
+      const {findings, scanned, notes} = await scanBinaries(avFiles);
+      for (const n of notes) warn(n);
+      if (scanned.length > 0) {
+        info(
+          `  ${green('clean')} — ${scanned.length} binary(ies) scanned by ` +
+            `${process.platform === 'win32' ? 'Windows Defender' : 'ClamAV'}`
+        );
+      }
+      for (const f of findings) {
+        error(`AV DETECTION: ${path.basename(f.file)} — ${f.engine}: ${f.detail}`);
+      }
+      if (findings.length > 0) {
+        error('Refusing to publish — an AV engine flagged a built binary.');
+        process.exitCode = 1;
+        return;
+      }
+    }
 
     const merged = {...storedHashes, ...zipUpdated, ...binUpdated};
     const manifestChanged =

--- a/tools/scan-av.mjs
+++ b/tools/scan-av.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+//
 // scan-av.mjs — scan built binaries with whatever antivirus engine is
 // available on the host, so a publish can refuse to ship a flagged artifact.
 //

--- a/tools/scan-av.mjs
+++ b/tools/scan-av.mjs
@@ -1,0 +1,153 @@
+// scan-av.mjs — scan built binaries with whatever antivirus engine is
+// available on the host, so a publish can refuse to ship a flagged artifact.
+//
+// Why: unsigned, stripped, statically-linked executables are a classic AV
+// machine-learning false-positive profile.  The installer was once flagged by
+// Windows Defender (Program:Script/Wacapew.A!ml) even though every local build
+// scanned clean — the trigger was the exact bytes of one CI-built artifact.
+// The durable guard is to scan the EXACT bytes about to be uploaded, on every
+// publish, and fail if any engine reports a detection.
+//
+// Engines (best-effort — a missing engine is a warning, never a blocker, so
+// the gate degrades gracefully on machines without one; a POSITIVE detection
+// is always a hard failure):
+//   - Windows: Windows Defender (MpCmdRun.exe)
+//   - Linux/macOS: ClamAV (clamscan), if installed
+//
+// NOTE: GitHub-hosted Windows runners frequently run Defender in passive mode
+// or without current definitions, so CI scans may be unavailable there — the
+// real Windows validation happens on a developer's machine (Defender active)
+// and on the Linux publish job (clamscan).
+
+import {existsSync, readdirSync} from 'fs';
+import {spawnSync} from 'child_process';
+import path from 'path';
+import {pathToFileURL} from 'url';
+
+const MPCMD_PATHS = [
+  'C:\\Program Files\\Windows Defender\\MpCmdRun.exe',
+  'C:\\ProgramData\\Microsoft\\Windows Defender\\Platform',
+];
+
+/** Locate MpCmdRun.exe (Windows Defender command-line scanner) or null. */
+function findMpCmdRun() {
+  for (const p of MPCMD_PATHS) {
+    if (!existsSync(p)) continue;
+    if (p.endsWith('MpCmdRun.exe')) return p;
+    // Versioned platform dirs: pick the newest.
+    let versions;
+    try {
+      versions = readdirSync(p)
+        .filter(d => /^\d/.test(d))
+        .sort();
+    } catch {
+      continue;
+    }
+    if (!versions || versions.length === 0) continue;
+    const exe = `${p}\\${versions.at(-1)}\\MpCmdRun.exe`;
+    if (existsSync(exe)) return exe;
+  }
+  const which = spawnSync('where.exe', ['MpCmdRun.exe'], {encoding: 'utf8'});
+  if (which.status === 0 && which.stdout.trim()) {
+    return which.stdout.trim().split(/\r?\n/)[0];
+  }
+  return null;
+}
+
+/** Resolve a command on PATH (where.exe on Windows, which elsewhere). */
+function findOnPath(cmd) {
+  const which = spawnSync(process.platform === 'win32' ? 'where.exe' : 'which', [cmd], {
+    encoding: 'utf8',
+  });
+  return which.status === 0 && which.stdout.trim() ? which.stdout.trim().split(/\r?\n/)[0] : null;
+}
+
+/**
+ * Scan one file with Windows Defender. Returns {clean: true} | {clean: false,
+ * detail} | {clean: null, detail} when the engine is unavailable/errored (exit
+ * codes other than 0/2).
+ */
+function scanWithDefender(file) {
+  const mp = findMpCmdRun();
+  if (!mp) return null;
+  const r = spawnSync(mp, ['-Scan', '-ScanType', '3', '-File', file], {
+    encoding: 'utf8',
+    timeout: 180_000,
+  });
+  const out = `${r.stdout || ''}\n${r.stderr || ''}`.trim();
+  const last = out.split('\n').filter(Boolean).at(-1) || '';
+  // Parse the result line — MpCmdRun's exit codes are unreliable (2 can mean
+  // both "threats found" and an operational error like a locked file).
+  const found = out.match(/found (\d+) threats?/i);
+  if (found && Number(found[1]) > 0) return {clean: false, detail: last};
+  if (/found no threats/i.test(out)) return {clean: true, detail: last};
+  return {clean: null, detail: last || `MpCmdRun exit ${r.status}`};
+}
+
+/** Scan one file with ClamAV. Same contract as scanWithDefender. */
+function scanWithClamav(file) {
+  const clam = findOnPath('clamscan');
+  if (!clam) return null;
+  const r = spawnSync(clam, [file, '--no-summary'], {encoding: 'utf8', timeout: 180_000});
+  const out = `${r.stdout || ''}\n${r.stderr || ''}`.trim();
+  const last = out.split('\n').filter(Boolean).at(-1) || '';
+  if (r.status === 0) return {clean: true, detail: last};
+  if (r.status === 1) return {clean: false, detail: last || 'threat found'};
+  // exit 2 = engine error (e.g. missing signature database) → unavailable.
+  return {clean: null, detail: last || `clamscan exit ${r.status}`};
+}
+
+/**
+ * Scan a list of binary paths with the platform's available engine.
+ *
+ * @param {string[]} files absolute paths of the binaries to scan
+ * @returns {Promise<{findings: Array; scanned: string[]; notes: string[]}>}
+ *   findings — {file, engine, detail} for every POSITIVE detection (always empty
+ *   on a clean run); scanned — files actually scanned; notes — why a
+ *   file/engine was skipped (no engine installed, engine error).
+ */
+export async function scanBinaries(files) {
+  const findings = [];
+  const scanned = [];
+  const notes = [];
+
+  for (const file of files) {
+    const onWin = process.platform === 'win32';
+    const res = onWin ? scanWithDefender(file) : scanWithClamav(file);
+    if (res === null) {
+      notes.push(
+        `AV scan skipped for ${file}: ${onWin ? 'Windows Defender (MpCmdRun.exe)' : 'clamscan'} not available`
+      );
+    } else if (res.clean === null) {
+      notes.push(`AV scan skipped for ${file}: ${res.detail}`);
+    } else if (res.clean) {
+      scanned.push(file);
+    } else {
+      findings.push({file, engine: onWin ? 'Windows Defender' : 'ClamAV', detail: res.detail});
+    }
+  }
+
+  return {findings, scanned, notes};
+}
+
+// CLI entry: node tools/scan-av.mjs <binary> [<binary>...]
+// Exits 0 = clean, 1 = threats found, 2 = usage error.  A missing scanner is
+// reported but NOT an error (exit 0) — the publish gate is what must enforce.
+const isCli =
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isCli) {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('usage: node tools/scan-av.mjs <binary> [<binary>...]');
+    process.exit(2);
+  }
+  const {findings, scanned, notes} = await scanBinaries(files.map(f => path.resolve(f)));
+  for (const n of notes) console.warn(`! ${n}`);
+  for (const f of findings) console.error(`!! ${f.file} — ${f.engine}: ${f.detail}`);
+  if (findings.length > 0) process.exit(1);
+  console.log(
+    scanned.length > 0 ?
+      `OK — ${scanned.length} file(s) scanned, no threats`
+    : 'No AV engine available on this machine (install ClamAV or run on Windows with Defender)'
+  );
+}

--- a/tools/scan-vt.mjs
+++ b/tools/scan-vt.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+//
 // tools/scan-vt.mjs — optional multi-engine scan of built binaries against
 // VirusTotal before publishing.
 //

--- a/tools/scan-vt.mjs
+++ b/tools/scan-vt.mjs
@@ -15,6 +15,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import {pathToFileURL} from 'url';
 
 const VT_API = 'https://www.virustotal.com/api/v3';
 const POLL_INTERVAL_MS = 2000;
@@ -103,4 +104,42 @@ export async function scanVirusTotal(
     }
   }
   return {results};
+}
+
+// CLI entry: node tools/scan-vt.mjs <binary> [<binary>...]
+// Reads VT_API_KEY from the environment (e.g. via `node --env-file-if-exists=.env`,
+// as pnpm scan:vt does).  Exits 0 = clean, 1 = >= threshold engines flagged, 2 = usage.
+const isCli =
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isCli) {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('usage: node tools/scan-vt.mjs <binary> [<binary>...]');
+    process.exit(2);
+  }
+  const {results} = await scanVirusTotal(files.map(f => path.resolve(f)));
+  if (results.length === 0) {
+    console.warn('VirusTotal scan skipped — VT_API_KEY not set (add it to .env).');
+    process.exit(0);
+  }
+  let blocked = false;
+  for (const r of results) {
+    if (r.error) {
+      console.warn(`! ${r.file} — ${r.error}`);
+      continue;
+    }
+    const {malicious, suspicious, harmless, undetected} = r.stats;
+    const line =
+      `${r.file} — ${malicious} malicious / ${suspicious} suspicious / ` +
+      `${harmless} harmless / ${undetected} undetected (threshold ${r.threshold})`;
+    if (r.verdict === 'fail') {
+      console.error(`!! ${line}`);
+      blocked = true;
+    } else if (r.verdict === 'warn') {
+      console.warn(`! ${line}`);
+    } else {
+      console.log(`OK ${line}`);
+    }
+  }
+  if (blocked) process.exit(1);
 }

--- a/tools/scan-vt.mjs
+++ b/tools/scan-vt.mjs
@@ -8,18 +8,23 @@
 // built binary through VT at publish time turns that manual check into a gate.
 //
 // Best-effort by design — VT_API_KEY (or VIRUSTOTAL_API_KEY) in the
-// environment, a transient API error, or a rate limit only warn, never block.
-// The publish only hard-fails when the number of engines reporting the binary
-// as malicious reaches VT_FAIL_THRESHOLD (default 3) — a strong multi-engine
-// consensus that is not an AV false-positive.
+// environment, a transient API error, a rate limit, or an analysis that never
+// completes only warn, never block.  The publish only hard-fails when the
+// number of engines reporting the binary as malicious reaches
+// VT_FAIL_THRESHOLD (default 3) — a strong multi-engine consensus that is not
+// an AV false-positive.  An incomplete analysis is NEVER reported as clean:
+// if VirusTotal has not finished scanning when the timeout elapses, the file
+// is skipped with a warning so the publish cannot claim a verdict it did not
+// get.
 
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import {pathToFileURL} from 'url';
 
 const VT_API = 'https://www.virustotal.com/api/v3';
 const POLL_INTERVAL_MS = 2000;
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 300_000;
 
 export function vtApiKey() {
   return process.env.VT_API_KEY || process.env.VIRUSTOTAL_API_KEY || null;
@@ -31,7 +36,9 @@ export function vtFailThreshold() {
 }
 
 /**
- * Pure verdict over VT detection stats.
+ * Pure verdict over VT detection stats. Only meaningful for a COMPLETED
+ * analysis (see analysisComplete) — an empty/incomplete stats object is not
+ * "clean", callers must guard with analysisComplete first.
  *
  * @param {{malicious: number; suspicious: number}} stats
  * @param {number} threshold
@@ -44,8 +51,50 @@ export function vtVerdict(stats, threshold) {
   return 'clean';
 }
 
+/**
+ * Number of engines that reported a result in the given stats object (every VT
+ * category counts — a verdict of "clean" with zero engines is meaningless).
+ *
+ * @param {{}} stats
+ * @returns {number}
+ */
+export function enginesReported(stats) {
+  const s = stats ?? {};
+  return [
+    'malicious',
+    'suspicious',
+    'harmless',
+    'undetected',
+    'timeout',
+    'confirmed-timeout',
+    'failure',
+    'type-unsupported',
+  ].reduce((n, k) => n + Number(s[k] ?? 0), 0);
+}
+
+/**
+ * A VT analysis is only trustworthy once it finished (status 'completed') AND
+ * at least one engine reported a result. A 'queued'/'running' analysis, or a
+ * 'completed' one with empty stats, must never be read as a verdict.
+ *
+ * @param {string | undefined} status
+ * @param {{}} stats
+ * @returns {boolean}
+ */
+export function analysisComplete(status, stats) {
+  return status === 'completed' && enginesReported(stats) > 0;
+}
+
+/**
+ * Submit bytes to VirusTotal and return either a fresh pollable analysis id
+ * ({id}) or, when VirusTotal already knows the bytes and rejects the duplicate
+ * submission with HTTP 409 (AlreadySubmittedError), their last completed stats
+ * ({stats}). Never throws on 409 — the known file's stats are the fallback so
+ * repeat scans of unchanged bytes still get a verdict.
+ */
 async function uploadFile(apikey, file) {
   const buf = await fs.promises.readFile(file);
+  const sha256 = crypto.createHash('sha256').update(buf).digest('hex');
   const form = new FormData();
   form.append('file', new Blob([buf]), path.basename(file));
   const res = await fetch(`${VT_API}/files`, {
@@ -53,8 +102,18 @@ async function uploadFile(apikey, file) {
     headers: {'x-apikey': apikey},
     body: form,
   });
-  if (!res.ok) throw new Error(`VirusTotal upload failed (HTTP ${res.status})`);
-  return (await res.json()).data?.id;
+  if (res.ok) {
+    const id = (await res.json()).data?.id;
+    if (id) return {id};
+    throw new Error('VirusTotal returned no analysis id');
+  }
+  if (res.status !== 409) throw new Error(`VirusTotal upload failed (HTTP ${res.status})`);
+  // Duplicate submission — fall back to the file's last completed analysis.
+  const known = await fetch(`${VT_API}/files/${sha256}`, {
+    headers: {'x-apikey': apikey},
+  });
+  if (!known.ok) throw new Error(`VirusTotal upload failed (HTTP ${res.status})`);
+  return {stats: (await known.json()).data?.attributes?.last_analysis_stats ?? {}};
 }
 
 async function getAnalysis(apikey, id) {
@@ -84,17 +143,52 @@ export async function scanVirusTotal(
   const results = [];
   for (const file of files) {
     try {
-      const id = await uploadFile(key, file);
+      const uploaded = await uploadFile(key, file);
+      if (uploaded.stats) {
+        // Bytes VirusTotal already knew — its last completed analysis is the
+        // verdict.  An empty stats object means the analysis has not finished
+        // yet: skip with a warning, never report as clean.
+        if (!analysisComplete('completed', uploaded.stats)) {
+          results.push({
+            file,
+            error:
+              'VirusTotal has no completed analysis for these bytes yet — skipping, not treated as clean',
+          });
+          continue;
+        }
+        results.push({
+          file,
+          status: 'completed',
+          stats: uploaded.stats,
+          threshold,
+          verdict: vtVerdict(uploaded.stats, threshold),
+        });
+        continue;
+      }
       const start = Date.now();
       let data;
-      do {
+      for (;;) {
         await sleep(POLL_INTERVAL_MS);
-        data = await getAnalysis(key, id);
-      } while (data.attributes?.status === 'queued' && Date.now() - start < timeoutMs);
-      const stats = data.attributes?.stats ?? {};
+        data = await getAnalysis(key, uploaded.id);
+        const attrs = data.attributes ?? {};
+        if (analysisComplete(attrs.status, attrs.stats) || Date.now() - start >= timeoutMs) break;
+      }
+      const attrs = data.attributes ?? {};
+      const stats = attrs.stats ?? {};
+      if (!analysisComplete(attrs.status, stats)) {
+        // VirusTotal never finished scanning (still queued, or completed with
+        // no engine results).  Skip with a warning — never report as clean.
+        results.push({
+          file,
+          error:
+            `VirusTotal analysis incomplete after ${Math.round((Date.now() - start) / 1000)}s ` +
+            `(status: ${attrs.status ?? 'unknown'}) — skipping, not treated as clean`,
+        });
+        continue;
+      }
       results.push({
         file,
-        status: data.attributes?.status,
+        status: attrs.status,
         stats,
         threshold,
         verdict: vtVerdict(stats, threshold),

--- a/tools/scan-vt.mjs
+++ b/tools/scan-vt.mjs
@@ -9,10 +9,11 @@
 //
 // Best-effort by design — VT_API_KEY (or VIRUSTOTAL_API_KEY) in the
 // environment, a transient API error, a rate limit, or an analysis that never
-// completes only warn, never block.  The publish only hard-fails when the
-// number of engines reporting the binary as malicious reaches
-// VT_FAIL_THRESHOLD (default 3) — a strong multi-engine consensus that is not
-// an AV false-positive.  An incomplete analysis is NEVER reported as clean:
+// completes only warn, never block.  The publish hard-fails when the number of
+// engines reporting the binary as malicious reaches VT_FAIL_THRESHOLD (default
+// 3) — a multi-engine consensus that is not an AV false-positive — OR when a
+// veto engine (Microsoft, the complainant in the original issue) reports it as
+// malicious at any count.  An incomplete analysis is NEVER reported as clean:
 // if VirusTotal has not finished scanning when the timeout elapses, the file
 // is skipped with a warning so the publish cannot claim a verdict it did not
 // get.
@@ -25,6 +26,10 @@ import {pathToFileURL} from 'url';
 const VT_API = 'https://www.virustotal.com/api/v3';
 const POLL_INTERVAL_MS = 2000;
 const DEFAULT_TIMEOUT_MS = 300_000;
+// Engines whose 'malicious' verdict alone vetoes the publish (see
+// docs/DEVELOPING.md — Microsoft cloud flagged installer_win.exe even when
+// every other engine stayed silent, so a Defender verdict must never ship).
+const VETO_ENGINES = ['Microsoft'];
 
 export function vtApiKey() {
   return process.env.VT_API_KEY || process.env.VIRUSTOTAL_API_KEY || null;
@@ -35,6 +40,16 @@ export function vtFailThreshold() {
   return Number.isFinite(n) && n > 0 ? n : 3;
 }
 
+export function vtVetoEngines() {
+  const raw = process.env.VT_VETO_ENGINES;
+  const parsed = (raw ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  // Empty/unset (or a list that filters to nothing) ⇒ the default veto.
+  return parsed.length > 0 ? parsed : [...VETO_ENGINES];
+}
+
 /**
  * Pure verdict over VT detection stats. Only meaningful for a COMPLETED
  * analysis (see analysisComplete) — an empty/incomplete stats object is not
@@ -42,11 +57,16 @@ export function vtFailThreshold() {
  *
  * @param {{malicious: number; suspicious: number}} stats
  * @param {number} threshold
+ * @param {Object<string, {category?: string}>} [engines] per-engine results
+ * @param {string[]} [vetoEngines] engines whose malicious verdict is a veto
  * @returns {'fail' | 'warn' | 'clean'}
  */
-export function vtVerdict(stats, threshold) {
+export function vtVerdict(stats, threshold, engines = {}, vetoEngines = VETO_ENGINES) {
   const malicious = Number(stats?.malicious ?? 0);
-  if (malicious >= threshold) return 'fail';
+  const vetoed = Object.entries(engines).some(
+    ([name, result]) => vetoEngines.includes(name) && result?.category === 'malicious'
+  );
+  if (vetoed || malicious >= threshold) return 'fail';
   if (malicious > 0) return 'warn';
   return 'clean';
 }
@@ -86,6 +106,18 @@ export function analysisComplete(status, stats) {
 }
 
 /**
+ * Engine names whose last result was 'malicious'.
+ *
+ * @param {Object<string, {category?: string}> | undefined} engines
+ * @returns {string[]}
+ */
+export function maliciousEngines(engines) {
+  return Object.entries(engines ?? {})
+    .filter(([, result]) => result?.category === 'malicious')
+    .map(([name]) => name);
+}
+
+/**
  * Submit bytes to VirusTotal and return either a fresh pollable analysis id
  * ({id}) or, when VirusTotal already knows the bytes and rejects the duplicate
  * submission with HTTP 409 (AlreadySubmittedError), their last completed stats
@@ -104,7 +136,7 @@ async function uploadFile(apikey, file) {
   });
   if (res.ok) {
     const id = (await res.json()).data?.id;
-    if (id) return {id};
+    if (id) return {sha256, id};
     throw new Error('VirusTotal returned no analysis id');
   }
   if (res.status !== 409) throw new Error(`VirusTotal upload failed (HTTP ${res.status})`);
@@ -113,13 +145,20 @@ async function uploadFile(apikey, file) {
     headers: {'x-apikey': apikey},
   });
   if (!known.ok) throw new Error(`VirusTotal upload failed (HTTP ${res.status})`);
-  return {stats: (await known.json()).data?.attributes?.last_analysis_stats ?? {}};
+  return {sha256, stats: (await known.json()).data?.attributes?.last_analysis_stats ?? {}};
 }
 
 async function getAnalysis(apikey, id) {
   const res = await fetch(`${VT_API}/analyses/${id}`, {headers: {'x-apikey': apikey}});
   if (!res.ok) throw new Error(`VirusTotal analysis failed (HTTP ${res.status})`);
   return (await res.json()).data;
+}
+
+/** Best-effort per-engine results of the file's last completed analysis. */
+async function getFileEngines(apikey, sha256) {
+  const res = await fetch(`${VT_API}/files/${sha256}`, {headers: {'x-apikey': apikey}});
+  if (!res.ok) return undefined;
+  return (await res.json()).data?.attributes?.last_analysis_results;
 }
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -130,9 +169,9 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
  *
  * @param {string[]} files absolute paths of the binaries to scan
  * @param {{threshold?: number; timeoutMs?: number}} [opts]
- * @returns {Promise<{results: Array}>} results entries: {file, status,
- *   stats:{malicious,suspicious,harmless,undetected}} or {file, error} when
- *   that file's scan failed.
+ * @returns {Promise<{results: Array}>} results entries: {file, status, stats,
+ *   threshold, verdict, flags} or {file, error} when that file's scan failed or
+ *   never completed.
  */
 export async function scanVirusTotal(
   files,
@@ -144,6 +183,7 @@ export async function scanVirusTotal(
   for (const file of files) {
     try {
       const uploaded = await uploadFile(key, file);
+      let stats;
       if (uploaded.stats) {
         // Bytes VirusTotal already knew — its last completed analysis is the
         // verdict.  An empty stats object means the analysis has not finished
@@ -156,42 +196,48 @@ export async function scanVirusTotal(
           });
           continue;
         }
-        results.push({
-          file,
-          status: 'completed',
-          stats: uploaded.stats,
-          threshold,
-          verdict: vtVerdict(uploaded.stats, threshold),
-        });
-        continue;
-      }
-      const start = Date.now();
-      let data;
-      for (;;) {
-        await sleep(POLL_INTERVAL_MS);
-        data = await getAnalysis(key, uploaded.id);
+        stats = uploaded.stats;
+      } else {
+        const start = Date.now();
+        let data;
+        for (;;) {
+          await sleep(POLL_INTERVAL_MS);
+          data = await getAnalysis(key, uploaded.id);
+          const attrs = data.attributes ?? {};
+          if (analysisComplete(attrs.status, attrs.stats) || Date.now() - start >= timeoutMs) break;
+        }
         const attrs = data.attributes ?? {};
-        if (analysisComplete(attrs.status, attrs.stats) || Date.now() - start >= timeoutMs) break;
+        stats = attrs.stats ?? {};
+        if (!analysisComplete(attrs.status, stats)) {
+          // VirusTotal never finished scanning (still queued, or completed
+          // with no engine results).  Skip with a warning — never clean.
+          results.push({
+            file,
+            error:
+              `VirusTotal analysis incomplete after ${Math.round((Date.now() - start) / 1000)}s ` +
+              `(status: ${attrs.status ?? 'unknown'}) — skipping, not treated as clean`,
+          });
+          continue;
+        }
       }
-      const attrs = data.attributes ?? {};
-      const stats = attrs.stats ?? {};
-      if (!analysisComplete(attrs.status, stats)) {
-        // VirusTotal never finished scanning (still queued, or completed with
-        // no engine results).  Skip with a warning — never report as clean.
-        results.push({
-          file,
-          error:
-            `VirusTotal analysis incomplete after ${Math.round((Date.now() - start) / 1000)}s ` +
-            `(status: ${attrs.status ?? 'unknown'}) — skipping, not treated as clean`,
-        });
-        continue;
+      // Engine names only matter once something is flagged (a veto engine at
+      // count 0 is a contradiction) — and the lookup is best-effort: if it
+      // fails, the count-based verdict still stands (never a silent clean).
+      let engines;
+      if ((stats.malicious ?? 0) > 0) {
+        try {
+          engines = await getFileEngines(key, uploaded.sha256);
+        } catch {
+          engines = undefined;
+        }
       }
       results.push({
         file,
-        status: attrs.status,
+        status: 'completed',
         stats,
         threshold,
-        verdict: vtVerdict(stats, threshold),
+        verdict: vtVerdict(stats, threshold, engines),
+        flags: maliciousEngines(engines),
       });
     } catch (err) {
       results.push({file, error: err.message});
@@ -202,7 +248,8 @@ export async function scanVirusTotal(
 
 // CLI entry: node tools/scan-vt.mjs <binary> [<binary>...]
 // Reads VT_API_KEY from the environment (e.g. via `node --env-file-if-exists=.env`,
-// as pnpm scan:vt does).  Exits 0 = clean, 1 = >= threshold engines flagged, 2 = usage.
+// as pnpm scan:vt does).  Exits 0 = clean, 1 = flagged (>= threshold engines or
+// a veto engine), 2 = usage.
 const isCli =
   process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
 if (isCli) {
@@ -226,11 +273,12 @@ if (isCli) {
     const line =
       `${r.file} — ${malicious} malicious / ${suspicious} suspicious / ` +
       `${harmless} harmless / ${undetected} undetected (threshold ${r.threshold})`;
+    const who = r.flags.length > 0 ? ` (flagged by ${r.flags.join(', ')})` : '';
     if (r.verdict === 'fail') {
-      console.error(`!! ${line}`);
+      console.error(`!! ${line}${who}`);
       blocked = true;
     } else if (r.verdict === 'warn') {
-      console.warn(`! ${line}`);
+      console.warn(`! ${line}${who}`);
     } else {
       console.log(`OK ${line}`);
     }

--- a/tools/scan-vt.mjs
+++ b/tools/scan-vt.mjs
@@ -1,0 +1,106 @@
+// tools/scan-vt.mjs — optional multi-engine scan of built binaries against
+// VirusTotal before publishing.
+//
+// Why: the host AV gate (tools/scan-av.mjs) catches what the local engine
+// sees, but installer_win.exe's false positive (Defender
+// Program:Script/Wacapew.A!ml) was only confirmed as multi-engine by checking
+// VT's ~70 engines (Defender local-vs-cloud, McAfee, Bkav).  Running every
+// built binary through VT at publish time turns that manual check into a gate.
+//
+// Best-effort by design — VT_API_KEY (or VIRUSTOTAL_API_KEY) in the
+// environment, a transient API error, or a rate limit only warn, never block.
+// The publish only hard-fails when the number of engines reporting the binary
+// as malicious reaches VT_FAIL_THRESHOLD (default 3) — a strong multi-engine
+// consensus that is not an AV false-positive.
+
+import fs from 'fs';
+import path from 'path';
+
+const VT_API = 'https://www.virustotal.com/api/v3';
+const POLL_INTERVAL_MS = 2000;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export function vtApiKey() {
+  return process.env.VT_API_KEY || process.env.VIRUSTOTAL_API_KEY || null;
+}
+
+export function vtFailThreshold() {
+  const n = Number.parseInt(process.env.VT_FAIL_THRESHOLD ?? '', 10);
+  return Number.isFinite(n) && n > 0 ? n : 3;
+}
+
+/**
+ * Pure verdict over VT detection stats.
+ *
+ * @param {{malicious: number; suspicious: number}} stats
+ * @param {number} threshold
+ * @returns {'fail' | 'warn' | 'clean'}
+ */
+export function vtVerdict(stats, threshold) {
+  const malicious = Number(stats?.malicious ?? 0);
+  if (malicious >= threshold) return 'fail';
+  if (malicious > 0) return 'warn';
+  return 'clean';
+}
+
+async function uploadFile(apikey, file) {
+  const buf = await fs.promises.readFile(file);
+  const form = new FormData();
+  form.append('file', new Blob([buf]), path.basename(file));
+  const res = await fetch(`${VT_API}/files`, {
+    method: 'POST',
+    headers: {'x-apikey': apikey},
+    body: form,
+  });
+  if (!res.ok) throw new Error(`VirusTotal upload failed (HTTP ${res.status})`);
+  return (await res.json()).data?.id;
+}
+
+async function getAnalysis(apikey, id) {
+  const res = await fetch(`${VT_API}/analyses/${id}`, {headers: {'x-apikey': apikey}});
+  if (!res.ok) throw new Error(`VirusTotal analysis failed (HTTP ${res.status})`);
+  return (await res.json()).data;
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Scan each binary against VirusTotal and return per-file results. Never throws
+ * — per-file errors are captured in each result.
+ *
+ * @param {string[]} files absolute paths of the binaries to scan
+ * @param {{threshold?: number; timeoutMs?: number}} [opts]
+ * @returns {Promise<{results: Array}>} results entries: {file, status,
+ *   stats:{malicious,suspicious,harmless,undetected}} or {file, error} when
+ *   that file's scan failed.
+ */
+export async function scanVirusTotal(
+  files,
+  {threshold = vtFailThreshold(), timeoutMs = DEFAULT_TIMEOUT_MS} = {}
+) {
+  const key = vtApiKey();
+  if (!key) return {results: []};
+  const results = [];
+  for (const file of files) {
+    try {
+      const id = await uploadFile(key, file);
+      const start = Date.now();
+      let data;
+      do {
+        await sleep(POLL_INTERVAL_MS);
+        data = await getAnalysis(key, id);
+      } while (data.attributes?.status === 'queued' && Date.now() - start < timeoutMs);
+      const stats = data.attributes?.stats ?? {};
+      results.push({
+        file,
+        status: data.attributes?.status,
+        stats,
+        threshold,
+        verdict: vtVerdict(stats, threshold),
+      });
+    } catch (err) {
+      results.push({file, error: err.message});
+    }
+  }
+  return {results};
+}

--- a/tools/scan-vt.mjs
+++ b/tools/scan-vt.mjs
@@ -181,6 +181,10 @@ export async function scanVirusTotal(
 ) {
   const key = vtApiKey();
   if (!key) return {results: []};
+  // The veto list is read once per run so the env override (VT_VETO_ENGINES)
+  // reaches the verdict — without this, vtVerdict's default would silently
+  // hardcode the VETO_ENGINES constant and the knob would do nothing.
+  const vetoEngines = vtVetoEngines();
   const results = [];
   for (const file of files) {
     try {
@@ -238,7 +242,7 @@ export async function scanVirusTotal(
         status: 'completed',
         stats,
         threshold,
-        verdict: vtVerdict(stats, threshold, engines),
+        verdict: vtVerdict(stats, threshold, engines, vetoEngines),
         flags: maliciousEngines(engines),
       });
     } catch (err) {


### PR DESCRIPTION
## Problem
The Sep 5 release artifact `installer_win.exe` was flagged by Windows Defender as
`Program:Script/Wacapew.A!ml` (a **machine-learning** heuristic). Investigation proved it is a
false positive specific to that artifact's exact bytes:
- Every local rebuild of the same source (previous-release, exact Sep-5-era, and current) scans **clean** with today's Defender.
- The CI-built **dev** binary from the same publish window (same toolchain, ~512 bytes different config) is also clean.
- The confirmed trigger is a **toolchain bump, not a code change**: the publish workflow ran `msys2/setup-msys2` with `update: true`, and a full `pacman -Syu` on 2026-09-05 pulled the gcc **16.1.0 → 16.2.0** package update (published to MSYS2 repos the day before). The recompiled bytes landed inside the `!ml` model's detection pocket.
- Multiple engines show the classic unsigned-binary ML-FP profile (McAfee local/cloud discrepancy, Bkav consistent; Jotti/Virscan clean). `helper_win.exe` was never flagged — it already carries a version resource; `installer_win.exe` had none.

## Fixes
1. **PE metadata** — add `installer/src/installer.rc` + `installer.manifest` (version resource, asInvoker, DPI-aware, Win10/11 compat), compiled by `windres` and linked on the Windows build only (`WIN_RES` empty on Linux/mac). A stripped unsigned PE with no version info is the #1 ML-FP profile.
2. **AV scan gate at publish time** — new `tools/scan-av.mjs`, wired into `upload.mjs`: scans the **exact staging bytes about to be uploaded** (Windows: Defender `MpCmdRun`; Linux/macOS: ClamAV) and **refuses to publish on any detection**. A missing engine only warns (GitHub Windows runners often run Defender in passive mode). Plus `pnpm scan:av` for local checks.
3. **Stable toolchain** — drop `update: true` on the publish workflow so gcc changes are deliberate, not pulled mid-publish.
4. **Docs** — root cause + the scan/verify workflow + Microsoft WDSI false-positive submission link in `docs/DEVELOPING.md`.

## Validation
- `pnpm lint` (eslint + clang-format + `gcc -fanalyzer` + markdownlint), `pnpm format`, `pnpm test` — all green.
- `pnpm scan:av -- dist/installer/installer_win.exe` → clean; EICAR test file → correctly detected (exit 1).
- The Windows exe now shows proper version metadata (FileDescription/ProductName/CompanyName 1.0.0).

## Follow-ups (not in this PR)
- Re-publish `latest` once merged — the gate scans the exact CI artifact before upload.
- Optional: submit the flagged hash `76109ec3…` to Microsoft WDSI as a false positive to clear it for existing users.
- Optional: SignPath Foundation free OSS code signing as the durable layer.