### PR TITLE
Hardening: bump Windows PE subsystem version + refresh setup-repo cache pin

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -41,7 +41,7 @@ runs:
     # runs restore it and skip the download.
     - name: Cache pnpm binary
       id: pnpm-bin
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/pnpm-bin
         key: pnpm-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.pnpm-version }}

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -16,6 +16,15 @@ CFLAGS = -Os -s -ffunction-sections
 # ~32 KB per binary (measured: 237 KB -> 200 KB on Windows).
 MINIZ_TRIM = -DMINIZ_NO_DEFLATE_APIS -DMINIZ_NO_ZLIB_APIS
 
+# PE header versions for the Windows installer.  mingw-w64's link defaults to
+# an XP-era MajorSubsystemVersion (5.02 / OS 4.0); AV machine-learning engines
+# weight a stripped, unsigned PE that claims to target Windows XP as a
+# packer/cryptor profile signal.  Windows 10/11 ignore these fields entirely
+# (the installer.manifest supportedOS GUID overrides them), so bumping to 6.0
+# is behavior-neutral but removes the anomaly.  Used only by the Windows
+# installer link lines below (both the all target and dist_win).
+WIN_PE_VERSIONS = -Wl,--major-subsystem-version,6 -Wl,--minor-subsystem-version,0 -Wl,--major-os-version,6 -Wl,--minor-os-version,0
+
 SRC_DIR = src
 # Unified build-output root: all build artifacts land in dist/installer at the
 # repo top level.  Make is always run from the installer/ dir (either `cd
@@ -87,7 +96,7 @@ all: resources config $(TARGET)
 # Native target rule - maps $(TARGET) to the actual build command
 $(TARGET): $(SRC_DIR)/resources.h $(SRC_DIR)/_config.h $(WIN_RES)
 	$(MKDIR)
-	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(WIN_RES) -o $(TARGET) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) $(WIN_LIBS)
+	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(WIN_RES) -o $(TARGET) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) $(WIN_PE_VERSIONS) $(WIN_LIBS)
 
 # Compile the Windows version resource + manifest into a COFF object.
 $(SRC_DIR)/installer.res: $(SRC_DIR)/installer.rc $(SRC_DIR)/installer.manifest
@@ -152,7 +161,7 @@ $(SRC_DIR)/resources.h: embed.mjs $(WEB_DIR)/index.html $(WEB_DIR)/style.css $(W
 # WINDRES=x86_64-w64-mingw32-windres.
 dist_win: resources config $(SRC_DIR)/installer.res
 	$(MKDIR)
-	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(SRC_DIR)/installer.res -o $(DIST_DIR)/installer_win$(ASSET_SUFFIX).exe $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) \
+	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) $(SRC_DIR)/installer.res -o $(DIST_DIR)/installer_win$(ASSET_SUFFIX).exe $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS) $(WIN_PE_VERSIONS) \
 		-lws2_32 -lshell32 -luser32 -lcrypt32 -lbcrypt -static -static-libgcc \
 		-mwindows
 


### PR DESCRIPTION
## Summary

Two small hardening fixes:

### 1. Bump Windows PE subsystem/OS version to 6.0 (`installer/Makefile`)
The installer PE's headers claimed XP-era `MajorSubsystemVersion 5.02` / `MajorOSystemVersion 4.0` — mingw-w64's link default. AV machine-learning engines (Bkav, Elastic — the two engines currently flagging `installer_win-dev.exe`) weight a stripped, **unsigned** PE that claims to target Windows XP as a packer/cryptor profile signal. Windows 10/11 ignore these header fields entirely (the `installer.manifest` Win10/11 `supportedOS` GUID overrides them), so the change is **behavior-neutral** — it only removes the anomaly from the binary's profile.

Verified locally:
```
MajorOSystemVersion   6
MinorOSystemVersion   0
MajorSubsystemVersion 6
MinorSubsystemVersion 0
```
(was `5.02` / `4.0`)

Applied to both Windows installer link lines (the `all`/`$(TARGET)` target and `dist_win`). The helper binary is intentionally untouched — it already scans clean (0/70).

### 2. Clear the "Node.js 20 is deprecated" CI warning (`.github/actions/setup-repo/action.yml`)
`setup-repo` pinned `actions/cache@0057852bf… # v4` (Node 20 runtime, force-run on Node 24 by GitHub) while every other workflow in the repo already uses `actions/cache@55cc8345… # v6.1.0`. Bumped the pin to match — removes the warning that appears on **every** publish job (windows/linux/mac) and keeps the composite action on the same cache version as the rest of the repo.

## Validation
- `make dist_win` builds cleanly; `objdump -p` confirms subsystem/OS 6.0
- `pnpm lint` (incl. `gcc -fanalyzer`) — clean
- `pnpm format` — clean
- `pnpm test` — 0 failures