### PR TITLE
publish: dev --note flag for RC-style announced test builds (ADR 0026)

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -669,6 +669,7 @@ into the same `DEV_BUILD_ID` first so installed test builds auto-update while th
 ```bash
 npm run upload -- --mode=prod            # hashes → rebuild changed zips + binaries → upload → Pages + manifest + UI
 npm run upload -- --mode=dev             # same, but always rebuild + upload, to the dev-build-<id> branch + release
+npm run upload -- --mode=dev --note="RC 1 for v1.0"   # RC-style: title `dev-build-<id> — RC 1 for v1.0`, note + test-build warning + provenance in the body (ADR 0026)
 npm run upload:local -- --mode=prod      # same, but write a snapshot to dist/prod-<branch>-<hash>/ (no token)
 npm run upload:local -- --mode=dev       # dev snapshot (-dev artifact names), no token
 ```

--- a/test/unit/publish/devReleaseRender.test.mjs
+++ b/test/unit/publish/devReleaseRender.test.mjs
@@ -1,0 +1,36 @@
+// test/unit/publish/devReleaseRender.test.mjs — unit tests for the dev
+// release page rendering (devReleasePage.mjs, ADR 0026's --note RC flag).
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+
+process.argv.push('--mode=dev');
+
+const {renderDevRelease} = await import('../../../tools/publish/devReleasePage.mjs');
+
+const BASE = {
+  note: '',
+  shortSha: '450468f',
+  date: '2026-09-12',
+  devBranch: 'dev-build-main-450468f',
+};
+
+test('plain dev publish: bare title, warning + provenance body', () => {
+  const {title, body} = renderDevRelease(BASE);
+  assert.equal(title, 'dev-build-main-450468f');
+  assert.match(body, /⚠️ Test build/);
+  assert.match(body, /never auto-updates/i);
+  assert.match(body, /latest stable/);
+  assert.match(body, /450468f/);
+  assert.match(body, /2026-09-12/);
+  assert.match(body, /tree\/dev-build-main-450468f/);
+});
+
+test('--note publish: title carries the label, body leads with it', () => {
+  const {title, body} = renderDevRelease({...BASE, note: 'RC 1 for v1.0 — community validation'});
+  assert.equal(title, 'dev-build-main-450468f — RC 1 for v1.0 — community validation');
+  assert.ok(body.startsWith('RC 1 for v1.0 — community validation\n'));
+  // Still a prerelease page: warning + provenance ride along.
+  assert.match(body, /⚠️ Test build/);
+  assert.match(body, /releases\/latest/);
+});

--- a/tools/publish/devReleasePage.mjs
+++ b/tools/publish/devReleasePage.mjs
@@ -1,0 +1,36 @@
+// devReleasePage.mjs — dev release page rendering (ADR 0026).
+//
+// Library-only so unit tests can import it without dragging in upload.mjs
+// (whose top-level main() runs the whole publish flow).
+
+import {REPO_OWNER, REPO_NAME} from './paths.js';
+
+/**
+ * Render the dev release page's title + body. Without a note the title is the
+ * bare dev-build branch; `--note="<label>"` turns the page into an RC-style
+ * announcement: the label leads the title and body, and the test-build warning
+ *
+ * - provenance ride along either way (the warning is what the existing
+ *   dev-build-main-* users need on the page they already visit).
+ *
+ * @param {{
+ *   note: string;
+ *   shortSha: string;
+ *   date: string;
+ *   devBranch: string;
+ * }} p
+ * @returns {{title: string; body: string}}
+ */
+export function renderDevRelease({note, shortSha, date, devBranch}) {
+  const title = note ? `${devBranch} — ${note}` : devBranch;
+  const body = [
+    ...(note ? [note, ''] : []),
+    '⚠️ Test build — for testing only; not for daily use. It never auto-updates to',
+    'the stable channel, and its updater stops working when this branch is deleted.',
+    `For daily use, install the [latest stable](https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest) instead.`,
+    '',
+    `Built from: [${shortSha}](https://github.com/${REPO_OWNER}/${REPO_NAME}/commit/${shortSha}) on ${date}`,
+    `Files are on the [${devBranch}](https://github.com/${REPO_OWNER}/${REPO_NAME}/tree/${devBranch}) branch.`,
+  ].join('\n');
+  return {title, body};
+}

--- a/tools/publish/upload.mjs
+++ b/tools/publish/upload.mjs
@@ -26,6 +26,10 @@
 //                      detached worktree (your checkout is left untouched).
 //   --ci               build binaries for all platforms (default: current OS).
 //   --platform=win|linux|mac (repeatable)  explicit binary platform set.
+//   --note="<label>"   (dev only, ADR 0026) announce this dev build as an
+//                      RC-style test build: the prerelease title becomes
+//                      `dev-build-<id> — <label>` and the body leads with the
+//                      note + test-build warning + source-commit provenance.
 //   --no-tag           (prod only) skip moving the 'latest' release tag to the
 //                      uploaded commit (it is force-updated after every
 //                      non-idle prod upload).
@@ -123,6 +127,7 @@ import {
   installerAssetName,
 } from './platforms.mjs';
 import {runProdCiGuard} from './prodCiGuard.mjs';
+import {renderDevRelease} from './devReleasePage.mjs';
 import {runStagingGuard} from './stagingGuard.mjs';
 
 const LOCAL = process.argv.includes('--local');
@@ -533,14 +538,29 @@ function writeBuildManifest(platforms, builtInstallers, builtHelpers) {
  * never seen (e.g. a local-only HEAD), so target_commitish must be an
  * already-pushed ref.
  */
+// --note="<label>" (dev mode only, ADR 0026): labels this dev publish as an
+// RC-style announced build — the prerelease page's title becomes
+// `dev-build-<id> — <label>` and the body leads with the note, a test-build
+// warning, and source-commit provenance (renderDevRelease in
+// devReleasePage.mjs). Without it, the body still warns but the title stays
+// bare.
+const DEV_NOTE = (() => {
+  const arg = process.argv.find(a => a.startsWith('--note='));
+  return arg ? arg.slice('--note='.length) : '';
+})();
+
 async function getOrCreateDevRelease(octokit) {
-  const body = [
-    'Development build for testing',
-    '',
-    `Files are on the [${DEV_BRANCH}](https://github.com/${REPO_OWNER}/${REPO_NAME}/tree/${DEV_BRANCH}) branch.`,
-  ].join('\n');
+  const shortSha = execSync('git rev-parse --short HEAD', {cwd: REPO_ROOT, encoding: 'utf-8'})
+    .trim()
+    .slice(0, 7);
+  const {title, body} = renderDevRelease({
+    note: DEV_NOTE,
+    shortSha,
+    date: new Date().toISOString().slice(0, 10),
+    devBranch: DEV_BRANCH,
+  });
   return getOrCreateRelease(octokit, DEV_BRANCH, {
-    name: DEV_BRANCH,
+    name: title,
     body,
     commitish: DEV_BRANCH,
     // A dev build is a pre-release: it is never the stable download.


### PR DESCRIPTION
Part of #72, #4. Records the **RC mechanism** for #4's release-candidate item ([decision comment](https://github.com/onemen/firefox-scripts/issues/4#issuecomment-5645375392)); implements the release-page half of [ADR 0026](https://github.com/onemen/firefox-scripts/pull/183) (PR A).

## What

`pnpm upload -- --mode=dev --note="RC 1 for v1.0 — community validation"` produces the RC announcement page:

- **Title:** `dev-build-main-450468f — RC 1 for v1.0 — community validation` (prerelease — it is genuinely one, and prereleases can never take the Latest badge).
- **Body:** the note first, then a ⚠️ test-build warning (*never auto-updates to stable; the updater stops working when the branch is deleted; install the latest stable for daily use* — the warning the current `dev-build-main-450468f` users need), then **source-commit provenance** (`Built from: <sha> on <date>`) and the branch pointer.
- Without `--note`, dev releases stay as before (bare branch title) **but the body now carries the same warning + provenance** — the warning rides on every dev page from now on.

Design notes: rendering lives in a new library module (`devReleasePage.mjs`) because unit tests must not import `upload.mjs` (its top-level `main()` runs the whole publish flow — discovered the hard way). The fallback ladder's tab banner (PR B) is the in-browser half of the same warning; the page is what RC recipients browse before installing.

## Validation

- `node --test test/unit/publish/devReleaseRender.test.mjs` ✓ 2/2 (bare + note variants)
- `pnpm lint` ✓ · `pnpm format` ✓ · `pnpm test` ✓ 328/0

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>