### PR TITLE
ci(e2e): updater path filter covers the updater-ui.zip sources (remote-ui/)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,6 +109,10 @@ jobs:
             updater:
               - 'core/chrome/utils/updater/**'
               - 'installer/src/helper/**'
+              # updater-ui.zip sources — remote-ui/updater.js IS the updater's
+              # runtime engine (shipped inside the ui package), so engine
+              # changes must run the updater legs (#174 skip audit).
+              - 'tools/publish/remote-ui/**'
               - 'test/e2e/updater/**'
               - 'test/e2e/shared/**'
               - '.github/workflows/e2e.yml'

--- a/docs/ci-inventory.md
+++ b/docs/ci-inventory.md
@@ -25,13 +25,13 @@ change.
 
 ### Filter ownership
 
-| Output              | Intended paths                                                                                                                                                                                               |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `publish`           | `core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, the AV/VT scan tools (`tools/scan-av.mjs`, `tools/scan-vt.mjs`), packaging dependencies, `.github/actions/**`, and CI workflow files |
-| `installer`         | Installer implementation/web/API files and `test/e2e/installer/**`                                                                                                                                           |
-| `updater`           | `core/chrome/utils/updater/**`, `installer/src/helper/**`, updater shared helpers/tests, and updater workflow/action files                                                                                   |
-| `core`              | Browser-chrome/core files and core smoke tests; shared E2E infrastructure may conservatively select all affected groups                                                                                      |
-| `browser-downloads` | `test/e2e/shared/downloads.mjs`, watchdog tooling, and watchdog workflow files                                                                                                                               |
+| Output              | Intended paths                                                                                                                                                                                                                               |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `publish`           | `core/**`, `config/installer.conf`, `installer/**`, `tools/publish/**`, the AV/VT scan tools (`tools/scan-av.mjs`, `tools/scan-vt.mjs`), packaging dependencies, `.github/actions/**`, and CI workflow files                                 |
+| `installer`         | Installer implementation/web/API files and `test/e2e/installer/**`                                                                                                                                                                           |
+| `updater`           | `core/chrome/utils/updater/**`, `installer/src/helper/**`, `tools/publish/remote-ui/**` (the updater-ui.zip sources — remote-ui/updater.js is the updater's runtime engine), updater shared helpers/tests, and updater workflow/action files |
+| `core`              | Browser-chrome/core files and core smoke tests; shared E2E infrastructure may conservatively select all affected groups                                                                                                                      |
+| `browser-downloads` | `test/e2e/shared/downloads.mjs`, watchdog tooling, and watchdog workflow files                                                                                                                                                               |
 
 `installer/src/helper/**` belongs to the updater group because the helper binary is used by updater
 installation flows. Its helper E2E remains a separate job, but shares the updater filter.


### PR DESCRIPTION
Follow-up to the #174 skip audit · syncs the `updater` filter-ownership row.

## Finding

#174 changed `tools/publish/remote-ui/updater.js` — the file that **is** the updater's runtime engine, shipped inside `updater-ui.zip` — yet all 9 updater E2E legs were skipped: the E2E `updater` path filter listed `core/chrome/utils/updater/**` and `installer/src/helper/**` but not `tools/publish/remote-ui/**`.

## Fix

- `.github/workflows/e2e.yml`: add `tools/publish/remote-ui/**` to the `updater` filter.
- `docs/ci-inventory.md`: the `updater` filter-ownership row now names it explicitly.

Note: the CI `publish` filter already covers all of `tools/publish/**`, so #174's publish-side changes (upload.mjs, hashUtils.mjs, platforms.mjs) *were* gated — only the E2E filter had the hole.

## Validation

- `pnpm test` 312/0 · `pnpm lint` ✓ · `pnpm format` ✓ · `check:gates` ✓ (both workflows' gates cover all jobs)

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>