### PR TITLE
feat(installer): universal macOS build (x86_64 + arm64) with CI slice check

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -451,6 +451,23 @@ jobs:
             macOS) make -C installer dist_mac MODE=dev ;;
             Windows) make -C installer dist_win MODE=dev ;;
           esac
+          # Universal-binary check (#132): dist_mac now builds x86_64 + arm64 in
+          # one fat installer_mac — assert both slices are really present and
+          # executable, not just that the file exists.
+          if [ "${{ runner.os }}" = macOS ]; then
+            LIPO_ARCHS=$(lipo -archs dist/installer/installer_mac-dev)
+            echo "installer_mac architectures: $LIPO_ARCHS"
+            for arch in x86_64 arm64; do
+              case " $LIPO_ARCHS " in
+                *" $arch "*) ;;
+                *) echo "::error::installer_mac-dev is missing the $arch slice (universal build broken)"; exit 1 ;;
+              esac
+            done
+            lipo -thin x86_64 -output /tmp/installer_mac_x64 dist/installer/installer_mac-dev
+            lipo -thin arm64 -output /tmp/installer_mac_arm dist/installer/installer_mac-dev
+            echo "x86_64 slice: $(/tmp/installer_mac_x64 --version)"
+            echo "arm64 slice:  $(/tmp/installer_mac_arm --version)"
+          fi
           case "${{ runner.os }}" in
             Linux) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_linux-dev" >> "$GITHUB_ENV" ;;
             macOS) echo "INSTALLER_BIN=$PWD/installer/../dist/installer/installer_mac-dev" >> "$GITHUB_ENV" ;;

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -123,6 +123,11 @@ xcode-select --install
 make dist_mac   # builds dist/installer/installer_mac
 ```
 
+The macOS build is **universal** (x86_64 + arm64 in one binary, mirroring `helper_mac`), so the
+single `installer_mac` asset serves Apple Silicon and Intel Macs — verify with
+`lipo -archs dist/installer/installer_mac` (the E2E macOS runner asserts both slices and executes
+each one; #132).
+
 ## AV false positives and the AV scan gate
 
 The installer/helper binaries are unsigned, stripped, statically-linked PEs — the classic profile

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -176,10 +176,12 @@ dist_linux: resources config
 	$(MKDIR)
 	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) -o $(DIST_DIR)/installer_linux$(ASSET_SUFFIX) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS)
 
-# macOS build (requires macOS with clang)
+# macOS build (requires macOS with clang). Universal (x86_64 + arm64) so one
+# installer_mac asset serves Apple Silicon and Intel — mirrors helper_mac's
+# -arch pair (see #132).
 dist_mac: resources config
 	$(MKDIR)
-	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) -o $(DIST_DIR)/installer_mac$(ASSET_SUFFIX) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS)
+	$(CC) $(SRC_DIR)/*.c $(MINIZ_SRC) -arch x86_64 -arch arm64 -o $(DIST_DIR)/installer_mac$(ASSET_SUFFIX) $(CFLAGS) $(MINIZ_TRIM) $(GC_FLAGS)
 
 # Build all platforms (requires cross-compilation toolchain)
 dist_all: dist_win dist_linux dist_mac


### PR DESCRIPTION
Fixes #132 (macOS universal installer — the decision, implemented: one universal `installer_mac` asset).

## What

`dist_mac` currently builds a native-arch-only installer, so an Apple Silicon (or Intel) user can get an installer that cannot run. `helper_mac` is already universal (`-arch x86_64 -arch arm64`); this PR mirrors that for the installer:

- **`installer/Makefile`** — `dist_mac` now compiles `-arch x86_64 -arch arm64` into one `installer_mac` (and `installer_mac-dev` in dev mode).
- **CI verification** — the e2e macOS leg (which already builds the dev installer) now asserts the binary is really universal: `lipo -archs` must contain both slices (hard error otherwise), then `lipo -thin` extracts each slice and **executes it** (`--version`) — proving each architecture actually runs, not just that the fat binary exists.
- **`docs/DEVELOPING.md`** — the macOS build section documents the universal build and the `lipo` check.

## Why one asset (ADR 0019 interplay)

Asset names stay **stable and unversioned**: `installer_mac` keeps its name, so the updater (`updater.js` self-update URL), the release-asset list, and ADR 0019's fixed-name rule are untouched — no per-arch asset names to maintain. Build cost on CI is one extra codegen slice per compile (the same cost `helper_mac` already pays).

## Validation

- `make -C installer -n dist_mac` shows the `-arch x86_64 -arch arm64` flags in the link command.
- `pnpm lint` / `pnpm format` clean (includes gcc -fanalyzer over the unchanged C sources).
- The slice-execution check itself can only run on a macOS runner (e2e.yml macos leg); local verification here is the dry-run + the identical-flag mirror of the proven `helper_mac` recipe.

🤖 Generated with Codebuff
Co-authored-by: Codebuff <noreply@codebuff.com>