### PR TITLE
fix(ai-review): raise diff cap + warn models not to infer cut-off context

### DIFF
--- a/test/unit/publish/ai-review.test.mjs
+++ b/test/unit/publish/ai-review.test.mjs
@@ -36,7 +36,7 @@ test('parseArgs applies defaults and overrides', () => {
   assert.equal(args.baseRef, 'main');
   assert.equal(args.headRef, process.env.HEAD_REF || 'HEAD');
   assert.equal(args.maxFiles, 30);
-  assert.equal(args.maxDiffChars, 8000);
+  assert.equal(args.maxDiffChars, 60000);
   assert.equal(args.dryRun, false);
 });
 
@@ -210,6 +210,44 @@ test('collects findings and summaries from provider responses', async () => {
   assert.equal(result.rdjson.diagnostics[1].message, 'Bug B\n\nSuggestion: Fix B');
   assert.equal(result.summary.length, 2);
   assert.match(result.summary[0], /Summary a\.js/);
+});
+
+test('truncated diffs warn the model to verify against the real file', async () => {
+  const providers = [{name: 'test', model: 'm1', key: 'k', endpoint: 'https://x'}];
+  const longDiff = `hunk start\n${'same-line\n'.repeat(50)}hunk end`;
+  const requestImpl = async (provider, body) => {
+    const content = body.messages[1].content;
+    // Capture what the model actually receives for both files.
+    captured.push({file: /Review the diff of ([^\s:]+)/.exec(content)?.[1], content});
+    return {
+      kind: 'success',
+      body: {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({summary: 'S', findings: []}),
+            },
+          },
+        ],
+      },
+    };
+  };
+  const captured = [];
+  await reviewFiles({
+    files: ['big.js', 'small.js'],
+    fileDiffs: new Map([
+      ['big.js', longDiff],
+      ['small.js', 'short diff'],
+    ]),
+    providers,
+    maxDiffChars: 40,
+    requestImpl,
+  });
+  const big = captured.find(c => c.file === 'big.js').content;
+  const small = captured.find(c => c.file === 'small.js').content;
+  assert.match(big, /diff truncated at 40 chars/);
+  assert.match(big, /verify against the actual file before reporting/);
+  assert.ok(!small.includes('diff truncated'), 'small diffs must not carry the marker');
 });
 
 test('caps findings via maxFindings and honors summaryOnly', async () => {

--- a/tools/ai-review.mjs
+++ b/tools/ai-review.mjs
@@ -19,7 +19,7 @@
 //   --head-ref <ref>    Head ref (default: $HEAD_REF env or HEAD).
 //   --max-findings N    Cap on total findings written to RDJSON (default 10).
 //   --max-files N       Cap on files reviewed per run (default 30).
-//   --max-diff-chars N  Per-file diff size cap for the token budget (default 8000).
+//   --max-diff-chars N  Per-file diff size cap for the token budget (default 60000).
 //   --summary-only      Write the summary but emit an empty diagnostics set.
 //   --dry-run           Print what would be reviewed without calling any API.
 //   --out <dir>         Output directory (default dist/review).
@@ -84,7 +84,7 @@ export function parseArgs(argv) {
     headRef: process.env.HEAD_REF || 'HEAD',
     maxFindings: 10,
     maxFiles: 30,
-    maxDiffChars: 8000,
+    maxDiffChars: 60000,
     summaryOnly: false,
     dryRun: false,
     out: join(process.cwd(), 'dist', 'review'),
@@ -302,8 +302,12 @@ function fileDiff(baseRef, headRef, file) {
 }
 
 function truncateDiff(diff, maxChars) {
+  // The marker must tell the model not to guess: a truncated diff hides
+  // surrounding code (e.g. the top of a function), and models fabricate
+  // "used before declared" bugs from that missing context. Verify against
+  // the real file instead of inferring from hunk order.
   return diff.length > maxChars ?
-      `${diff.slice(0, maxChars)}\n\n[...diff truncated at ${maxChars} chars for token budget]`
+      `${diff.slice(0, maxChars)}\n\n[...diff truncated at ${maxChars} chars — code outside these hunks is\nnot shown; if a suspected issue depends on it (e.g. declaration order),\nverify against the actual file before reporting]`
     : diff;
 }
 
@@ -356,7 +360,7 @@ export async function reviewFiles({
   files,
   fileDiffs,
   providers,
-  maxDiffChars = 8000,
+  maxDiffChars = 60000,
   maxFindings = 10,
   summaryOnly = false,
   name = 'AI review',


### PR DESCRIPTION
## What & why

The local reviewer's 8,000-char per-file diff cap produced a false positive during the #151 review: the `upload.mjs` diff was truncated before the model saw the top of `buildBinaries()`, so it saw the `if (SKIP_BUILD)` branch without the declarations above it and fabricated a "used before declared" `ReferenceError`. The truncation marker existed but read as a passive note, and the model guessed instead of verifying.

Two changes in `tools/ai-review.mjs`:

1. **Raise the default `maxDiffChars` from 8,000 → 60,000** (CLI override unchanged) — realistic single-file diffs in this repo now fit uncut.
2. **Strengthen the truncation marker** — when a diff still exceeds the cap, the marker now tells the model explicitly: code outside the shown hunks is missing, and if a suspected issue depends on it (e.g. declaration order), verify against the actual file before reporting.

## Validation

- New unit test: a diff over the cap carries the marker + the verify instruction in the prompt sent to the model; a small diff carries neither.
- Updated the `parseArgs` default assertion (8000 → 60000).
- `pnpm test` (244 pass, 0 fail), `pnpm lint`, `pnpm format` all clean.

Backstory + the evidence re-run that exposed the root cause: local-review false positive on #151 (TDZ claim, disproven by code order + a live `--skip-build` run).
