### PR TITLE
publish: prod publishes are CI-only (ADR 0026)

### DIFF
--- a/test/unit/publish/prodCiGuard.test.mjs
+++ b/test/unit/publish/prodCiGuard.test.mjs
@@ -1,0 +1,26 @@
+// test/unit/publish/prodCiGuard.test.mjs — unit tests for prodCiGuard.mjs
+// (the guard itself is pure; the process-exit behavior lives in the throw).
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+
+const {runProdCiGuard} = await import('../../../tools/publish/prodCiGuard.mjs');
+
+test('prod + real upload + not CI → aborts', () => {
+  assert.throws(() => runProdCiGuard({mode: 'prod', local: false, isCi: false}), {
+    message: /not a CI run/,
+  });
+});
+
+test('CI prod run proceeds', () => {
+  assert.deepEqual(runProdCiGuard({mode: 'prod', local: false, isCi: true}), {aborted: false});
+});
+
+test('--local prod snapshot is exempt (offline, publishes nothing)', () => {
+  assert.deepEqual(runProdCiGuard({mode: 'prod', local: true, isCi: false}), {aborted: false});
+});
+
+test('dev mode is exempt (disposable test channel, ADR 0026)', () => {
+  assert.deepEqual(runProdCiGuard({mode: 'dev', local: false, isCi: false}), {aborted: false});
+  assert.deepEqual(runProdCiGuard({mode: 'dev', local: true, isCi: false}), {aborted: false});
+});

--- a/tools/publish/prodCiGuard.mjs
+++ b/tools/publish/prodCiGuard.mjs
@@ -1,0 +1,40 @@
+// prodCiGuard.mjs — prod publishes run only inside CI (ADR 0026).
+//
+// A real (non-`--local`) `--mode=prod` run from a developer machine publishes
+// an incomplete release: only the current OS's binaries exist locally, while
+// the release contract (ADR 0024) is the full cross-OS set — 4 installers +
+// helpers. The complete set is buildable only by the Pages publish workflow
+// (or a future per-OS build matrix, issue #33), so any other prod run is a
+// mistake the user must not discover on the release page after the fact.
+//
+//   prod + real upload + not invoked by CI → ABORT before building, with the
+//   pointer to the workflow_dispatch. `--local` snapshots are exempt (offline
+//   validation, touches no GitHub target). The detection is
+//   workflow-agnostic: a run is "in CI" when the Pages workflow (or any future
+//   publish vehicle, #33) passes --ci — upload.mjs's explicit flag, never
+//   ambient CI env vars, which local shells often export.
+//
+// Dev/test publishes are exempt: they are disposable by design (ADR 0026) and
+// a developer legitimately publishes a dev build from one machine.
+
+import {error} from './log.mjs';
+
+/**
+ * @param {{mode: string; local: boolean; isCi: boolean}} p
+ * @returns {{aborted: boolean}} for tests; runProdCiGuard itself exits via a
+ *   thrown error (fail-fast, same as runStagingGuard).
+ */
+export function runProdCiGuard({mode, local, isCi}) {
+  if (mode !== 'prod' || local || isCi) return {aborted: false};
+  error(
+    'Prod publishes are CI-only (ADR 0026): a local machine can build only its own ' +
+      "OS's binaries, but the `latest` release must always carry the complete " +
+      'cross-OS set (all installers + helpers, ADR 0024).\n' +
+      '  → Dispatch the Pages publish workflow instead:\n' +
+      '      gh workflow run pages.yml -f mode=prod\n' +
+      '    (or use --local for an offline validation snapshot, which publishes nothing).'
+  );
+  throw new Error(
+    'Prod publish aborted: not a CI run — use the Pages publish workflow (gh workflow run pages.yml -f mode=prod) or --local.'
+  );
+}

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -121,6 +121,7 @@ import {
   helperShaAssetName,
   installerAssetName,
 } from './platforms.mjs';
+import {runProdCiGuard} from './prodCiGuard.mjs';
 import {runStagingGuard} from './stagingGuard.mjs';
 
 const LOCAL = process.argv.includes('--local');
@@ -173,6 +174,9 @@ const PLATFORMS = process.argv
 // snapshots touch no GitHub target and are exempt). Escaping to a real staging
 // rehearsal requires the explicit FIREFOX_SCRIPTS_ALLOW_STAGING=1.
 runStagingGuard({mode: PUBLISH_MODE, local: LOCAL});
+// Prod is CI-only (ADR 0026): a local real prod run cannot produce the full
+// cross-OS binary set. --local snapshots and CI runs (explicit --ci) proceed.
+runProdCiGuard({mode: PUBLISH_MODE, local: LOCAL, isCi: IS_CI});
 
 const INSTALLER_DIR = path.join(REPO_ROOT, 'installer');
 const INSTALLER_SRC = path.join(INSTALLER_DIR, 'src');


### PR DESCRIPTION
Part of #72, #4 (records the "Prod is CI-only" clause of [ADR 0026](https://github.com/onemen/firefox-scripts/pull/183); guard requested in the channels design discussion).

## What

A real (non-`--local`) `--mode=prod` run **outside CI** aborts before building: a developer machine can build only its own OS's binaries, while the `latest` release contract is the complete cross-OS set (4 installers + helpers, ADR 0024). Publishing a partial set is exactly the hazard this kills — previously nothing stopped it.

- **Workflow-agnostic** (per the #33 forward-compat note on #4): "in CI" = `upload.mjs`'s explicit `--ci` flag (what the Pages workflow passes), never ambient `CI=` env vars, which local shells often export. A future build matrix needs no guard change.
- **Exemptions:** `--local` snapshots (offline validation, publish nothing) and explicit `--ci` runs. Dev mode exempt — the test channel is disposable by design (ADR 0026).
- Same fail-fast pattern as the staging guard (`runStagingGuard`), placed right after it, with a clear pointer: `gh workflow run pages.yml -f mode=prod`.
- Optional hardening from the design discussion (post-publish asset-set verification job in `pages.yml`) is **not** in this PR — kept minimal; can ride with the #33 workflow work.

## Validation

- `node --test test/unit/publish/prodCiGuard.test.mjs` ✓ 4/4
- `pnpm lint` ✓ · `pnpm format` ✓ · `pnpm test` ✓ 330/0

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>