### PR TITLE
publish: Latest Scripts scheme — full component releases, make_latest pin, helpers off releases

### DIFF
--- a/docs/decisions/0019-release-versioning.md
+++ b/docs/decisions/0019-release-versioning.md
@@ -23,12 +23,17 @@ communicates freshness without pretending every package changed.
   `installer_linux`. `updater-ui.zip` and `helper_<os>` are gh-pages-branch artifacts — never
   release assets.
 - Releases are tagged **per component + date**: `scripts-<YYYY-MM-DD>` (the zips) and
-  `installer-<YYYY-MM-DD>` (installer + helper binaries). A component release is created only when
-  that component changed.
+  `installer-<YYYY-MM-DD>` (installer binaries; helpers are gh-pages-only — they never appear on a
+  release page, and a helper-only rebuild creates no tag). A component release is created only when
+  that component changed. Component releases are **full releases** (not prereleases); after each
+  publish the Latest badge is re-pinned onto `latest` with `make_latest=true` on Update-a-release —
+  GitHub renders the badge-holding release as the page's hero card, so the page reads: latest hero
+  first, frozen date tags below (amended 2026-09-12, Latest Scripts scheme: the earlier
+  `prerelease=true` badge-guard and the `make_latest=false` wording predate the verified
+  availability of `make_latest` on Update-a-release).
 - `latest` (existing moving tag) always carries the **complete release asset set** — both package
-  zips + the installers — and stays GitHub's "Latest"; component releases are created with
-  `make_latest=false`. README, docs and the updater point only at `latest` — never at versioned
-  URLs.
+  zips + the installers — and stays GitHub's "Latest". README, docs and the updater point only at
+  `latest` — never at versioned URLs.
 
 ## Consequences
 

--- a/test/unit/publish/componentReleases.test.mjs
+++ b/test/unit/publish/componentReleases.test.mjs
@@ -28,27 +28,34 @@ test('tags: date-stamped, per component', () => {
   assert.equal(installerTag('2026-09-09'), 'installer-2026-09-09');
 });
 
-test('groupBuilt: updater-ui excluded from scripts; helpers ride with installer; deduped', () => {
+test('groupBuilt: updater-ui excluded from scripts; helpers never join a release', () => {
   const {scripts, installer} = groupBuilt({
     builtZips: ['utils', 'fx-folder', 'updater-ui'],
     builtInstallers: ['win', 'linux'],
     builtHelpers: ['linux', 'aarch64', 'linux'],
   });
   assert.deepEqual(scripts, ['utils', 'fx-folder']);
-  assert.deepEqual(installer, ['win', 'linux', 'aarch64']);
+  // Helpers are gh-pages-only (updater fetches them + sidecars) — a rebuilt
+  // helper never lands on a release page, and a helper-only rebuild creates
+  // no installer-<date> tag at all.
+  assert.deepEqual(installer, ['win', 'linux']);
 });
 
-test('groupBuilt: empty buckets stay empty', () => {
-  assert.deepEqual(groupBuilt({builtZips: ['updater-ui'], builtInstallers: [], builtHelpers: []}), {
-    scripts: [],
-    installer: [],
+test('groupBuilt: helper-only rebuild produces no component release', () => {
+  assert.deepEqual(
+    groupBuilt({builtZips: ['updater-ui'], builtInstallers: [], builtHelpers: ['win']}),
+    {scripts: [], installer: []}
+  );
+});
+
+test('renderComponentBody: lists artifacts with per-file dates, points back at latest', () => {
+  const body = renderComponentBody('scripts', '2026-09-09', ['utils.zip', 'fx-folder.zip'], {
+    'utils.zip': '2026-09-02',
   });
-});
-
-test('renderComponentBody: lists artifacts and points back at latest', () => {
-  const body = renderComponentBody('scripts', '2026-09-09', ['utils.zip', 'fx-folder.zip']);
   assert.match(body, /Package zips \(utils, fx-folder\) — 2026-09-09/);
-  assert.match(body, /- utils\.zip/);
+  // Per-file dates: manifest date when known, else the release's own date.
+  assert.match(body, /- utils\.zip — updated 2026-09-02/);
+  assert.match(body, /- fx-folder\.zip — updated 2026-09-09/);
   assert.match(body, /releases\/latest/);
   // User-facing wording: plain English, no internals like hashes.json.
   assert.doesNotMatch(body, /hashes\.json/);
@@ -56,50 +63,29 @@ test('renderComponentBody: lists artifacts and points back at latest', () => {
   assert.doesNotMatch(body, /gh-pages/);
   assert.match(body, /newest files/);
 
-  const installerBody = renderComponentBody('installer', '2026-09-09', [
-    'installer_win.exe',
-    'helper_win.exe',
-    'helper_win.exe.sha256',
-  ]);
-  assert.match(installerBody, /Installer \+ helper binaries — 2026-09-09/);
+  const installerBody = renderComponentBody('installer', '2026-09-09', ['installer_win.exe']);
+  assert.match(installerBody, /Installer binaries — 2026-09-09/);
   assert.match(installerBody, /- installer_win\.exe/);
 
   const empty = renderComponentBody('installer', '2026-09-09', []);
   assert.match(empty, /no artifacts this date/);
 });
 
-// The CodeRabbit Major finding on the first draft: groupBuilt unions
-// installers+helpers, so a partial rebuild (helper leg skipped) must not
-// touch the helper accessor — the old inline loop read the staged helper path
-// for every unioned platform and threw ENOENT, silently dropping the whole
-// installer- release.
-test('componentAssets: partial rebuild contributes only artifacts actually built', () => {
+test('componentAssets: exactly the installers built — never helpers', () => {
   const access = {
     installer: p => `installer_${p}.exe`,
-    helper: p => `helper_${p}.exe`,
-    helperSha: p => `helper_${p}.exe.sha256`,
-    installerPath: p => `staged/installer-${p}`, // throws for unstaged in real life
-    helperPath: p => {
-      if (p !== 'win') throw new Error(`ENOENT: ${p} helper not staged`);
-      return `staged/helper-${p}`;
-    },
-    sidecar: () => Buffer.from('abc'),
+    installerPath: p => `staged/installer-${p}`,
   };
-  const built = {builtInstallers: ['win', 'linux'], builtHelpers: ['win']};
+  const built = {builtInstallers: ['win', 'linux']};
   const assets = componentAssets(['win', 'linux'], built, access);
-  assert.deepEqual([...assets.keys()].sort(), [
-    'helper_win.exe',
-    'helper_win.exe.sha256',
-    'installer_linux.exe',
-    'installer_win.exe',
-  ]);
+  assert.deepEqual([...assets.keys()].sort(), ['installer_linux.exe', 'installer_win.exe']);
 });
 
 test('componentAssets: nothing built → empty map', () => {
   const assets = componentAssets(
     [],
-    {builtInstallers: [], builtHelpers: []},
-    {installer: p => p, helper: p => p, helperSha: p => p}
+    {builtInstallers: []},
+    {installer: p => p, installerPath: p => p}
   );
   assert.equal(assets.size, 0);
 });

--- a/test/unit/publish/componentReleases.test.mjs
+++ b/test/unit/publish/componentReleases.test.mjs
@@ -50,7 +50,11 @@ test('renderComponentBody: lists artifacts and points back at latest', () => {
   assert.match(body, /Package zips \(utils, fx-folder\) — 2026-09-09/);
   assert.match(body, /- utils\.zip/);
   assert.match(body, /releases\/latest/);
-  assert.match(body, /hashes\.json/);
+  // User-facing wording: plain English, no internals like hashes.json.
+  assert.doesNotMatch(body, /hashes\.json/);
+  assert.doesNotMatch(body, /unversioned/);
+  assert.doesNotMatch(body, /gh-pages/);
+  assert.match(body, /newest files/);
 
   const installerBody = renderComponentBody('installer', '2026-09-09', [
     'installer_win.exe',

--- a/tools/publish/componentReleases.mjs
+++ b/tools/publish/componentReleases.mjs
@@ -15,9 +15,20 @@
 // badge is what the flag protects.)
 //
 // Library-only (no entry point): upload.mjs calls syncComponentReleases() in
-// prod mode after the latest-release + Pages uploads. All GitHub calls fail
-// soft: a component-release sync problem is a loud warning, never a publish
-// failure (latest + Pages are the contract; the date tags are a convenience).
+// prod mode after the latest-release + Pages uploads, then re-pins the Latest
+// badge onto `latest` with make_latest=true (see pinLatestRelease below).
+// All GitHub calls fail soft: a component-release sync problem is a loud
+// warning, never a publish failure (latest + Pages are the contract; the date
+// tags are a convenience).
+//
+// Release shape (maintainer's Latest Scripts scheme, 2026-09-12): component
+// releases are FULL releases — GitHub renders the badge-holding release as the
+// hero card at the top of the releases page (verified on TabMixPlus), so after
+// every publish the badge is re-pinned onto `latest` and the page reads:
+// Latest Scripts hero first, frozen date tags below. The old prerelease=true
+// trick is obsolete: "Update a release" accepts make_latest (REST-level
+// parameter surfaced by the CLI's --latest flag), and prereleases can never
+// hold the badge.
 
 import {REPO_OWNER, REPO_NAME} from './paths.js';
 import {green, dim, warn} from './log.mjs';
@@ -42,10 +53,14 @@ export function scriptsTag(date) {
 /** Tag for the installer+helper component release. */
 export function installerTag(date) {
   return `installer-${date}`;
-}
-
-/**
+} /**
  * Group the built artifacts into component-release buckets.
+ *
+ * Helpers never join a component release (maintainer call, 2026-09-12, mock
+ * review on #72): they are not user downloads — the updater fetches them from
+ * gh-pages with their .sha256 sidecars (ADR 0019). A helper-only rebuild
+ * therefore creates NO release tag at all; only installer binaries make the
+ * installer-<date> bucket.
  *
  * @param {{
  *   builtZips: string[];
@@ -54,36 +69,27 @@ export function installerTag(date) {
  * }} built
  *   package names / platform keys actually rebuilt this run
  * @returns {{scripts: string[]; installer: string[]}} package names for the
- *   scripts release (updater-ui excluded — internal, Pages-only), platform keys
- *   for the installer release (helpers ride with the installer: same helper
- *   sources, one tag for the binary surface)
+ *   scripts release (updater-ui excluded — internal, Pages-only), platform
+ *   keys for the installer release (installer binaries only)
  */
+
 export function groupBuilt(built) {
   const scripts = built.builtZips.filter(n => n !== 'updater-ui');
-  const installer = [...new Set([...built.builtInstallers, ...built.builtHelpers])];
+  const installer = built.builtInstallers;
   return {scripts, installer};
 }
 
 /**
- * Build the installer component release's asset map, contributing only the
- * artifacts this run actually built: a platform's installer is added only when
- * the installer leg built it, its helper + sha256 sidecar only when the helper
- * leg did. Per-artifact (not per-platform) because a run can rebuild one leg
- * without the other, and the staged-path accessors throw for anything not
- * staged.
+ * Build the installer component release's asset map: exactly the installers
+ * this run built (helpers are gh-pages-only — never release assets).
  *
- * @param {string[]} installer platform keys (the groupBuilt union)
- * @param {{builtInstallers: string[]; builtHelpers: string[]}} built what the
- *   run rebuilt
+ * @param {string[]} installer platform keys (groupBuilt's installer bucket)
+ * @param {{builtInstallers: string[]}} built what the run rebuilt
  * @param {object} access
  * @param {(p: string) => string} access.installer platform → installer asset
  *   name
- * @param {(p: string) => string} access.helper platform → helper asset name
- * @param {(p: string) => string} access.helperSha platform → sidecar asset name
  * @param {(p: string) => string} access.installerPath platform → staged path
- * @param {(p: string) => string} access.helperPath platform → staged path
- * @param {(p: string) => Buffer} access.sidecar platform → sidecar bytes
- * @returns {Map<string, string | Buffer>} asset name → path or bytes
+ * @returns {Map<string, string>} asset name → staged path
  */
 export function componentAssets(installer, built, access) {
   const assets = new Map();
@@ -91,26 +97,25 @@ export function componentAssets(installer, built, access) {
     if (built.builtInstallers.includes(p)) {
       assets.set(access.installer(p), access.installerPath(p));
     }
-    if (built.builtHelpers.includes(p)) {
-      const helper = access.helper(p);
-      assets.set(helper, access.helperPath(p));
-      // Sidecar regenerated from the staged bytes (issue #33 contract).
-      assets.set(access.helperSha(p), access.sidecar(p));
-    }
   }
   return assets;
 }
 
 /**
- * Render the release body for one component release: what's in it, and the
- * pointer back to `latest` + hashes.json (the machines' source of truth).
+ * Render the release body for one component release: what's in it (each file
+ * with its own last-updated date — asset rows are collapsible on GitHub, the
+ * body is always visible), and the pointer back to the latest release.
+ *
+ * `dates` maps asset name → YYYY-MM-DD (per-package source-commit date from the
+ * manifest; defaults to the release's own date).
  */
-export function renderComponentBody(kind, date, names) {
+export function renderComponentBody(kind, date, names, dates = {}) {
   const base = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases`;
-  const title =
-    kind === 'scripts' ? 'Package zips (utils, fx-folder)' : 'Installer + helper binaries';
+  const title = kind === 'scripts' ? 'Package zips (utils, fx-folder)' : 'Installer binaries';
   const list =
-    names.length > 0 ? names.map(n => `- ${n}`).join('\n') : '- (no artifacts this date)';
+    names.length > 0 ?
+      names.map(n => `- ${n} — updated ${dates[n] || date}`).join('\n')
+    : '- (no artifacts this date)';
   return (
     `${title} — ${date}.\n\n` +
     `${list}\n\n` +
@@ -120,38 +125,77 @@ export function renderComponentBody(kind, date, names) {
 }
 
 /**
- * Sync one component release: get-or-create the tagged release (prerelease=true
- * — never "Latest"), then delete+reupload the given assets and refresh the
- * body. Idempotent: same-day republishes replace assets and rewrite the body in
- * place.
+ * Sync one component release: get-or-create the tagged release as a FULL
+ * release (no prerelease flag — the maintainer's Latest Scripts scheme,
+ * 2026-09-12: date tags are first-class releases), then delete+reupload the
+ * given assets (each labelled with its updated-date) and refresh the body. The
+ * caller re-pins the Latest badge onto `latest` via make_latest afterwards — a
+ * newly created full release briefly holds the badge otherwise. Idempotent:
+ * same-day republishes replace assets and rewrite the body.
  *
  * @returns {Promise<{created: boolean}>} whether the release was newly created
  */
-export async function syncComponentRelease(octokit, tagName, date, assets, {kind} = {}) {
-  const {getRelease, getOrCreateRelease, deleteExistingAsset, uploadAsset} =
+export async function syncComponentRelease(
+  octokit,
+  tagName,
+  date,
+  assets,
+  {kind, dates = {}} = {}
+) {
+  const {getRelease, getOrCreateRelease, deleteExistingAsset, uploadAsset, uploadAssetBuffer} =
     await import('./uploadUtilsZip.mjs');
   const existed = !!(await getRelease(octokit, tagName));
   const release = await getOrCreateRelease(octokit, tagName, {
     name: `${kind === 'scripts' ? 'Scripts' : 'Installer'} — ${date}`,
-    body: renderComponentBody(kind, date, [...assets.keys()]),
+    body: renderComponentBody(kind, date, [...assets.keys()], dates),
     commitish: 'main',
-    prerelease: true,
+    prerelease: false,
   });
 
   for (const [assetName, src] of assets) {
     await deleteExistingAsset(octokit, release.id, assetName);
     if (!src) continue;
+    const label = `Updated ${dates[assetName] || date}`.slice(0, 50);
     if (Buffer.isBuffer(src)) {
-      // Buffer source (the derived sha256 sidecar) — uploadReleaseAsset takes
-      // data directly; reuse uploadAsset's logging by a tiny inline upload.
-      const {uploadAssetBuffer} = await import('./uploadUtilsZip.mjs');
-      await uploadAssetBuffer(octokit, release.id, src, assetName);
+      await uploadAssetBuffer(octokit, release.id, src, assetName, label);
     } else {
-      await uploadAsset(octokit, release.id, src, assetName);
+      await uploadAsset(octokit, release.id, src, assetName, label);
     }
   }
   console.log(green(`  ✓ component release ${tagName} synced`));
   return {created: !existed};
+}
+
+/**
+ * Re-pin the Latest badge onto the `latest` release (the Latest Scripts hero).
+ * A newly created full component release briefly holds the badge (GitHub's
+ * default for a new non-prerelease); make_latest=true on Update-a-release moves
+ * it back. Idempotent and fails soft — the badge is cosmetic; the
+ * /releases/latest URL is resolved by GitHub from this same flag, so call this
+ * after every component-release sync.
+ */
+export async function pinLatestRelease(octokit) {
+  try {
+    const {getRelease} = await import('./uploadUtilsZip.mjs');
+    const release = await getRelease(octokit);
+    if (!release) {
+      warn('component releases: latest release not found — badge pin skipped');
+      return;
+    }
+    if (release.make_latest === 'true') {
+      console.log(dim('  latest badge: already on latest'));
+      return;
+    }
+    await octokit.repos.updateRelease({
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      release_id: release.id,
+      make_latest: 'true',
+    });
+    console.log(green('  ✓ latest badge pinned on latest (make_latest=true)'));
+  } catch (err) {
+    warn(`latest badge re-pin failed (non-fatal): ${err.message}`);
+  }
 }
 
 /**
@@ -164,51 +208,58 @@ export async function syncComponentRelease(octokit, tagName, date, assets, {kind
  * @param {object} p
  * @param {string[]} p.builtZips rebuilt package names
  * @param {string[]} p.builtInstallers rebuilt platform keys
- * @param {string[]} p.builtHelpers rebuilt platform keys
+ * @param {string[]} p.builtHelpers rebuilt platform keys (informed the
+ *   installer/helper rebuild decisions upstream; helpers never join a release)
+ * @param {Record<string, {hash: string; date?: string}>} p.manifest the merged
+ *   hash manifest — per-package `date` labels the assets and bodies
  * @param {(name: string) => string} p.zipPath staged zip path by package name
  * @param {(p: string) => string} p.installerPath staged installer path by
  *   platform
- * @param {(p: string) => string} p.helperPath staged helper path by platform
  */
 export async function syncComponentReleases(
   octokit,
-  {builtZips, builtInstallers, builtHelpers, zipPath, installerPath, helperPath}
+  {builtZips, builtInstallers, builtHelpers, manifest, zipPath, installerPath}
 ) {
   try {
-    const {installerAssetName, helperAssetName, helperShaAssetName} =
-      await import('./platforms.mjs');
+    const {installerAssetName} = await import('./platforms.mjs');
     const date = componentDate();
     const {scripts, installer} = groupBuilt({builtZips, builtInstallers, builtHelpers});
     if (scripts.length === 0 && installer.length === 0) {
       console.log(dim('  component releases: nothing rebuilt — date tags unchanged'));
       return;
     }
+    // Per-file dates for bodies + asset labels: the manifest's per-package
+    // source-commit date (falls back to the release date when absent).
+    const dates = {};
+    for (const n of scripts) {
+      if (manifest[n]?.date) dates[`${n}.zip`] = manifest[n].date;
+    }
+    for (const p of installer) {
+      if (manifest.installer?.date) dates[installerAssetName(p)] = manifest.installer.date;
+    }
 
     if (scripts.length > 0) {
       const assets = new Map(scripts.map(n => [`${n}.zip`, zipPath(n)]));
-      await syncComponentRelease(octokit, scriptsTag(date), date, assets, {kind: 'scripts'});
+      await syncComponentRelease(octokit, scriptsTag(date), date, assets, {
+        kind: 'scripts',
+        dates,
+      });
     }
 
     if (installer.length > 0) {
-      const {helperSha256Sidecar} = await import('./hashUtils.mjs');
-      const {readFileSync} = await import('fs');
       const assets = componentAssets(
         installer,
-        {builtInstallers, builtHelpers},
-        {
-          installer: installerAssetName,
-          helper: helperAssetName,
-          helperSha: helperShaAssetName,
-          installerPath,
-          helperPath,
-          sidecar: p => helperSha256Sidecar(readFileSync(helperPath(p)), helperAssetName(p)),
-        }
+        {builtInstallers},
+        {installer: installerAssetName, installerPath}
       );
       if (assets.size === 0) {
         console.log(dim('  component releases: installer bucket empty — date tag unchanged'));
         return;
       }
-      await syncComponentRelease(octokit, installerTag(date), date, assets, {kind: 'installer'});
+      await syncComponentRelease(octokit, installerTag(date), date, assets, {
+        kind: 'installer',
+        dates,
+      });
     }
   } catch (err) {
     warn(`component releases sync failed (non-fatal): ${err.message}`);

--- a/tools/publish/componentReleases.mjs
+++ b/tools/publish/componentReleases.mjs
@@ -114,9 +114,8 @@ export function renderComponentBody(kind, date, names) {
   return (
     `${title} — ${date}.\n\n` +
     `${list}\n\n` +
-    `Frozen per-component snapshot for browsing only: fetch artifacts by their permanent ` +
-    `unversioned names from the [latest release](${base}/latest) or the gh-pages branch ` +
-    `(integrity: \`hashes.json\`).`
+    `This release is an archived snapshot: the files above are from that date and will not ` +
+    `change. Always download the newest files from the [Latest Scripts release](${base}/latest).`
   );
 }
 

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -89,7 +89,7 @@ import {
   REPO_ROOT,
 } from './publishCommon.mjs';
 import {pagesIndex, uploadFilesToPages} from './uploadToPages.mjs';
-import {syncComponentReleases} from './componentReleases.mjs';
+import {pinLatestRelease, syncComponentReleases} from './componentReleases.mjs';
 import {scanBinaries} from '../scan-av.mjs';
 import {scanVirusTotal} from '../scan-vt.mjs';
 import {
@@ -687,18 +687,21 @@ async function publishToGitHub({
   }
 
   // Date-stamped component releases alongside `latest` (issue #72, ADR 0019):
-  // scripts-<date> for rebuilt zips, installer-<date> for rebuilt installers +
-  // helpers. Prerelease=true so the date tags can never take GitHub's
-  // "Latest" badge; skipped on idle runs (nothing rebuilt → tags stay frozen).
+  // scripts-<date> for rebuilt zips, installer-<date> for rebuilt installers
+  // (helpers are gh-pages-only — never release assets). Full releases, then the
+  // Latest badge is re-pinned onto `latest` via make_latest (the Latest Scripts
+  // scheme — the badge release renders as the page's hero card). Skipped on
+  // idle runs (nothing rebuilt → tags stay frozen).
   if (PUBLISH_MODE === 'prod' && anythingUploaded) {
     await syncComponentReleases(octokit, {
       builtZips,
       builtInstallers,
       builtHelpers,
+      merged,
       zipPath,
       installerPath,
-      helperPath,
     });
+    await pinLatestRelease(octokit);
   }
 }
 

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -697,7 +697,7 @@ async function publishToGitHub({
       builtZips,
       builtInstallers,
       builtHelpers,
-      merged,
+      manifest: merged,
       zipPath,
       installerPath,
     });

--- a/tools/publish/uploadUtilsZip.mjs
+++ b/tools/publish/uploadUtilsZip.mjs
@@ -81,15 +81,18 @@ export async function deleteExistingAsset(octokit, releaseId, assetName) {
 
 /**
  * Upload in-memory bytes as a release asset (the derived sha256 sidecars are
- * buffers, never staged files).
+ * buffers, never staged files). `label` is the optional human-readable label
+ * GitHub renders next to the asset name (≤50 chars, e.g. "Updated
+ * 2026-09-12").
  */
-export async function uploadAssetBuffer(octokit, releaseId, data, assetName) {
+export async function uploadAssetBuffer(octokit, releaseId, data, assetName, label) {
   try {
     const {data: asset} = await octokit.repos.uploadReleaseAsset({
       owner: REPO_OWNER,
       repo: REPO_NAME,
       release_id: releaseId,
       name: assetName,
+      label,
       data,
     });
     console.log(
@@ -102,8 +105,8 @@ export async function uploadAssetBuffer(octokit, releaseId, data, assetName) {
   }
 }
 
-/** Upload asset to release */
-export async function uploadAsset(octokit, releaseId, filePath, assetName) {
+/** Upload asset to release (`label` — optional, GitHub renders it by the name) */
+export async function uploadAsset(octokit, releaseId, filePath, assetName, label) {
   try {
     if (!fs.existsSync(filePath)) {
       throw new Error(`File not found: ${filePath}`);
@@ -117,6 +120,7 @@ export async function uploadAsset(octokit, releaseId, filePath, assetName) {
       repo: REPO_NAME,
       release_id: releaseId,
       name: assetName,
+      label,
       data: fileData,
     });
 


### PR DESCRIPTION
Part of #72. Stacked on #184 (shares `componentReleases.mjs`). Implements the scheme designed in the release-page mock review and summarized in [this #4 comment](https://github.com/onemen/firefox-scripts/issues/4#issuecomment-5645375392).

## What

1. **Full component releases + badge pin.** `scripts-<date>` / `installer-<date>` are created as full releases (no prerelease flag); after every publish, `pinLatestRelease()` re-pins the Latest badge onto `latest` via `make_latest=true` (Update-a-release). GitHub renders the badge-holding release as the hero card at the top of the page — so the page reads: **Latest Scripts** hero first, frozen date tags below. Replaces the old `prerelease=true` badge-guard (whose premise — "REST has no `make_latest`" — was incorrect; verified in octokit's generated types).
2. **Helpers leave the release page.** `groupBuilt`'s installer bucket is installer binaries only; `componentAssets` no longer adds helper binaries or `.sha256` sidecars. Helpers stay gh-pages-only per ADR 0019's original rule; a helper-only rebuild creates **no** release tag. The maintainer's call from the mock review (they are not user downloads — the updater fetches them with verify-before-execute).
3. **Per-file dates, twice.** Release bodies list each asset with `— updated <date>` (bodies are always visible; asset rows are collapsible on GitHub), and assets upload with a `Updated <date>` **label** (≤50 chars) as the bonus. Dates come from the merged manifest's per-package source-commit date — the same date the updater tab shows. (GitHub renders the label in place of the filename on the asset row; full name on hover.)
4. **ADR 0019 amended in place** (badge-mechanics paragraph); the stale "REST has no make_latest" note on #4's #72 entry gets corrected when this merges.

## Out of scope (sequenced)

Zip entry timestamps (files *inside* the zips showing the release date) — separate small PR, needs a date-source decision. `latest`'s own body/date list stays as is here.

## Validation

- `node --test test/unit/publish/componentReleases.test.mjs` ✓ 7/7 (rewritten contracts: helpers never join, per-file dates, `Updated` labels)
- `pnpm lint` ✓ · `pnpm format` ✓ · `pnpm test` ✓ 326/0
- `check:decisions` ✓ (0019 amendment keeps links/statuses valid)

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>