### PR TITLE
Harden #136 status table against hostile cell values; markdownlint ignores .local drafts

### DIFF
--- a/config/.markdownlint-cli2.jsonc
+++ b/config/.markdownlint-cli2.jsonc
@@ -45,5 +45,10 @@
     "**/.agents/skills/lavish/**",
     "**/node_modules/**",
     "**/dist/**",
+    // Local drafts (gitignored .local files/dirs) — same exclusion
+    // .prettierignore and eslint.config.js use (AGENTS.md: they are not
+    // authoritative sources and their style is not gated).
+    "**/*local*/**",
+    "**/*local*.*",
   ],
 }

--- a/docs/ci-inventory.md
+++ b/docs/ci-inventory.md
@@ -70,6 +70,22 @@ blocked on drift — the error tells the operator to run the URL watchdog workfl
 the baseline and triggers the browser-specific E2E) and then re-dispatch. **Dev** publishes warn
 instead of blocking, since dev artifacts are disposable test builds.
 
+## Deployment environments
+
+The Pages publish workflow deploys through GitHub environments (Settings → Environments); each
+publish job creates a deployment record, so a prod publish shows three `release` records (one per OS
+job) plus the `github-pages` Pages deployment.
+
+| Environment    | Created by           | Used by                            | Policy                                                                                                                                                                                |
+| -------------- | -------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `release`      | #76 (2026-08-27)     | All three prod publish jobs        | Protected-branches-only (main) — the main-only prod publish policy is enforced here; the E2E-validated requirement itself is checked pre-flight (drift gate + pre-publish job, above) |
+| `dev`          | 0744648 (2026-08-29) | Dev-mode publish (`mode == 'dev'`) | None — dev snapshots are disposable (ADR 0021); the environment exists so dev deployments get a valid name, it carries no rules                                                       |
+| `github-pages` | #15 (2026-08-22)     | The Pages deployment itself        | Custom branch policy for `gh-pages`                                                                                                                                                   |
+
+Dev publishes also create a disposable `dev-build-<id>` branch, tag, and prerelease release (served
+via jsDelivr). Delete all three after testing — the branch deletion alone leaves the tag serving on
+jsDelivr, so delete the release with `--cleanup-tag` too (DEVELOPING.md → Publish).
+
 ## Main observations
 
 | Area                           | Current behavior                                                                                                                                                                                                                                                                                                              | Remaining follow-up                                             |

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -401,6 +401,18 @@ test('buildStatusTable: hostile pipe in a vendor-served value cannot split a cel
   assertTableIntegrity(failed, 'failed-hostile table');
   const zenRow = failed.split('\n').find(l => l.startsWith('| zen '));
   assert.match(zenRow, /cached: 1\.22\\\|b/);
+
+  // A line break in a hostile value would split the ROW itself into extra
+  // markdown rows (cmark-gfm ends a table row at \n) — row injection, the
+  // same failure class as a pipe. The renderer collapses it to a space.
+  const injected = buildStatusTable({
+    results: {firefox: {status: 'ok'}},
+    baseline: {firefox: {version: `1.0\n| injected | row |`}},
+  });
+  assertTableIntegrity(injected, 'newline-injection table');
+  assert.equal(injected.split('\n').length, 8); // no extra rows appeared
+  const ffRow = injected.split('\n').find(l => l.startsWith('| firefox '));
+  assert.match(ffRow, /1\.0 \\\| injected \\\| row \\\|/); // kept, pipes escaped, one line
 });
 
 test('escapeTableCell: pipes and backslashes, non-string input', () => {
@@ -420,6 +432,9 @@ test('escapeTableCell: pipes and backslashes, non-string input', () => {
   assert.equal(escapeTableCell(BS), [BS, BS].join(''));
   assert.equal(escapeTableCell(12900), '12900'); // String() coercion
   assert.equal(escapeTableCell(undefined), 'undefined');
+  // line breaks collapse to a single space (row-splitting prevention)
+  assert.equal(escapeTableCell(`a${PIPE}b`.replace(PIPE, '\n')), 'a b');
+  assert.equal(escapeTableCell('a\r\n\nb'), 'a b');
 });
 
 test('formatDownloadMs: human durations, unknown stays an em dash', () => {

--- a/test/unit/tools/check-browser-downloads.test.mjs
+++ b/test/unit/tools/check-browser-downloads.test.mjs
@@ -15,6 +15,7 @@ const scriptUrl = pathToFileURL(path.join(REPO_ROOT, 'tools', 'check-browser-dow
 const {
   buildMetaIssueBody,
   buildStatusTable,
+  escapeTableCell,
   collectDrift,
   collectValidatedDrift,
   compareBaseline,
@@ -367,6 +368,58 @@ test('buildStatusTable: cell-count integrity under extreme cell values', () => {
   const cols = assertTableIntegrity(table, 'kitchen-sink table');
   assert.equal(cols, 8);
   assert.equal(table.split('\n').length, 8); // header + delimiter + 6 browsers
+});
+
+test('buildStatusTable: hostile pipe in a vendor-served value cannot split a cell', () => {
+  // version comes from vendor release feeds — treat it as hostile. A raw |
+  // in any cell value would add a cell that GitHub renders by shifting/
+  // dropping the rest of the row; the renderer must escape it (the test-side
+  // assertTableIntegrity is the tripwire, this is the prevention).
+  const table = buildStatusTable({
+    results: {firefox: {status: 'ok'}},
+    baseline: {
+      firefox: {version: '155.0.1|x', sha256: 'ab12cd', downloadMs: 12900},
+    },
+  });
+  assertTableIntegrity(table, 'hostile-version table');
+  const row = table.split('\n').find(l => l.startsWith('| firefox '));
+  assert.match(row, /\| 155\.0\.1\\\|x \|/); // rendered escaped: 155.0.1\|x
+
+  // Backslash-pipe combo in the value must also stay one cell (the renderer
+  // escapes backslashes first so a pre-escaped \| can't turn live again).
+  const sneaky = buildStatusTable({
+    results: {zen: {status: 'ok'}},
+    baseline: {zen: {version: '1.22\\|b'}},
+  });
+  assertTableIntegrity(sneaky, 'sneaky-version table');
+
+  // Fallback cell (cached: <version>) is escaped too.
+  const failed = buildStatusTable({
+    results: {zen: {status: 'download-failed'}},
+    baseline: {zen: {version: '1.22|b'}},
+  });
+  assertTableIntegrity(failed, 'failed-hostile table');
+  const zenRow = failed.split('\n').find(l => l.startsWith('| zen '));
+  assert.match(zenRow, /cached: 1\.22\\\|b/);
+});
+
+test('escapeTableCell: pipes and backslashes, non-string input', () => {
+  // Inputs/expectations are built from char codes — no backslash literals, so
+  // the assertions cannot be silently altered by escaping layers.
+  const PIPE = String.fromCharCode(124);
+  const BS = String.fromCharCode(92);
+  assert.equal(escapeTableCell('plain'), 'plain');
+  assert.equal(escapeTableCell(`a${PIPE}b`), ['a', BS, PIPE, 'b'].join(''));
+  assert.equal(escapeTableCell(`a${PIPE}${PIPE}b`), ['a', BS, PIPE, BS, PIPE, 'b'].join(''));
+  // pre-escaped backslash+pipe in the input: the backslash is escaped first,
+  // so the pipe can never become live again (BS BS BS PIPE out)
+  assert.equal(
+    escapeTableCell(['a', BS, PIPE, 'b'].join('')),
+    ['a', BS, BS, BS, PIPE, 'b'].join('')
+  );
+  assert.equal(escapeTableCell(BS), [BS, BS].join(''));
+  assert.equal(escapeTableCell(12900), '12900'); // String() coercion
+  assert.equal(escapeTableCell(undefined), 'undefined');
 });
 
 test('formatDownloadMs: human durations, unknown stays an em dash', () => {

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -434,14 +434,22 @@ export function formatDownloadMs(ms) {
  */
 /**
  * Escape a value interpolated into a markdown table cell: an unescaped pipe
- * would split the cell on github.com, silently shifting/dropping the cells
- * after it (the row then fails the cell-count integrity tests). Values are
- * vendor-served (version strings, checked URLs), so treat them as hostile. An
- * escaped pipe (|) renders as a literal | and does NOT split — cmark-gfm splits
- * the raw row before inline parsing, so no code-span awareness needed.
+ * would split the cell on github.com (silently shifting/dropping the cells
+ * after it), and a raw line break would split the ROW into extra markdown rows.
+ * Values are vendor-served (version strings, checked URLs), so treat them as
+ * hostile. Backslashes are escaped first so a pre-escaped backslash pipe
+ * sequence can't become live again; an escaped pipe renders as a literal pipe
+ * and does NOT split — cmark-gfm splits the raw row before inline parsing, so
+ * no code-span awareness is needed.
  */
 export function escapeTableCell(value) {
-  return String(value).replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+  // Backslashes first (a pre-escaped \| can't become live again), then line
+  // breaks (a raw \r/\n would split the ROW into extra markdown rows — same
+  // failure class as a pipe), then pipes.
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\|/g, '\\|');
 }
 
 export function buildStatusTable({results, baseline, validated}) {

--- a/tools/check-browser-downloads.mjs
+++ b/tools/check-browser-downloads.mjs
@@ -432,6 +432,18 @@ export function formatDownloadMs(ms) {
  * is exactly what the version-aware CI installer cache still serves (the
  * fallback column). `validated` is the E2E record (see validatedCell).
  */
+/**
+ * Escape a value interpolated into a markdown table cell: an unescaped pipe
+ * would split the cell on github.com, silently shifting/dropping the cells
+ * after it (the row then fails the cell-count integrity tests). Values are
+ * vendor-served (version strings, checked URLs), so treat them as hostile. An
+ * escaped pipe (|) renders as a literal | and does NOT split — cmark-gfm splits
+ * the raw row before inline parsing, so no code-span awareness needed.
+ */
+export function escapeTableCell(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+}
+
 export function buildStatusTable({results, baseline, validated}) {
   const rows = BROWSERS.map(browser => {
     const res = results[browser] || {status: 'ok'};
@@ -455,7 +467,9 @@ export function buildStatusTable({results, baseline, validated}) {
     // version has been fully downloaded at least once.
     const downloadTime = formatDownloadMs(entry.downloadMs);
     const e2e = validatedCell(browser, entry, validated);
-    return `| ${browser} | ${version} | ${sizeSha} | ${lastCheck} | ${statusTag(res.status)} | ${fallback} | ${downloadTime} | ${e2e} |`;
+    // Every variable value goes through escapeTableCell: the row's cell
+    // count must never depend on what a vendor feed returned (issue #136).
+    return `| ${browser} | ${escapeTableCell(version)} | ${escapeTableCell(sizeSha)} | ${escapeTableCell(lastCheck)} | ${escapeTableCell(statusTag(res.status))} | ${escapeTableCell(fallback)} | ${escapeTableCell(downloadTime)} | ${escapeTableCell(e2e)} |`;
   });
   return [
     '| Browser | Last verified | Size · SHA-256 | Last check | Status | Fallback (CI cache) | Download time | E2E validated |',


### PR DESCRIPTION
Relates to #136. Follow-ups to #148; grew by two review-driven items:

## 1. Renderer hardening: `escapeTableCell` (prevention, not just detection)

`buildStatusTable` interpolates vendor-served values into the #136 meta-issue table — version strings from external release feeds, checked URLs from APIs. A raw `|` in such a value would add a cell that GitHub renders by shifting/dropping the rest of the row; a raw line break would split the row into extra markdown rows. #148 added the test-side tripwire; this makes the renderer itself defensive:

- new exported `escapeTableCell(value)`: escapes backslashes first (so a pre-escaped `\|` can never become live again), collapses `\r`/`\n` runs to a space (row-splitting vector — CodeRabbit batch finding, triaged right), then escapes pipes;
- applied to every variable cell in the row;
- **output for well-formed values is byte-identical** — the rendered issue does not change today.

Tests: hostile `155.0.1|x` version, newline-injection (`1.0\n| injected | row`), backslash-pipe combo, and `escapeTableCell` unit tests built from char codes so escaping layers can't mangle assertions.

## 2. markdownlint ignores local drafts

`markdownlint-cli2` has no gitignore support, so gitignored `.local` files errored `pnpm lint` locally. Added the same two patterns `.prettierignore` and `eslint.config.js` use — all three markdown-aware gates share one local-draft policy.

## 3. ci-inventory: deployment environments documented (Part of the #136/#123 observability thread)

New "Deployment environments" section: `release` (from #76, main-only protected-branch policy), `dev` (from 0744648, deliberately rule-free per ADR 0021), `github-pages` — plus the discovered-in-practice dev-cleanup recipe: branch deletion alone leaves the tag serving on jsDelivr; delete the release with `--cleanup-tag`.

## Validation

- 243 unit tests pass; prettier clean; eslint + C analyzer clean; markdownlint 44 files / 0 issues
- CodeRabbit batch review: 1 finding, triaged right, fixed (`44db153`), thread resolved
- CI on `e7bb6bc`: CI, E2E, URL watchdog all completed success