### PR TITLE
docs: move worktree removal recipe to the change-workflow skill

### DIFF
--- a/.agents/skills/change-workflow/SKILL.md
+++ b/.agents/skills/change-workflow/SKILL.md
@@ -13,16 +13,32 @@ description:
 
 Do task work in a fresh `git worktree add ../<parent>/worktrees/<slug> -b <branch>` (one folder per
 task, trivially deletable, out of the parent dir). A stale-husk sweep after threads exit is just
-`rmdir worktrees/*`. Remove the worktree before finishing (`git worktree remove <path>`; add
-`--force` if it refuses over the gitignored node_modules, and retry the empty dir later if a process
-still holds it as its cwd).
+`rmdir worktrees/*`.
+
+**Removing a worktree (Windows gotcha):** `git worktree remove` — even `--force` — can silently
+leave the pnpm `node_modules` behind: the deep `.pnpm` paths exceed `MAX_PATH`, part of the
+filesystem deletion fails, and git deregisters the worktree anyway. `git worktree list` then looks
+clean while a husk stays on disk (22 of these accumulated in one week). `--force` only relaxes git's
+_cleanliness_ check (untracked/modified files, submodules); it does not make the filesystem delete
+more thorough. Remove in this order, and verify at the end:
+
+```bash
+rm -rf <workspace>/worktrees/<slug>/node_modules   # delete deps FIRST ...
+git worktree remove --force <workspace>/worktrees/<slug>
+git worktree list                                   # ... then verify the dir is really gone
+```
+
+A dead husk is provably safe to delete: fully unregistered (`git worktree prune` reports nothing),
+no `.git` file inside, and nothing but `node_modules` in the directory. Anything else — report it,
+don't delete it. The officially blessed alternative is the same two steps manually: `rm -rf` the
+directory, then `git worktree prune`.
 
 A fresh worktree carries no install: run `pnpm install` in it before running tools. pnpm hard-links
-packages from the global content-addressable store, so this is fast and disk-cheap, and the
-worktreestays fully self-contained — nothing done inside it can corrupt the parent checkout. When
-the opt-in githooks are installed (`pnpm hooks:install`), the `post-checkout` hook already does this
-for brand-new worktrees, so a fresh worktree is ready to use immediately. (The hook does not copy
-the root `.env` — the GitHub token stays in the main checkout only; copy it by hand if a token-using
+packages from the global content-addressable store, so this is fast and disk-cheap, and the worktree
+stays fully self-contained — nothing done inside it can corrupt the parent checkout. When the opt-in
+githooks are installed (`pnpm hooks:install`), the `post-checkout` hook already does this for
+brand-new worktrees, so a fresh worktree is ready to use immediately. (The hook does not copy the
+root `.env` — the GitHub token stays in the main checkout only; copy it by hand if a token-using
 command must run from a worktree.)
 
 Never link/symlink the parent's node_modules into a worktree (junction or otherwise). A shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,10 +176,12 @@ is not gated on CI — it can help debug failing checks. Add no CI/repo AI secre
 
 ## Agent workflow
 
-**Task worktrees:** use `<workspace>/worktrees/<slug>/` (one deletable folder per task) and remove
-them before finishing (`git worktree remove`; retry the empty dir if a process still held it). Run
-`pnpm install` in a fresh worktree; never link the parent's node_modules into it — details in the
-`change-workflow` skill.
+**Task worktrees:** use `<workspace>/worktrees/<slug>/` (one deletable folder per task), remove them
+before finishing, and verify the directory is really gone afterwards — on Windows the removal can
+silently leave an orphaned `node_modules` husk behind. The failure mode, the exact rm-then-prune
+recipe, and worktree install rules: the `change-workflow` skill.
+
+Run `pnpm install` in a fresh worktree; never link the parent's node_modules into it.
 
 Before changing code:
 
@@ -200,8 +202,7 @@ Before finishing:
 - if a code change invalidates any statement in AGENTS.md, skills, or docs/, update those documents
   in the same step. Do not leave stale instructions;
 - failed/unavailable validation is reported;
-- the task worktree is removed (`git worktree remove`; retry the empty directory if a process still
-  held it).
+- the task worktree is removed and the directory verified gone (see the `change-workflow` skill).
 
 ## Roadmap tracking
 


### PR DESCRIPTION
## Summary

AGENTS.md should stay a checklist, not a manual (its own Skills section says deep-dive detail lives in skills). The Windows worktree-removal recipe was documented inline in AGENTS.md; this moves it to the `change-workflow` skill, which already owns the "Worktrees & node_modules" section.

## What changes

- **`change-workflow` skill** — replaces the stale "retry the empty dir if a process still holds it" advice with the verified failure mode and recipe:
  - `git worktree remove` (even `--force`) can silently leave pnpm's `node_modules` husk behind on Windows (deep `.pnpm` paths exceed `MAX_PATH`); git deregisters the worktree anyway, so `git worktree list` looks clean while the husk stays on disk (22 accumulated in one week).
  - What `--force` actually does: relaxes git's *cleanliness* check only — it does not make the filesystem deletion more thorough.
  - The recipe: `rm -rf <worktree>/node_modules` **first**, then `git worktree remove --force`, then verify via `git worktree list`.
  - Husk-safety criteria: provably unregistered, no `.git` file, nothing but `node_modules` inside — anything else is reported, not deleted.
- **`AGENTS.md`** — shrunk to a 3-line pointer to the skill; the stale retry advice in the Before-finishing checklist replaced with "removed and the directory verified gone".

## Validation

- The recipe was verified end-to-end against a real 123 MB worktree (create → install → rm-then-prune → zero residue on filesystem, worktree registry, and refs).
- `pnpm lint` (44 files, 0 issues), `pnpm format`, `pnpm test` (243 pass / 0 fail) — local and via the pre-push gate.

Docs-only change: no test added, nothing to test.

Relates to the worktree-husk cleanup thread on the repo's agent workflow.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>