### PR TITLE
publish: zip entries carry the package's release date

### DIFF
--- a/test/shared/zipReader.mjs
+++ b/test/shared/zipReader.mjs
@@ -39,15 +39,36 @@ export function listZipEntries(buf) {
     const nameLen = buf.readUInt16LE(p + 28);
     const extraLen = buf.readUInt16LE(p + 30);
     const commentLen = buf.readUInt16LE(p + 32);
+    // DOS time/date (central directory): 16-bit time at +12, date at +14.
+    const dosTime = buf.readUInt16LE(p + 12);
+    const dosDate = buf.readUInt16LE(p + 14);
     const localOffset = buf.readUInt32LE(p + 42);
     // archiver writes data-descriptor zips: the local header's sizes are zero
     // and the real compressed size lives only in the central directory.
     const compSize = buf.readUInt32LE(p + 20);
     const name = buf.toString('utf8', p + 46, p + 46 + nameLen);
-    entries.push({name, method, localOffset, compSize});
+    entries.push({name, method, localOffset, compSize, dosTime, dosDate});
     p += 46 + nameLen + extraLen + commentLen;
   }
   return entries;
+}
+
+/**
+ * Decode a central-directory DOS time/date pair (as listed by listZipEntries)
+ * to a UTC Date. ZIP stores local clock time without a zone; the writer
+ * (compress-commons) encodes UTC fields, so decode as UTC.
+ *
+ * @param {{dosTime: number; dosDate: number}} entry
+ * @returns {Date}
+ */
+export function dosDateTimeToUtc({dosTime, dosDate}) {
+  const year = 1980 + (dosDate >> 9);
+  const month = (dosDate >> 5) & 0x0f;
+  const day = dosDate & 0x1f;
+  const hours = dosTime >> 11;
+  const minutes = (dosTime >> 5) & 0x3f;
+  const seconds = (dosTime & 0x1f) * 2;
+  return new Date(Date.UTC(year, month - 1, day, hours, minutes, seconds));
 }
 
 /**

--- a/test/unit/publish/createZip.test.mjs
+++ b/test/unit/publish/createZip.test.mjs
@@ -84,6 +84,8 @@ test('zipEntryDate: YYYY-MM-DD → 12:00 UTC, invalid → now', () => {
   const nowish = zipEntryDate(undefined);
   assert.ok(Math.abs(nowish.getTime() - Date.now()) < 60_000);
   assert.ok(Math.abs(zipEntryDate('garbage').getTime() - Date.now()) < 60_000);
+  // Well-formed but impossible calendar dates fall back too (no JS roll-over).
+  assert.ok(Math.abs(zipEntryDate('2026-02-30').getTime() - Date.now()) < 60_000);
 });
 
 test('createZip: entryDate stamps every entry with the release date (12:00 UTC)', async () => {

--- a/test/unit/publish/createZip.test.mjs
+++ b/test/unit/publish/createZip.test.mjs
@@ -17,7 +17,8 @@ process.argv.push('--mode=prod');
 
 const {createZip, loadAllGitignorePatterns, zipPrefixFor} =
   await import('../../../tools/publish/createZip.mjs');
-import {listZipEntries, readZipEntry} from '../../shared/zipReader.mjs';
+const {zipEntryDate} = await import('../../../tools/publish/publishCommon.mjs');
+import {dosDateTimeToUtc, listZipEntries, readZipEntry} from '../../shared/zipReader.mjs';
 
 /** Make a temp source tree with a fixed set of files. */
 function makeSourceTree(files) {
@@ -72,6 +73,51 @@ test('createZip: fx-folder package wraps entries under a top-level folder', asyn
       .map(e => e.name)
       .sort();
     assert.deepEqual(names, ['fx-folder/chrome/fx.js', 'fx-folder/user.js']);
+  } finally {
+    fs.rmSync(src, {recursive: true, force: true});
+    fs.rmSync(out, {force: true});
+  }
+});
+
+test('zipEntryDate: YYYY-MM-DD → 12:00 UTC, invalid → now', () => {
+  assert.equal(zipEntryDate('2026-09-12').toISOString(), '2026-09-12T12:00:00.000Z');
+  const nowish = zipEntryDate(undefined);
+  assert.ok(Math.abs(nowish.getTime() - Date.now()) < 60_000);
+  assert.ok(Math.abs(zipEntryDate('garbage').getTime() - Date.now()) < 60_000);
+});
+
+test('createZip: entryDate stamps every entry with the release date (12:00 UTC)', async () => {
+  const src = makeSourceTree({
+    'a.js': '// a',
+    'b.js': '// b',
+  });
+  const out = path.join(os.tmpdir(), `out-${Date.now()}.zip`);
+  try {
+    const patterns = loadAllGitignorePatterns(src, [], []);
+    await createZip(src, out, patterns, null, [], zipEntryDate('2026-09-12'));
+    const entries = listZipEntries(fs.readFileSync(out));
+    assert.equal(entries.length, 2);
+    for (const e of entries) {
+      // Every entry reads as the package's release date, regardless of each
+      // source file's own mtime.
+      assert.equal(dosDateTimeToUtc(e).toISOString(), '2026-09-12T12:00:00.000Z', e.name);
+    }
+  } finally {
+    fs.rmSync(src, {recursive: true, force: true});
+    fs.rmSync(out, {force: true});
+  }
+});
+
+test('createZip: no entryDate → source mtimes (previous behavior)', async () => {
+  const src = makeSourceTree({'a.js': '// a'});
+  const out = path.join(os.tmpdir(), `out-${Date.now()}.zip`);
+  try {
+    const patterns = loadAllGitignorePatterns(src, [], []);
+    await createZip(src, out, patterns, null, []);
+    const [e] = listZipEntries(fs.readFileSync(out));
+    const decoded = dosDateTimeToUtc(e);
+    // Not pinned to a fixed date — just sanity: decodes near now (± 1 day).
+    assert.ok(Math.abs(decoded.getTime() - Date.now()) < 24 * 3600_000, String(decoded));
   } finally {
     fs.rmSync(src, {recursive: true, force: true});
     fs.rmSync(out, {force: true});

--- a/tools/publish/createZip.mjs
+++ b/tools/publish/createZip.mjs
@@ -99,7 +99,14 @@ export function zipPrefixFor(name) {
  *   updater config is untracked/gitignored but MUST ship inside utils.zip and
  *   appear in the manifest `files` list so the hash check stays consistent).
  */
-export async function createZip(sourceDir, outputPath, patterns, prefix = null, extraFiles = []) {
+export async function createZip(
+  sourceDir,
+  outputPath,
+  patterns,
+  prefix = null,
+  extraFiles = [],
+  entryDate = null
+) {
   return new Promise((resolve, reject) => {
     if (!fs.existsSync(OUTPUT_DIR)) {
       fs.mkdirSync(OUTPUT_DIR, {recursive: true});
@@ -135,7 +142,13 @@ export async function createZip(sourceDir, outputPath, patterns, prefix = null, 
 
     for (const file of files) {
       const relativePath = path.relative(sourceDir, file).replace(/\\/g, '/');
-      archive.file(file, {name: prefix ? `${prefix}/${relativePath}` : relativePath});
+      archive.file(file, {
+        name: prefix ? `${prefix}/${relativePath}` : relativePath,
+        // Every entry reads as the release's date (zipEntryDate normalizes to
+        // 12:00 UTC for timezone-proof display + reproducible builds); null →
+        // the source file's own mtime (previous behavior).
+        date: entryDate || undefined,
+      });
     }
 
     archive.finalize();

--- a/tools/publish/publishCommon.mjs
+++ b/tools/publish/publishCommon.mjs
@@ -57,6 +57,23 @@ export function getLatestCommitDate(dir, patterns) {
   }
 }
 
+/**
+ * Turn a manifest date (YYYY-MM-DD) into the timestamp every entry of the
+ * shipped zip gets (maintainer request, 2026-09-12: file dates inside utils.zip
+ * / fx-folder.zip should read as the release's date, not each source file's
+ * last-edit date). Normalized to 12:00 UTC so any timezone's zip viewer shows
+ * the intended calendar date, and so builds are reproducible. Falls back to now
+ * when the date is missing/invalid.
+ *
+ * @param {string | undefined} date YYYY-MM-DD (the manifest's `date` field)
+ * @returns {Date}
+ */
+export function zipEntryDate(date) {
+  const m = /^\d{4}-\d{2}-\d{2}$/.exec(date || '');
+  if (!m) return new Date();
+  return new Date(`${date}T12:00:00Z`);
+}
+
 // Both publish scripts call loadSharedPatterns twice (zip + hash variants,
 // installer + helper variants); the "Loading gitignore files" block must print
 // once, not per call.

--- a/tools/publish/publishCommon.mjs
+++ b/tools/publish/publishCommon.mjs
@@ -69,9 +69,12 @@ export function getLatestCommitDate(dir, patterns) {
  * @returns {Date}
  */
 export function zipEntryDate(date) {
-  const m = /^\d{4}-\d{2}-\d{2}$/.exec(date || '');
-  if (!m) return new Date();
-  return new Date(`${date}T12:00:00Z`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date || '')) return new Date();
+  const d = new Date(`${date}T12:00:00Z`);
+  // Reject well-formed but impossible calendar dates (2026-02-30 — JS rolls
+  // them forward instead of returning NaN): the round-trip must match.
+  if (isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== date) return new Date();
+  return d;
 }
 
 // Both publish scripts call loadSharedPatterns twice (zip + hash variants,

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -85,6 +85,7 @@ import {
   enforcePublishBranch,
   getGitHubToken,
   getLatestCommitDate,
+  zipEntryDate,
   loadSharedPatterns,
   REPO_ROOT,
 } from './publishCommon.mjs';
@@ -361,7 +362,10 @@ async function buildPackages(createZip, storedHashes, zipPatterns, hashPatterns)
         zipPath(name),
         zipPatterns,
         createZip.zipPrefixFor(name),
-        extraFiles.map(f => f.rel)
+        extraFiles.map(f => f.rel),
+        // Every file inside the zip carries the package's release date (the
+        // same manifest `date` users see) — not each source file's mtime.
+        zipEntryDate(date)
       );
       built.push(name);
     }


### PR DESCRIPTION
Part of #72. From the release-page mock review (maintainer): "need to find a way to make all files in utils.zip / fx-folder.zip have the date of the release."

## What

`createZip` gains an optional `entryDate`; `upload.mjs` passes the package's manifest `date` (the per-package source-commit date the updater tab already shows). Every zip entry's timestamp becomes that date instead of each source file's last-edit mtime — after unzipping, files read as "when this release shipped".

- **Timezone-proof:** timestamps normalize to `12:00:00 UTC` (zip stores local clock time with no zone; the writer encodes UTC fields — verified in compress-commons' `dateToDos`), so viewers in any timezone show the intended calendar date. Side effect: reproducible builds (stable hashes for identical content).
- **Opt-in:** `entryDate = null` keeps the previous mtime behavior (default parameter), so nothing else that calls `createZip` changes behavior.
- `zipReader` (test helper) now exposes the central-directory DOS time/date + a `dosDateTimeToUtc` decoder so the test asserts the real bytes on disk, not the writer API.

## Validation

- `node --test test/unit/publish/createZip.test.mjs` ✓ 7/7 (new: date stamped on every entry; no-date → mtime; `zipEntryDate` parsing)
- `pnpm lint` ✓ · `pnpm format` ✓ · `pnpm test` ✓ 329/0

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>