### PR TITLE
docs(readme): find-your-version and revert section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ by hand. After your first install from this repository, the browser will notify 
 version is available (see
 [How the updater keeps your scripts up to date](#how-the-updater-keeps-your-scripts-up-to-date)).
 
+### Finding your version and reverting
+
+The packages are dated, not version-numbered: every publish stamps each package with the date its
+content last changed (`YYYY-MM-DD`, UTC). To find what you have:
+
+- **Updater tab** — open the updater from the browser menu. Next to each package's manual-download
+  link it shows the date of the current published package; "Up to Date" means your installed copy
+  matches it.
+- **Installer** — re-running the installer shows the same per-package dates next to the
+  manual-download links, plus each browser's Up to Date / Update Available status.
+
+To **revert** a package to an earlier build, open the
+[releases page](https://github.com/onemen/firefox-scripts/releases): the `latest` release always
+holds the newest build of every file, and the frozen `scripts-<date>` (package zips) and
+`installer-<date>` (installer binaries + helpers) releases hold each past publish. Download the
+package zip from the dated release you want and install it by hand (updater tab → manual download
+link, or unpack into your profile's `chrome/utils/` — see the
+[original scripts](#original-scripts-and-core-folders) section for the layout). The next daily check
+will offer the newer version again; use the tab's skip option if you want to stay on the older build
+for that update.
+
 The original scripts are governed by the
 [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/); the in-browser updater
 (`core/chrome/utils/updater/`) is custom to this project and licensed under the


### PR DESCRIPTION
Part of #4 pre-1.0 scope (Version visibility item).

## What ships

- **README "Finding your version and reverting" section**: how to read the per-package dates (they are surfaced in both UIs already — updater tab manual-download links via formatScriptsDate, installer package-urls bar via get_package_date), and how to walk back to an older build using the scripts-<date> / installer-<date> component releases (#176) with the updater's skip option as the stay-on-older mechanism.

## Audit result (the rest of the item needs no code)

- Installer UI: per-package dates already annotated on manual-download links (g_cached_utils_date / g_cached_fx_folder_date, get_package_date() in detect_browser.c)
- Updater tab: per-package date from the state snapshot rendered through formatScriptsDate (updater-ui.js)
- Manifest: per-package date = source-commit date of each package's files (getLatestCommitDate), the lookup aid #4 describes

## Validation

Docs-only change: pnpm format / pnpm lint / pnpm test (326/0) green; CI path filters will trim to the docs jobs.

Generated with Codebuff