### PR TITLE
feat(e2e): strict pin semantics for browser installs — ADR 0023

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -299,6 +299,21 @@ single-browser updater-E2E run. CI's `cleanup-ci-downloads` job deletes the cons
 afterwards and the release + tag once empty, so the steady state is "the release does not exist".
 Extra flags: `--no-dispatch` (upload only), `--clean` (delete release + tag now).
 
+### Browser version pinning (ADR 0023)
+
+The E2E matrix resolves the _latest_ browser release at run time — by design (ADR 0023): the URL
+watchdog → E2E dispatch → validated-versions → drift-gate chain exists to validate each new vendor
+release, so a vendor update flipping CI is signal. To reproduce or test a specific version, pin a
+single-browser dispatch with a `version` input (`pnpm ci:download -- <installer> --version <v>` does
+it as part of the manual escape; it sets `BROWSER_PIN_VERSION`). Pin semantics are strict: a pinned
+run is served only by sources that can express the exact version — version-embedded mirror URLs and
+the `ci-downloads` asset. Version-agnostic sources (floorp/zen's `/releases/latest/download/` URLs)
+are skipped under a pin, so a pinned floorp/zen leg requires the exact installer uploaded to
+`ci-downloads` and fails loudly otherwise. Firefox stable / Dev Edition are not pinnable (their
+official endpoints are version-agnostic redirects). Whatever a leg installed,
+`downloads.mjs --installed-version` reads the version from the binary itself — the recorded ground
+truth.
+
 A partial (single-browser) dispatch deliberately skips the validated-versions recorder — it cannot
 fabricate E2E coverage for firefox/firefox-dev, so it can never satisfy the publish gate on its own.
 A FULL dispatch (browser input unset or `all`) is the post-release re-validation escape: the path

--- a/docs/decisions/0023-e2e-browser-version-pinning.md
+++ b/docs/decisions/0023-e2e-browser-version-pinning.md
@@ -1,0 +1,49 @@
+# 0023: E2E browser versions track latest at run time — explicit pin escape hatch
+
+- **Status:** accepted
+- **Date:** 2026-09-07
+
+Related: [0021](./0021-tiered-publish-gating-shared-resolver.md) (tiered gating + shared resolver +
+`ci-downloads`), issue #131 (Part of #3).
+
+## Context
+
+`test/e2e/shared/downloads.mjs` resolves the _latest_ browser release at run time, so a runner-side
+vendor update can flip a green E2E matrix red with no repo change. The alternative — pinning exact
+browser versions in the repo and bumping them deliberately — would make runs deterministic, but the
+repository's whole release machinery (URL watchdog → per-release E2E dispatch → validated-versions
+record → publish drift gate, #131's siblings) exists to track and validate each new vendor release.
+Pinning by default would fight that machinery and add a stale-pin failure mode (CI validating a
+years-old release while users run the current one).
+
+## Decision
+
+**Latest-at-run-time stays the default for every browser.** A vendor update flipping CI is signal —
+the thing the E2E matrix exists to catch — and the advisory-leg + validated-versions machinery
+already reconciles noise (flaky legs, download outages) without hiding real regressions.
+
+Reproducibility is served by explicit escape hatches instead of repo-pinned versions:
+
+- **Pin a single run**: dispatch `e2e.yml` with a `version` input (or
+  `pnpm ci:download -- <file> --version <v>`, which pins as part of the manual escape) —
+  `BROWSER_PIN_VERSION` short-circuits the version chain.
+- **Pin semantics are strict**: a pinned run may only be served by sources that can actually express
+  the pinned version — version-embedded mirror URLs and the `ci-downloads` asset keyed by exact
+  version. Version-agnostic sources (floorp/zen's `/releases/latest/download/` URLs) are skipped
+  under a pin; a pinned browser without any version-embedded source is served by `ci-downloads`
+  alone (upload the exact installer with `pnpm ci:download`).
+- **Ground truth is recorded per run**: `downloads.mjs --installed-version` reads the version from
+  the installed binary — what a leg validated is never inferred from a redirect.
+
+Firefox stable / Dev Edition are deliberately _not_ pinnable: their official `download.mozilla.org`
+endpoints are version-agnostic redirects, and tracking Firefox releases is the primary job of the
+hard-gated legs.
+
+## Consequences
+
+- No pinned-version rot: no file in the repo claims a browser version that ages.
+- A pinned run of floorp/zen fails loudly ("upload the exact installer with `pnpm ci:download`")
+  when the escape release is absent, instead of silently downloading the latest installer while
+  labeling it the pinned version (the pre-#131 behavior).
+- Reproducing a historical run means re-deriving its versions from the run logs
+  (`--installed-version` output) and pinning a dispatch if needed — accepted, rare.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -78,6 +78,8 @@ Open these before proposing a new primitive, surface, or storage home.
   resolver (retry + mirror chains, fail-closed watchdog) + temporary `ci-downloads` manual escape
 - [0022](./0022-agent-skills-management.md) — Agent skills are `gh`-installed and pristine; no
   `skills-lock.json`, no second `.agent/` root; drift = watchdog issue → reviewed PR
+- [0023](./0023-e2e-browser-version-pinning.md) — E2E browser versions track latest at run time;
+  explicit pin escape hatch with strict pin semantics (version-embedded sources + `ci-downloads`)
 
 ## Historical
 

--- a/test/e2e/shared/browserResolver.mjs
+++ b/test/e2e/shared/browserResolver.mjs
@@ -464,8 +464,18 @@ export function ciDownloadsAssetName(browser, version) {
 /**
  * Resolve the installer download URL for a browser, walking its source chain.
  * `version` pins the version-embedded sources; without it, the current version
- * is resolved first. The `ci-downloads` manual-escape release is probed by
- * expected filename after the official mirrors.
+ * is resolved first (or taken from BROWSER_PIN_VERSION when set). The
+ * `ci-downloads` manual-escape release is probed by expected filename after the
+ * official mirrors.
+ *
+ * Pin semantics (ADR 0023): a pinned run may only be served by sources that can
+ * actually express the pinned version — version-embedded mirror URLs and the
+ * ci-downloads asset keyed by exact version. Version-AGNOSTIC sources
+ * (floorp/zen's `/releases/latest/download/` URLs) are skipped under a pin:
+ * they always serve the newest release, so honoring them would download the
+ * latest installer while labeling it the pinned version. A pinned browser
+ * without any version-embedded source is served by ci-downloads alone (the
+ * manual escape's contract: `pnpm ci:download` uploads the exact installer).
  *
  * @param {string} browser
  * @param {{version?: string | null}} [opts]
@@ -480,11 +490,20 @@ export function ciDownloadsAssetName(browser, version) {
 export async function resolveInstallerUrl(browser, {version = null} = {}) {
   const chain = INSTALLER_CHAINS[browser];
   if (!chain) throw new Error(`no installer chain for browser '${browser}'`);
-  const resolved = await resolveBrowserVersion(browser, {pin: version});
+  const pin = version ?? process.env.BROWSER_PIN_VERSION ?? null;
+  const resolved = await resolveBrowserVersion(browser, {pin});
   const v = resolved.version;
 
-  // ① official mirrors (each source may be version-embedded)
+  // ① official mirrors (each source may be version-embedded). Under a pin,
+  // version-agnostic sources are ineligible (they cannot serve `v` — a
+  // zero-arity source takes no version parameter by construction).
   for (const build of chain.sources) {
+    if (pin && build.length === 0) {
+      console.log(
+        `  pin ${v}: skipping version-agnostic mirror (it always serves the latest release)`
+      );
+      continue;
+    }
     const url = build(v);
     // Cheap existence check: the version-embedded hosts 404 on a wrong guess,
     // the stable-latest URLs always answer. A 404 moves to the next source.
@@ -523,7 +542,10 @@ export async function resolveInstallerUrl(browser, {version = null} = {}) {
   }
 
   throw new Error(
-    `no installer source answered for ${browser} ${v} (official mirrors + ${CI_DOWNLOADS_TAG})`
+    pin ?
+      `no installer source answered for ${browser} ${v} (pinned run: version-embedded ` +
+        `mirrors + ${CI_DOWNLOADS_TAG} — upload the exact installer with pnpm ci:download)`
+    : `no installer source answered for ${browser} ${v} (official mirrors + ${CI_DOWNLOADS_TAG})`
   );
 }
 

--- a/test/unit/e2e/browserResolver.test.mjs
+++ b/test/unit/e2e/browserResolver.test.mjs
@@ -353,6 +353,67 @@ test('resolveInstallerUrl: bsys6 release asset before ci-downloads', async () =>
   }
 });
 
+test('resolveInstallerUrl: pin skips version-agnostic mirrors (floorp/zen) → ci-downloads', async () => {
+  resetCiDownloadsProbe();
+  const {restore} = stubFetch([
+    // The version-agnostic official mirror MUST NOT be probed: it always
+    // serves the latest release, so honoring it under a pin would download
+    // the newest installer while labeling it the pinned version (ADR 0023).
+    [
+      'releases/latest/download/floorp-windows-x86_64.installer.exe',
+      () => {
+        throw new Error('version-agnostic mirror reached under a pin');
+      },
+    ],
+    // ci-downloads carries the EXACT pinned asset.
+    [
+      'releases/tags/ci-downloads',
+      () =>
+        okJson({
+          assets: [
+            {
+              name: 'floorp-12.17.2-installer.exe',
+              browser_download_url: 'https://x/ci-floorp.exe',
+            },
+          ],
+        }),
+    ],
+  ]);
+  try {
+    const resolved = await resolveInstallerUrl('floorp', {version: '12.17.2'});
+    assert.equal(resolved.url, 'https://x/ci-floorp.exe');
+    assert.equal(resolved.source, CI_DOWNLOADS_TAG);
+    assert.equal(resolved.version, '12.17.2');
+  } finally {
+    restore();
+  }
+});
+
+test('resolveInstallerUrl: unpinned floorp keeps the stable latest mirror', async () => {
+  resetCiDownloadsProbe();
+  const {restore} = stubFetch([
+    // version chain: GitHub releases answers
+    ['repos/Floorp-Projects/Floorp/releases/latest', () => okJson({tag_name: 'v12.17.3'})],
+    // the stable mirror answers (HEAD probe) — the official source wins
+    [
+      'releases/latest/download/floorp-windows-x86_64.installer.exe',
+      u => ({ok: true, status: 200, url: u}),
+    ],
+  ]);
+  try {
+    const resolved = await resolveInstallerUrl('floorp');
+    assert.equal(
+      resolved.url,
+      'https://github.com/Floorp-Projects/Floorp/releases/latest/download/floorp-windows-x86_64.installer.exe'
+    );
+    assert.equal(resolved.source, 'official');
+    assert.equal(resolved.version, '12.17.3');
+    assert.equal(resolved.sha256Url, null);
+  } finally {
+    restore();
+  }
+});
+
 test('resolveBrowserVersion: BROWSER_PIN_VERSION env pins the chain', async () => {
   const prev = process.env.BROWSER_PIN_VERSION;
   process.env.BROWSER_PIN_VERSION = '155.0-1';

--- a/test/unit/publish/zipContents.test.mjs
+++ b/test/unit/publish/zipContents.test.mjs
@@ -1,0 +1,112 @@
+// test/unit/publish/zipContents.test.mjs — Publish integration test (issue
+// #133, Part of #3): opens each produced package zip with a read-only
+// central-directory reader and asserts its entries match
+// `computeDirectoryHash().files` EXACTLY.
+//
+// Catches packaging drift the rest of the unit suite cannot see: a file
+// present in the directory but missing from the zip (gitignore pattern
+// mismatch, wrong extraFiles), an extra/stale zip entry, or a prefix/layout
+// regression. The invariant — zip content == canonical manifest `files` list —
+// is what the installer and updater hash against (ADR 0002).
+//
+// The reader is `test/shared/zipReader.mjs` (pure Node, parses the central
+// directory directly) rather than the yauzl devDep the audit suggested: same
+// read-only guarantee, zero new dependencies. The zips are built here through
+// the REAL pipeline — the same createZip + loadSharedPatterns calls
+// upload.mjs's buildPackages makes — into a temp dir, so the test runs in the
+// plain unit suite (no dist/ snapshot, no network) and exercises the true
+// packaging path, including the regenerated generated files.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// paths.js calls requireMode() at import time — same arrangement as
+// createZip.test.mjs. Importing createZip.mjs also regenerates the gitignored
+// generated files (updater-config.sys.mjs, updater.css) — a no-op write when
+// they are already in sync.
+process.argv.push('--mode=prod');
+
+const {createZip, zipPrefixFor} = await import('../../../tools/publish/createZip.mjs');
+const {computeDirectoryHash} = await import('../../../tools/publish/hashUtils.mjs');
+const {loadSharedPatterns} = await import('../../../tools/publish/publishCommon.mjs');
+const {PROFILE_PATH, REMOTE_UI_DIR} = await import('../../../tools/publish/paths.js');
+const {listZipEntries} = await import('../../shared/zipReader.mjs');
+
+const FX_FOLDER_SOURCE = path.join(PROFILE_PATH, 'fx-folder');
+const UTILS_SOURCE = path.join(PROFILE_PATH, 'chrome', 'utils');
+
+// Mirrors upload.mjs exactly: the package list, the generated extraFiles that
+// ship despite being gitignored, and the obsolete-file exclusion shared by the
+// zip and the hash (so the two can never disagree about it).
+const PACKAGES = [
+  {name: 'utils', dir: UTILS_SOURCE},
+  {name: 'fx-folder', dir: FX_FOLDER_SOURCE},
+  {name: 'updater-ui', dir: REMOTE_UI_DIR},
+];
+const GENERATED_UPDATER_CONFIG = {
+  rel: 'updater/updater-config.sys.mjs',
+  absPath: path.join(UTILS_SOURCE, 'updater', 'updater-config.sys.mjs'),
+};
+const GENERATED_UI_CSS = {
+  rel: 'updater.css',
+  absPath: path.join(REMOTE_UI_DIR, 'updater.css'),
+};
+const HASH_EXCLUDE = ['versionInfo.json'];
+
+for (const {name, dir} of PACKAGES) {
+  test(`zip central directory matches the manifest files list: ${name}`, async () => {
+    const extraFiles =
+      name === 'utils' ? [GENERATED_UPDATER_CONFIG]
+      : name === 'updater-ui' ? [GENERATED_UI_CSS]
+      : [];
+
+    // The exact pattern sets buildPackages passes: the zip walks the shared
+    // patterns unfiltered, the hash additionally excludes obsolete files.
+    const zipPatterns = loadSharedPatterns(FX_FOLDER_SOURCE, []);
+    const hashPatterns = loadSharedPatterns(FX_FOLDER_SOURCE, HASH_EXCLUDE);
+    const {files} = computeDirectoryHash(dir, hashPatterns, extraFiles);
+
+    // Build the package through the real pipeline into a temp dir.
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), `zip-contents-${name}-`));
+    try {
+      const zipPath = path.join(outDir, `${name}.zip`);
+      await createZip(
+        dir,
+        zipPath,
+        zipPatterns,
+        zipPrefixFor(name),
+        extraFiles.map(f => f.rel)
+      );
+
+      const entries = listZipEntries(fs.readFileSync(zipPath)).map(e => e.name);
+      const prefix = zipPrefixFor(name);
+      const stripped =
+        prefix ?
+          entries.map(n => {
+            assert.ok(
+              n === `${prefix}/` || n.startsWith(`${prefix}/`),
+              `entry outside the ${prefix}/ prefix: ${n}`
+            );
+            return n === `${prefix}/` ? '' : n.slice(prefix.length + 1);
+          })
+        : entries;
+
+      // No duplicates: a doubled entry renders as two files after extraction
+      // and would break the installed-dir hash.
+      const dupes = stripped.filter((n, i) => stripped.indexOf(n) !== i);
+      assert.deepEqual(dupes, [], 'duplicate zip entries');
+
+      // The invariant: central directory == canonical files list, exactly.
+      assert.deepEqual(
+        [...stripped].sort(),
+        [...files].sort(),
+        'zip central directory must match computeDirectoryHash().files exactly'
+      );
+    } finally {
+      fs.rmSync(outDir, {recursive: true, force: true});
+    }
+  });
+}


### PR DESCRIPTION
Fixes #131 · Part of #3

## Decision (ADR 0023)

**The E2E matrix tracks latest at run time — by design.** The repo's release machinery (URL
watchdog → per-release E2E dispatch → validated-versions record → publish drift gate) exists to
validate each new vendor release; a vendor update flipping CI red is signal. Pinning by default
would fight that machinery and add a stale-pin rot failure mode. Reproducibility is served by the
explicit escape hatches: the single-browser dispatch `version` pin (`BROWSER_PIN_VERSION` via
`pnpm ci:download`), the `ci-downloads` release, the cached-installer fallback, and
`--installed-version` ground-truth recording.

## The bug this fixes

Under a pin, `resolveInstallerUrl` walked the installer chain in source order — and for **floorp/zen**
the official mirrors are version-agnostic (`/releases/latest/download/…`): `urlExists` always
answers, so a **pinned run downloaded the newest installer while labeling it the pinned version**.
The `ci-downloads` asset for the exact pinned version sat *after* those mirrors and was never
reached.

## Pin semantics (now strict)

- A pinned run is served only by sources that can express the exact version: version-embedded
  mirror URLs (LibreWolf, Waterfox) and the `ci-downloads` asset keyed by exact version.
- Version-agnostic sources are skipped under a pin (zero-arity source = takes no version).
- A pinned browser with no version-embedded source (floorp/zen) is served by `ci-downloads` alone
  and **fails loudly** ("upload the exact installer with `pnpm ci:download`") when absent.
- Firefox stable / Dev Edition are deliberately not pinnable (official endpoints are
  version-agnostic redirects) — recorded in the ADR.

## Changes

- `test/e2e/shared/browserResolver.mjs` — pin-aware source skipping + pin-specific error message.
- `test/unit/e2e/browserResolver.test.mjs` — pinned floorp never probes the version-agnostic mirror
  and lands on the exact ci-downloads asset; unpinned floorp keeps the stable mirror.
- `docs/decisions/0023-e2e-browser-version-pinning.md` + index entry (validated by
  `pnpm check:decisions`).
- `docs/DEVELOPING.md` — "Browser version pinning (ADR 0023)" policy section.

## Validation

- `pnpm test` 245 pass / 0 fail (2 new tests), `pnpm format`, `pnpm lint` (incl. markdownlint),
  `pnpm check:decisions` — all green locally; pre-push gate passed.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

---

# Also in this PR: zip central-directory verification (Fixes #133)

The publish integration suite from the audit: for each real package (**utils**,
**fx-folder**, **updater-ui**), build the zip through the *actual* pipeline (same
`createZip` + `loadSharedPatterns` calls as `upload.mjs`, regenerated generated
files included) and assert its central-directory entries equal
`computeDirectoryHash().files` **exactly** — no missing/extra/stale entries, no
duplicates, fx-folder prefix intact. Reader: the in-repo pure-Node
`test/shared/zipReader.mjs` instead of the suggested `yauzl` devDep (same
read-only guarantee, zero new deps). Runs in the plain unit suite (no dist/, no
network). Mutation-proven: a stray `versionInfo.json` on disk (zip yes, manifest
no) fails the utils leg — the exact historical drift class.

Commit `0f555d6`; `pnpm test` 248 pass / 0 fail (3 new tests).
