### PR TITLE
feat(publish): abort prod publish when env overrides redirect the target

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -20,3 +20,26 @@ GITHUB_TOKEN_VAR=ghp_your_token_here
 # Dev-mode: stable per-run id for the dev-build-<id> branch and baked URLs.
 # Optional — defaults to '<current-branch>-<short-sha>' when unset.
 # DEV_BUILD_ID=my-feature-1
+
+# =============================================================================
+# PROD-SAFETY WARNING — publish-target overrides
+# =============================================================================
+# These env vars OVERRIDE config/installer.conf when set (env-over-conf in
+# tools/publish/paths.js) and REDIRECT where a publish lands:
+#
+#   REPO_OWNER  REPO_NAME  RELEASE_NAME  ZIP_PAGES_REPO  ZIP_PAGES_BRANCH
+#   HASHES_URL  ZIP_BASE_URL  ZIP_PAGES_URL  HELPER_BASE_URL  UI_BASE_URL
+#
+# With any of them set, a prod publish (`pnpm upload -- --mode=prod`) ABORTS
+# with a STAGING banner before anything is built or uploaded — production
+# targets must come from installer.conf, not ambient shell state.
+#
+# An intentional staging rehearsal (e.g. pointing at a fork to test the full
+# publish path) acknowledges the banner explicitly:
+#
+#   FIREFOX_SCRIPTS_ALLOW_STAGING=1
+#
+# Dev-mode publishes only warn (artifacts go to the disposable
+# dev-build-<id> branch), and `upload:local` snapshots never touch GitHub so
+# they run without the guard.
+# FIREFOX_SCRIPTS_ALLOW_STAGING=1

--- a/test/unit/publish/stagingGuard.test.mjs
+++ b/test/unit/publish/stagingGuard.test.mjs
@@ -1,0 +1,100 @@
+// test/unit/publish/stagingGuard.test.mjs — unit tests for the #33
+// staging-target guard (tools/publish/stagingGuard.mjs).
+//
+// stagingGuard.mjs itself never calls requireMode(), but log.mjs (imported by
+// the guard) and the tested code paths are argv-tolerant; --mode=prod is pushed
+// before import to mirror the other publish unit tests.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+
+process.argv.push('--mode=prod');
+
+const {collectOverrides, readInstallerConf, runStagingGuard, stagingBanner} =
+  await import('../../../tools/publish/stagingGuard.mjs');
+
+test('readInstallerConf parses KEY=value lines and skips comments', () => {
+  const conf = readInstallerConf('config/installer.conf');
+  assert.equal(conf.RELEASE_NAME, 'latest');
+  assert.equal(conf.REPO_OWNER, 'onemen');
+});
+
+test('readInstallerConf tolerates a missing file', () => {
+  assert.deepEqual(readInstallerConf('no/such/file.conf'), {});
+});
+
+test('collectOverrides: prod mode reports every set target key', () => {
+  const overrides = collectOverrides(
+    {REPO_OWNER: 'someone', HASHES_URL: 'https://evil.test/hashes.json'},
+    'prod',
+    {REPO_OWNER: 'onemen'}
+  );
+  assert.deepEqual(overrides, [
+    {key: 'REPO_OWNER', value: 'someone', conf: 'onemen'},
+    {key: 'HASHES_URL', value: 'https://evil.test/hashes.json', conf: undefined},
+  ]);
+});
+
+test('collectOverrides: dev mode only checks repo-identity keys', () => {
+  const overrides = collectOverrides(
+    {RELEASE_NAME: 'x', ZIP_PAGES_BRANCH: 'y', REPO_NAME: 'other'},
+    'dev',
+    {}
+  );
+  assert.deepEqual(overrides, [{key: 'REPO_NAME', value: 'other', conf: undefined}]);
+});
+
+test('collectOverrides: unset and empty values are ignored', () => {
+  assert.deepEqual(collectOverrides({REPO_OWNER: '', RELEASE_NAME: undefined}, 'prod', {}), []);
+});
+
+test('collectOverrides: a value equal to the conf baseline is still an override', () => {
+  const overrides = collectOverrides({REPO_OWNER: 'onemen'}, 'prod', {REPO_OWNER: 'onemen'});
+  assert.deepEqual(overrides, [{key: 'REPO_OWNER', value: 'onemen', conf: 'onemen'}]);
+});
+
+test('stagingBanner lists every override with its baseline', () => {
+  const banner = stagingBanner([{key: 'REPO_OWNER', value: 'someone', conf: 'onemen'}], {
+    mode: 'prod',
+  });
+  assert.match(banner, /STAGING PUBLISH TARGET/);
+  assert.match(banner, /REPO_OWNER\s+= someone\s+\[installer\.conf: onemen\]/);
+  assert.match(banner, /FIREFOX_SCRIPTS_ALLOW_STAGING=1/);
+});
+
+test('runStagingGuard: prod + override throws and prints the banner', () => {
+  assert.throws(
+    () =>
+      runStagingGuard({
+        mode: 'prod',
+        env: {REPO_OWNER: 'someone'},
+      }),
+    /Prod publish aborted/
+  );
+});
+
+test('runStagingGuard: prod + FIREFOX_SCRIPTS_ALLOW_STAGING=1 continues', () => {
+  const result = runStagingGuard({
+    mode: 'prod',
+    env: {REPO_OWNER: 'someone', FIREFOX_SCRIPTS_ALLOW_STAGING: '1'},
+  });
+  assert.equal(result.allowed, true);
+  assert.equal(result.overrides.length, 1);
+});
+
+test('runStagingGuard: dev + override warns but does not throw', () => {
+  const result = runStagingGuard({mode: 'dev', env: {REPO_NAME: 'other'}});
+  assert.equal(result.allowed, true);
+  assert.equal(result.overrides.length, 1);
+});
+
+test('runStagingGuard: --local snapshots are exempt', () => {
+  const result = runStagingGuard({mode: 'prod', local: true, env: {REPO_OWNER: 'someone'}});
+  assert.deepEqual(result, {overrides: [], allowed: false});
+});
+
+test('runStagingGuard: no overrides → no-op in every mode', () => {
+  for (const mode of ['prod', 'dev']) {
+    assert.deepEqual(runStagingGuard({mode, env: {}}), {overrides: [], allowed: false});
+  }
+});

--- a/tools/publish/stagingGuard.mjs
+++ b/tools/publish/stagingGuard.mjs
@@ -1,0 +1,133 @@
+// stagingGuard.mjs — prod-publish safety guard for env-overridden targets (#33).
+//
+// paths.js gives environment variables precedence over config/installer.conf
+// (env-over-conf), so a stray `REPO_OWNER=...` / `HASHES_URL=...` in the shell
+// or CI environment silently redirects a prod publish to an unintended release,
+// Pages branch, or manifest host. This guard makes that loud instead of silent:
+//
+//   prod → ABORT with a STAGING banner before anything is built or uploaded.
+//          Escape hatch for an intentional staging rehearsal:
+//          FIREFOX_SCRIPTS_ALLOW_STAGING=1 prints the banner and continues.
+//   dev  → warn-only for repo-identity overrides (dev artifacts are disposable
+//          and normally live in the dev-build-<id> namespace anyway).
+//   --local → never runs: an offline snapshot touches no GitHub target.
+//
+// The baseline for "unintended" is config/installer.conf itself (single source
+// of truth, ADR 0013): an env var whose value equals the conf value is still
+// reported — publishing must not depend on ambient shell state.
+
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {error, info, warn, yellow} from './log.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CONF_PATH = path.resolve(__dirname, '..', '..', 'config', 'installer.conf');
+
+/** Env vars that redirect a publish target when set. */
+export const TARGET_KEYS = [
+  'REPO_OWNER',
+  'REPO_NAME',
+  'RELEASE_NAME',
+  'ZIP_PAGES_REPO',
+  'ZIP_PAGES_BRANCH',
+  'HASHES_URL',
+  'ZIP_BASE_URL',
+  'ZIP_PAGES_URL',
+  'HELPER_BASE_URL',
+  'UI_BASE_URL',
+];
+
+/** In dev mode only these matter: a redirect to somebody else's repository. */
+const DEV_KEYS = ['REPO_OWNER', 'REPO_NAME', 'ZIP_PAGES_REPO'];
+
+/** Escape hatch for intentional staging rehearsals (documented in .env-example). */
+const ALLOW_STAGING_VAR = 'FIREFOX_SCRIPTS_ALLOW_STAGING';
+
+/** Parse config/installer.conf (same tiny parser as paths.js) → {KEY: value}. */
+export function readInstallerConf(confPath = CONF_PATH) {
+  const conf = {};
+  try {
+    const text = fs.readFileSync(confPath, 'utf-8');
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) continue;
+      const eq = trimmed.indexOf('=');
+      conf[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+  } catch {
+    // Missing conf: env-presence detection still works, just without a baseline.
+  }
+  return conf;
+}
+
+/**
+ * Overrides present in `env` for the keys that matter in `mode`. Returns [{key,
+ * value, conf}] — conf is the installer.conf baseline (or undefined when the
+ * key is not in the conf).
+ */
+export function collectOverrides(env, mode, conf = readInstallerConf()) {
+  const keys = mode === 'dev' ? DEV_KEYS : TARGET_KEYS;
+  const overrides = [];
+  for (const key of keys) {
+    const value = env[key];
+    if (value === undefined || value === '') continue;
+    overrides.push({key, value, conf: conf[key]});
+  }
+  return overrides;
+}
+
+/** The loud multi-line banner text (also the thrown error message in prod). */
+export function stagingBanner(overrides, {mode}) {
+  const lines = [
+    '============================================================',
+    '  STAGING PUBLISH TARGET — env overrides are active',
+    '============================================================',
+    `Environment variables are redirecting this ${mode} publish:`,
+    '',
+  ];
+  for (const {key, value, conf} of overrides) {
+    const base = conf === undefined ? '(not in installer.conf)' : `installer.conf: ${conf}`;
+    lines.push(`  ${key.padEnd(18)} = ${value}    [${base}]`);
+  }
+  lines.push(
+    '',
+    'Production targets come from config/installer.conf. Unset these',
+    'variables unless this is an intentional staging rehearsal —',
+    `or export ${ALLOW_STAGING_VAR}=1 to acknowledge and continue.`,
+    '============================================================'
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Run the guard for a publish CLI (upload.mjs). Never runs for --local
+ * snapshots. Throws in prod when target overrides are present and
+ * FIREFOX_SCRIPTS_ALLOW_STAGING is not set; warns in dev.
+ *
+ * @returns {{overrides: Array; allowed: boolean}} what was found.
+ */
+export function runStagingGuard({mode, local = false, env = process.env} = {}) {
+  if (local) return {overrides: [], allowed: false};
+  const overrides = collectOverrides(env, mode);
+  if (overrides.length === 0) return {overrides: [], allowed: false};
+
+  const allowed = env[ALLOW_STAGING_VAR] === '1';
+  const banner = stagingBanner(overrides, {mode});
+
+  if (mode === 'dev') {
+    warn(banner);
+    warn(`${ALLOW_STAGING_VAR} is not needed in dev mode — artifacts go to the dev-build branch.`);
+    return {overrides, allowed: true};
+  }
+  if (allowed) {
+    info(yellow(`${banner}\n${ALLOW_STAGING_VAR}=1 — continuing this STAGING publish on purpose.`));
+    return {overrides, allowed: true};
+  }
+  error(banner);
+  throw new Error(
+    'Prod publish aborted: environment variables override publish targets ' +
+      `(see the STAGING banner above). Set ${ALLOW_STAGING_VAR}=1 to override.`
+  );
+}

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -112,6 +112,7 @@ import {REF_NAME, REF_SHA} from './publishMode.mjs';
 import {assertCleanWorktree} from './gitUtils.mjs';
 import {linkNodeModules, unlinkNodeModules} from './refNodeModules.mjs';
 import {cleanGenerated} from './syncGeneratedFiles.mjs';
+import {runStagingGuard} from './stagingGuard.mjs';
 
 const LOCAL = process.argv.includes('--local');
 const FORCE = process.argv.includes('--force');
@@ -157,6 +158,12 @@ const IS_CI = process.argv.includes('--ci');
 const PLATFORMS = process.argv
   .filter(a => a.startsWith('--platform='))
   .map(a => a.slice('--platform='.length));
+
+// Staging-target guard (#33): environment variables that redirect the publish
+// target abort a prod run before anything is built (warn in dev; --local
+// snapshots touch no GitHub target and are exempt). Escaping to a real staging
+// rehearsal requires the explicit FIREFOX_SCRIPTS_ALLOW_STAGING=1.
+runStagingGuard({mode: PUBLISH_MODE, local: LOCAL});
 
 const INSTALLER_DIR = path.join(REPO_ROOT, 'installer');
 const INSTALLER_SRC = path.join(INSTALLER_DIR, 'src');


### PR DESCRIPTION
Part of #33 (staging-target guard item; the other #33 items stay post-v1.0).

## What

`tools/publish/paths.js` gives environment variables precedence over `config/installer.conf` (env-over-conf), so a stray `REPO_OWNER=...` / `HASHES_URL=...` in the shell or CI environment silently redirects a prod publish to an unintended release, Pages branch, or manifest host.

This PR makes that loud instead of silent:

- **New `tools/publish/stagingGuard.mjs`**, wired into `upload.mjs` right after flag parsing — before anything is built or uploaded.
- **Prod + override → loud STAGING banner + hard abort** (exit before any build step). Baseline is `installer.conf` itself: even a value *equal* to the conf value is reported — publishing must not depend on ambient shell state.
- **Dev mode → warn-only**, and only for repo-identity keys (`REPO_OWNER`/`REPO_NAME`/`ZIP_PAGES_REPO`) — dev artifacts are disposable and live in the `dev-build-<id>` namespace anyway.
- **`--local` snapshots are exempt** (they touch no GitHub target).
- **Escape hatch** for an intentional staging rehearsal: `FIREFOX_SCRIPTS_ALLOW_STAGING=1` prints the banner and continues.
- **`.env-example`** documents the full key list, the abort behavior, and the escape hatch (the `#33` checklist item "Document the staging keys in .env-example (same key set, with prod-safety warnings)").

Covered keys: `REPO_OWNER`, `REPO_NAME`, `RELEASE_NAME`, `ZIP_PAGES_REPO`, `ZIP_PAGES_BRANCH`, `HASHES_URL`, `ZIP_BASE_URL`, `ZIP_PAGES_URL`, `HELPER_BASE_URL`, `UI_BASE_URL`.

## Validation

- 12 new unit tests in `test/unit/publish/stagingGuard.test.mjs` (conf parsing, per-mode key scoping, baseline-equal overrides, banner rendering, all four guard behaviors); full suite 292/0.
- Live probe: `REPO_OWNER=someone-else node tools/publish/upload.mjs --mode=prod` → banner + `Prod publish aborted`, exit 1, zero build steps.
- `pnpm lint` / `pnpm format` clean; verified CI sets none of these keys today (no false-positive risk in workflows).

🤖 Generated with Codebuff
Co-authored-by: Codebuff <noreply@codebuff.com>