### PR TITLE
docs(decisions): ADR 0026 — publish channels, dev branch-only + dead-channel fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,10 @@ facts most often cause bugs:
   `b.addTrustedTab(chrome://firefox-scripts/content/ui/updater.html)` → `updater.js` (same package)
   downloads, verifies, extracts and copies; admin-protected dirs use a freshly downloaded standalone
   helper binary (single UAC prompt, exit 2 = cancelled). If a package cannot be downloaded the check
-  exits silently — except a **test/dev build** whose own manifest is unreachable (its dev-build
-  branch was deleted): it falls back to the stable channel's manifest (generated `STABLE_*` URLs,
-  ADR 0026) and auto-migrates to stable.
+  exits silently — except a **remote test/dev build** (`--mode=dev`, non-`--local`) whose own
+  manifest is unreachable (its dev-build branch was deleted): it falls back to the stable channel's
+  manifest (generated `STABLE_*` URLs, ADR 0026) and auto-migrates to stable. Local snapshots keep
+  the silent exit (ephemeral by design).
 - **Publishing:** `--mode=prod` → `latest` release + `gh-pages` (branch `main` only, CI-only — runs
   the full cross-OS binary matrix); `--mode=dev` → disposable `dev-build-<id>` branch (branch-only;
   `--note` adds an RC-style prerelease page), `-dev` artifact names, served via jsDelivr. Requires a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,13 @@ facts most often cause bugs:
   `b.addTrustedTab(chrome://firefox-scripts/content/ui/updater.html)` → `updater.js` (same package)
   downloads, verifies, extracts and copies; admin-protected dirs use a freshly downloaded standalone
   helper binary (single UAC prompt, exit 2 = cancelled). If a package cannot be downloaded the check
-  exits silently — no fallback UI.
-- **Publishing:** `--mode=prod` → `latest` release + `gh-pages` (branch `main` only); `--mode=dev` →
-  disposable `dev-build-<id>` branch, `-dev` artifact names, served via jsDelivr. Requires a clean
-  worktree; real runs need `GITHUB_TOKEN_VAR`.
+  exits silently — except a **test/dev build** whose own manifest is unreachable (its dev-build
+  branch was deleted): it falls back to the stable channel's manifest (generated `STABLE_*` URLs,
+  ADR 0026) and auto-migrates to stable.
+- **Publishing:** `--mode=prod` → `latest` release + `gh-pages` (branch `main` only, CI-only — runs
+  the full cross-OS binary matrix); `--mode=dev` → disposable `dev-build-<id>` branch (branch-only;
+  `--note` adds an RC-style prerelease page), `-dev` artifact names, served via jsDelivr. Requires a
+  clean worktree; real runs need `GITHUB_TOKEN_VAR`.
 - **Gotchas:** Waterfox skips `BootstrapLoader.js` in `config.js`. Per-package skip prefs
   `extensions.firefox-scripts.skippedHash.<pkg>`; daily gate prefs `lastScriptsCheckDate` /
   `lastUpdateTabShown`. `versionInfo.json` is obsolete (excluded from zips; installed copies cleaned

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -651,14 +651,18 @@ See ADR [0009](./decisions/0009-unified-publish-modes.md) for the decision behin
 
 `dev` publishes to a per-run branch and release tag (`dev-build-<id>`, where `<id>` defaults to
 `<current-branch>-<short-sha>` or `DEV_BUILD_ID`), so a test build never touches the live `latest`
-release or the `gh-pages` site. The release is marked **pre-release**, its body links the branch,
-and it carries the manual-download artifacts: the `utils` + `fx-folder` zips and the installer
-binary (the `updater-ui` zip and helper binaries stay branch-only — the updater fetches `updater-ui`
-itself and helpers are installer-side). Dev URLs are baked into the built artifacts and served from
+release or the `gh-pages` site. Publishes are **branch-only** by default (ADR
+[0026](./decisions/0026-publish-channels-and-dead-channel-fallback.md)); `--note="<label>"`
+additionally creates a pre-release page (title `dev-build-<id> — <label>`, body with the note, a
+test-build warning and provenance) for RC-style announcements. Its body links the branch, and it
+carries the manual-download artifacts: the `utils` + `fx-folder` zips and the installer binary (the
+`updater-ui` zip and helper binaries stay branch-only — the updater fetches `updater-ui` itself and
+helpers are installer-side). Dev URLs are baked into the built artifacts and served from
 `cdn.jsdelivr.net` for the browser-facing pieces (installer web UI, remote updater UI) and
 `raw.githubusercontent.com` for the privileged engine fetches (chrome:// context has no CORS).
-Delete the dev branch after testing: `git push origin --delete dev-build-<id>` (CI test runs delete
-it automatically in a `finally`).
+Delete the dev branch only after its users have received the fallback logic (ADR 0026 — republish
+into the same `DEV_BUILD_ID` first so installed test builds auto-update while the branch lives):
+`git push origin --delete dev-build-<id>` (CI test runs delete it automatically in a `finally`).
 
 ### Run
 

--- a/docs/decisions/0001-versioninfo-and-gist.md
+++ b/docs/decisions/0001-versioninfo-and-gist.md
@@ -6,7 +6,7 @@
 ## Context
 
 The upstream firefox-scripts tree shipped `versionInfo.json` as the version source for update checks
-(`a24af78`, 2026-01-05).The 2026 installer / publish rewrite inherited it: the early publish
+(`a24af78`, 2026-01-05). The 2026 installer / publish rewrite inherited it: the early publish
 pipeline published per-package hashes **and** `versionInfo.json` to a **GitHub Gist** (`9b91fda`,
 2026-07-28 — `updateGistHashes` in the first `checkAndUpload.mjs`), and the updater compared the
 manifest's `date` against the local `versionInfo.json`. Meanwhile the installer treated

--- a/docs/decisions/0012-new-tab-daily-notification.md
+++ b/docs/decisions/0012-new-tab-daily-notification.md
@@ -24,4 +24,6 @@ design review).
 
 No OS notification permissions, no scheduler beyond a `setInterval`, and an ignored update is never
 marked as "checked". If a package cannot be downloaded the check exits silently — there is no
-fallback UI. Revisit-if: OS notifications or a manual check button are ever requested.
+fallback UI. Scoped exception: a test-channel build whose own manifest is unreachable falls back to
+the stable channel per [0026](./0026-publish-channels-and-dead-channel-fallback.md) — still through
+this tab, no new surface. Revisit-if: OS notifications or a manual check button are ever requested.

--- a/docs/decisions/0017-ci-validation-contract.md
+++ b/docs/decisions/0017-ci-validation-contract.md
@@ -33,7 +33,7 @@ elevated-copy test joined the installer/updater/browser-matrix gates — and the
 share one verify engine (`.github/actions/verify-gate`) whose contract (every job in the gate's
 `needs:`, filters in place, always-report jobs ungated) is enforced statically by
 `pnpm check:gates`. The fork legs no longer act as an always-on canary for upstream fork releases
-breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PRcatches a
+breaking the updater — the watchdog flags version bumps, and the next E2E-relevant PR catches a
 breakage.
 
 PRs land via the GitHub merge queue: each queued PR is validated in a temporary merge-group

--- a/docs/decisions/0022-agent-skills-management.md
+++ b/docs/decisions/0022-agent-skills-management.md
@@ -30,19 +30,19 @@ One tool, one classification, one root:
    root `skills-lock.json` is retired.
 2. **Classification is metadata, not location or naming**: a skill with `metadata.github-repo` in
    `SKILL.md` is third-party; without it, authored here. No `vendor-*` prefixes, no nested discovery
-   layouts.3. **Third-party skills stay pristine** — never linted, never formatted. The gate ignores
+   layouts. 3. **Third-party skills stay pristine** — never linted, never formatted. The gate ignores
    derive from the frontmatter metadata itself: eslint computes its ignore list at config-load from
    `metadata.github-repo` (`config/eslint.config.js`), and `.prettierignore` carries a generated
    block (`tools/sync-skill-gates.mjs`, run by the format scripts) that ignores every skill and
    un-ignores the authored ones — so a newly installed third-party skill is ignored automatically
    and only authored skills are ever gated. Gates that mutate apply to things we author; gates that
    validate apply to everything.
-3. **One root**: `.agents/skills/<skill-name>/`, flat, tracked. The `.agent/` root is retired; its
+4. **One root**: `.agents/skills/<skill-name>/`, flat, tracked. The `.agent/` root is retired; its
    vendored skill moves under the common root (still pristine, still MIT-attributed).
-4. **Updates are `gh skill update`** — `--dry-run` in a weekly advisory CI check that opens/updates
+5. **Updates are `gh skill update`** — `--dry-run` in a weekly advisory CI check that opens/updates
    a tracking issue; locally `--all`. Drift becomes a **deliberate human-reviewed PR per batch** —
    never auto-merged: upstream skill text is a prompt-injection surface.
-5. **Scope split**: repo-shared skills are committed here; personal skills live in user scope
+6. **Scope split**: repo-shared skills are committed here; personal skills live in user scope
    (`~/.agents/skills/`), installed with the same tool, never committed.
 
 ## Consequences

--- a/docs/decisions/0022-agent-skills-management.md
+++ b/docs/decisions/0022-agent-skills-management.md
@@ -30,8 +30,9 @@ One tool, one classification, one root:
    root `skills-lock.json` is retired.
 2. **Classification is metadata, not location or naming**: a skill with `metadata.github-repo` in
    `SKILL.md` is third-party; without it, authored here. No `vendor-*` prefixes, no nested discovery
-   layouts. 3. **Third-party skills stay pristine** — never linted, never formatted. The gate ignores
-   derive from the frontmatter metadata itself: eslint computes its ignore list at config-load from
+   layouts.
+3. **Third-party skills stay pristine** — never linted, never formatted. The gate ignores derive
+   from the frontmatter metadata itself: eslint computes its ignore list at config-load from
    `metadata.github-repo` (`config/eslint.config.js`), and `.prettierignore` carries a generated
    block (`tools/sync-skill-gates.mjs`, run by the format scripts) that ignores every skill and
    un-ignores the authored ones — so a newly installed third-party skill is ignored automatically

--- a/docs/decisions/0026-publish-channels-and-dead-channel-fallback.md
+++ b/docs/decisions/0026-publish-channels-and-dead-channel-fallback.md
@@ -1,0 +1,56 @@
+# 0026: Publish channels — stable (CI-only) vs test (branch-only dev), dead-test-channel fallback
+
+- **Status:** accepted
+- **Date:** 2026-09-12
+- **Extends:** [0009](./0009-unified-publish-modes.md) (unified publish modes — the pipeline and the
+  prod gate are unchanged; this record defines the channel model on top of them)
+
+## Context
+
+[0009] gave dev publishing a disposable `dev-build-<id>` branch + prerelease. Real usage diverged
+from that contract: dev builds acquired actual users (`dev-build-main-450468f` shows real download
+counts), but a dev install's generated config points **exclusively** at its own branch (jsDelivr
+`@dev-build-<id>`, `-dev` asset names, `IS_DEV`). When that branch is deleted the daily check's
+manifest fetch 404s and the check exits silently ([0002]'s failure rule) — the install is stranded
+forever, invisibly: it never compares against the stable channel because its config contains no
+stable URLs. Separately, prod publishing needs the full cross-OS binary set ([0024]), which only CI
+can build; a local `--mode=prod` run publishes an incomplete asset set. And RC-style announcements
+want a browsable page, while routine dev testing wants no release clutter.
+
+## Decision
+
+Two channels. **Stable** = `--mode=prod` (`latest` release + gh-pages). **Test** = `--mode=dev`.
+
+1. **Test publishes are branch-only.** `--mode=dev` pushes artifacts to the `dev-build-<id>` branch
+   and creates **no release**. `--mode=dev --note="<label>"` opts into a prerelease page (title
+   `dev-build-<id> — <label>`, body: the note, a test-build warning, and provenance — source commit
+   and date) for RC-style announcements. The existing `dev-build-main-450468f` release stays as a
+   historical artifact; it is not deleted and not re-created.
+2. **Test-channel configs carry the stable channel's URLs.** The generators emit `STABLE_HASHES_URL`
+   / `STABLE_ZIP_BASE_URL` / `STABLE_UI_BASE_URL` / `STABLE_HELPER_BASE_URL` (derived from
+   `config/installer.conf` per [0013] — no hardcoded URLs) into dev builds only; stable builds get
+   empty values, the channel being their own.
+3. **Dead-test-channel fallback.** When a test-channel daily check cannot fetch its own manifest
+   (branch deleted or expired), it fetches the **stable** manifest from the `STABLE_*` URLs and runs
+   the same hash comparison ([0002] unchanged). A difference is auto-installed through the existing
+   updater flow (the updater is always auto-install within reachability); installing stable rewrites
+   the installed `updater-config.sys.mjs` with prod URLs, so the channel migrates itself. What
+   happened is recorded through the updater tab's existing banner surface ([0012] — no new
+   notification mechanism, daily-gate prefs pattern applies). If stable is also unreachable, the
+   existing silent exit stands.
+4. **Prod is CI-only.** A real (non-`--local`) `--mode=prod` run outside the Pages publish workflow
+   is rejected before building; prod publishes go through CI, which builds the full installer +
+   helper set for all platforms ([0024]).
+
+This supersedes the "if a package cannot be downloaded the check exits silently — no fallback UI"
+invariant (AGENTS.md / `docs/`) **for the test channel only**; stable-channel behavior is unchanged.
+
+## Consequences
+
+Test installs keep auto-updating within their branch while it lives; a branch may only be deleted
+once the fallback logic has reached its users (republish into the same `DEV_BUILD_ID` first — the
+existing installs auto-install the fixed updater from the still-alive branch). The bootstrap
+republish is the delivery mechanism, so no consent banner is needed for the fix itself. `--local`
+snapshots keep the silent-exit behavior (ephemeral by design). Revisit-if: test installs must
+outlive their branch with per-branch identity intact (a fork distribution channel), or stable itself
+needs a migration path — then supersede this record.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -84,6 +84,9 @@ Open these before proposing a new primitive, surface, or storage home.
   universal macOS installer; additive platform growth under [0019]'s naming rules
 - [0025](./0025-waterfox-hard-gate.md) — Waterfox joins the hard gate after its 4-green-run soak:
   required Windows leg + publish-drift coverage; pin-first break-glass runbook (extends [0021])
+- [0026](./0026-publish-channels-and-dead-channel-fallback.md) — Publish channels: stable (CI-only,
+  full cross-OS asset set) vs test (`--mode=dev`, branch-only, optional RC note); dead-test-channel
+  daily check falls back to the stable manifest (extends [0009])
 
 ## Historical
 

--- a/test/unit/publish/generateUpdaterConfig.test.mjs
+++ b/test/unit/publish/generateUpdaterConfig.test.mjs
@@ -91,6 +91,33 @@ test('generated module: dev mode — jsDelivr URLs, IS_DEV true, -dev suffix', (
   assert.match(module, /ASSET_SUFFIX: '-dev'/);
 });
 
+test('generated module: STABLE_* fallback URLs only in dev mode (ADR 0026)', () => {
+  // Stable builds get empty values — the stable channel is their own.
+  const prod = probe();
+  assert.match(prod.module, /STABLE_HASHES_URL: ''/);
+  assert.match(prod.module, /STABLE_ZIP_BASE_URL: ''/);
+  assert.match(prod.module, /STABLE_UI_BASE_URL: ''/);
+  assert.match(prod.module, /STABLE_HELPER_BASE_URL: ''/);
+  assert.doesNotMatch(prod.module, /STABLE_[A-Z_]+: '[^']+'/);
+
+  // Dev builds embed the stable channel's URLs (derived from installer.conf),
+  // so a dead test channel can fall back to the stable manifest.
+  const dev = probe('--mode=dev');
+  assert.match(
+    dev.module,
+    /STABLE_HASHES_URL: 'https:\/\/onemen\.github\.io\/firefox-scripts\/hashes\.json'/
+  );
+  assert.match(
+    dev.module,
+    /STABLE_ZIP_BASE_URL: 'https:\/\/github\.com\/onemen\/firefox-scripts\/releases\/download\/latest'/
+  );
+  assert.match(dev.module, /STABLE_UI_BASE_URL: 'https:\/\/onemen\.github\.io\/firefox-scripts'/);
+  assert.match(
+    dev.module,
+    /STABLE_HELPER_BASE_URL: 'https:\/\/onemen\.github\.io\/firefox-scripts'/
+  );
+});
+
 test('generated module: prod-local — IS_LOCAL true, file:// URLs, no suffix change', () => {
   const {module} = probe('--mode=prod', '--local');
   assert.match(module, /IS_DEV: false/);

--- a/tools/publish/generateUpdaterConfig.mjs
+++ b/tools/publish/generateUpdaterConfig.mjs
@@ -156,8 +156,42 @@ export function effectiveConfig(config, {installer = false} = {}) {
   return {...eff, UI_BASE_URL: eff.UI_BASE_URL || eff.ZIP_PAGES_URL || eff.ZIP_BASE_URL};
 }
 
+/**
+ * stableChannelUrls — the stable channel's fetch-side URLs, derived from the
+ * installer.conf values BEFORE any mode override (ADR 0026). Dev/test builds
+ * embed them so the daily check can fall back to the stable channel when the
+ * test channel's own manifest becomes unreachable (its dev-build branch was
+ * deleted). Stable builds get no fallback — the channel is their own — and the
+ * C-installer config header never sees these keys (generateModule emits them
+ * only here).
+ */
+function stableChannelUrls(config) {
+  if (MODE !== 'dev') return null;
+  const {REPO_OWNER, ZIP_DOWNLOAD_REPO, RELEASE_NAME} = config;
+  if (!REPO_OWNER || !ZIP_DOWNLOAD_REPO || !RELEASE_NAME || !config.HASHES_URL) {
+    throw new Error(
+      'installer.conf is missing required keys (REPO_OWNER, ZIP_DOWNLOAD_REPO, RELEASE_NAME, HASHES_URL)'
+    );
+  }
+  const zipBase =
+    config.ZIP_BASE_URL && !config.ZIP_BASE_URL.includes('${') ?
+      config.ZIP_BASE_URL
+    : `https://github.com/${REPO_OWNER}/${ZIP_DOWNLOAD_REPO}/releases/download/${RELEASE_NAME}`;
+  const helperBase =
+    config.HELPER_BASE_URL ||
+    `https://${REPO_OWNER}.github.io/${config.REPO_NAME || 'firefox-scripts'}`;
+  const uiBase = config.UI_BASE_URL || config.ZIP_PAGES_URL || zipBase;
+  return {
+    STABLE_HASHES_URL: config.HASHES_URL,
+    STABLE_ZIP_BASE_URL: zipBase,
+    STABLE_UI_BASE_URL: uiBase,
+    STABLE_HELPER_BASE_URL: helperBase,
+  };
+}
+
 function generateModule(config) {
   const eff = effectiveConfig(config);
+  const stableUrls = stableChannelUrls(config);
   const {REPO_OWNER, ZIP_DOWNLOAD_REPO, RELEASE_NAME} = eff;
   if (!REPO_OWNER || !ZIP_DOWNLOAD_REPO || !RELEASE_NAME || !eff.HASHES_URL) {
     throw new Error(
@@ -239,6 +273,15 @@ ${urlLine('ASSET_SUFFIX', eff.ASSET_SUFFIX || '')}
   // Absolute path of the local snapshot directory (--local builds only; empty
   // otherwise).  The file:// URLs above point into it.
 ${urlLine('LOCAL_DIST_PATH', LOCAL ? localSnapshotDir().replace(/\\/g, '/') : '')}
+
+  // Stable-channel fallback URLs (test/dev builds only, ADR 0026): where the
+  // daily check turns when this channel's own manifest is unreachable (its
+  // dev-build branch was deleted).  Empty in stable builds — the stable
+  // channel is their own.
+${urlLine('STABLE_HASHES_URL', stableUrls ? stableUrls.STABLE_HASHES_URL : '')}
+${urlLine('STABLE_ZIP_BASE_URL', stableUrls ? stableUrls.STABLE_ZIP_BASE_URL : '')}
+${urlLine('STABLE_UI_BASE_URL', stableUrls ? stableUrls.STABLE_UI_BASE_URL : '')}
+${urlLine('STABLE_HELPER_BASE_URL', stableUrls ? stableUrls.STABLE_HELPER_BASE_URL : '')}
 
   // The dev-build branch this run publishes to (dev mode only).
 ${urlLine('DEV_BRANCH', DEV_BRANCH)}


### PR DESCRIPTION
Part of #72, #4.

## What

Records and starts implementing the channel model discussed on #72/#4 (design summarized in [this #4 comment](https://github.com/onemen/firefox-scripts/issues/4#issuecomment-5645375392)):

1. **ADR 0026 — Publish channels.** Stable (`--mode=prod`, CI-only) vs test (`--mode=dev`). Test publishes become **branch-only** (no release page); `--note="<label>"` opts into an RC-style prerelease page — this is the recorded **RC mechanism** for #4. Extends ADR 0009; scopes ADR 0012's "no fallback UI" invariant for the test channel (cross-reference added); AGENTS.md + `docs/DEVELOPING.md` updated in the same step.
2. **Dead-test-channel fallback (generator half).** `generateUpdaterConfig.mjs` emits `STABLE_HASHES_URL` / `STABLE_ZIP_BASE_URL` / `STABLE_UI_BASE_URL` / `STABLE_HELPER_BASE_URL` into dev builds (derived from `installer.conf` per ADR 0013 — no hardcoded URLs; empty in stable builds), so a test install whose dev-build branch was deleted can find the stable channel. New unit test pins the contract in all four modes.
3. **Absorbed adr-refactor typos** (cherry-pick of `030e582`: ADR 0001/0017/0022 fixes) plus the residual 0022 cleanup (split embedded list item, garbled sentence).

## Not in this PR (sequenced work)

- The fallback ladder itself in `scriptsUpdater.sys.mjs` + the updater-tab banner (consumes the `STABLE_*` fields this PR generates) — next PR in the sequence.
- `--note` flag, prod CI-only guard, Latest Scripts release scheme — each its own PR.

## Validation

- `pnpm check:decisions` ✓ (26 records, links OK)
- `pnpm lint` ✓ · `pnpm format` ✓ · `pnpm test` ✓ (327 pass / 0 fail)
- `syncGeneratedFiles` regen ✓; `generateUpdaterConfig.mjs --check` ✓

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>