### PR TITLE
publish: plain-English component release bodies

### DIFF
--- a/test/unit/publish/componentReleases.test.mjs
+++ b/test/unit/publish/componentReleases.test.mjs
@@ -50,7 +50,11 @@ test('renderComponentBody: lists artifacts and points back at latest', () => {
   assert.match(body, /Package zips \(utils, fx-folder\) — 2026-09-09/);
   assert.match(body, /- utils\.zip/);
   assert.match(body, /releases\/latest/);
-  assert.match(body, /hashes\.json/);
+  // User-facing wording: plain English, no internals like hashes.json.
+  assert.doesNotMatch(body, /hashes\.json/);
+  assert.doesNotMatch(body, /unversioned/);
+  assert.doesNotMatch(body, /gh-pages/);
+  assert.match(body, /newest files/);
 
   const installerBody = renderComponentBody('installer', '2026-09-09', [
     'installer_win.exe',

--- a/tools/publish/componentReleases.mjs
+++ b/tools/publish/componentReleases.mjs
@@ -114,9 +114,8 @@ export function renderComponentBody(kind, date, names) {
   return (
     `${title} — ${date}.\n\n` +
     `${list}\n\n` +
-    `Frozen per-component snapshot for browsing only: fetch artifacts by their permanent ` +
-    `unversioned names from the [latest release](${base}/latest) or the gh-pages branch ` +
-    `(integrity: \`hashes.json\`).`
+    `This release is an archived snapshot: the files above are from that date and will not ` +
+    `change. Always download the newest files from the [Latest Scripts release](${base}/latest).`
   );
 }
 


### PR DESCRIPTION
Part of #72. First PR of the Latest Scripts sequence (flagged by the maintainer in the mock review: user-facing release text must not leak internals).

## What

`renderComponentBody()` wrote maintainer-speak onto every user-facing date-tag release:

> ~~Frozen per-component snapshot for browsing only: fetch artifacts by their permanent unversioned names from the latest release or the gh-pages branch (integrity: `hashes.json`).~~

Now:

> This release is an archived snapshot: the files above are from that date and will not change. Always download the newest files from the [Latest Scripts release](https://github.com/onemen/firefox-scripts/releases/latest).

No `hashes.json`, no `gh-pages`, no "unversioned" — and the pointer to the current files is a clickable link. The unit test now *rejects* the internals in user-facing bodies and requires the new sentence.

## Note

The next PR in this sequence (Latest Scripts scheme) changes this function again — installer tags become installer-binaries-only, so the "Installer + helper binaries" title changes there, with its test.

## Validation

- `node --test test/unit/publish/componentReleases.test.mjs` ✓ 7/7
- `pnpm lint` ✓ · `pnpm format` ✓

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>