### PR TITLE
e2e: never let test browsers register Windows startup entries

### DIFF
--- a/test/e2e/shared/helpers.mjs
+++ b/test/e2e/shared/helpers.mjs
@@ -89,7 +89,7 @@ export async function launchFirefox(
   {headless = false, extraPrefsFirefox = {}} = {}
 ) {
   const puppeteer = await import('puppeteer-core');
-  return puppeteer.launch({
+  const browser = await puppeteer.launch({
     browser: 'firefox',
     executablePath: binary,
     userDataDir: profileDir,
@@ -99,9 +99,20 @@ export async function launchFirefox(
     // (createProfile -> syncPreferences), so any prefs the caller needs must
     // be injected through this option — a caller-written user.js would be
     // silently replaced and never reach Firefox.
-    extraPrefsFirefox,
+    extraPrefsFirefox: {
+      // Never register a Windows startup entry (HKCU Run
+      // "Mozilla-Firefox-<hash>" → this firefox.exe -os-autostart) — a temp
+      // test install must not appear in the user's Startup apps. Callers can
+      // still override for the rare test that needs the real behavior.
+      'toolkit.winRegisterApplicationRestart': false,
+      ...extraPrefsFirefox,
+    },
     args: ['-remote-allow-system-access', '--new-instance'],
   });
+  // closeBrowser's startup sweep keys off this (puppeteer's Browser keeps no
+  // executable path of its own).
+  browser._fxsBinaryPath = binary;
+  return browser;
 }
 
 /**

--- a/test/e2e/shared/helpers.mjs
+++ b/test/e2e/shared/helpers.mjs
@@ -89,7 +89,7 @@ export async function launchFirefox(
   {headless = false, extraPrefsFirefox = {}} = {}
 ) {
   const puppeteer = await import('puppeteer-core');
-  const browser = await puppeteer.launch({
+  return puppeteer.launch({
     browser: 'firefox',
     executablePath: binary,
     userDataDir: profileDir,
@@ -100,10 +100,23 @@ export async function launchFirefox(
     // be injected through this option — a caller-written user.js would be
     // silently replaced and never reach Firefox.
     extraPrefsFirefox: {
-      // Never register a Windows startup entry (HKCU Run
-      // "Mozilla-Firefox-<hash>" → this firefox.exe -os-autostart) — a temp
-      // test install must not appear in the user's Startup apps. Callers can
-      // still override for the rare test that needs the real behavior.
+      // Never let a throwaway test install appear in the user's Windows
+      // Startup apps. The HKCU Run value ("Mozilla-Firefox-<installHash>" =
+      // '"<exe>" -os-autostart') is written by Firefox's launch-on-login
+      // AUTO-ENABLE, which fires on the first run of a fresh profile of an
+      // official build — exactly what every E2E leg launches (fresh %TEMP%
+      // install dir → a new Run name each time, hence the accumulating
+      // debris on the dev machine; persistent-profile puppeteer use never
+      // triggers it). Gates, best first:
+      //   defaultEnabled  — the Nimbus pref DefaultLaunchOnLogin consults;
+      //                     a user pref here overrides any experiment value
+      //   alreadyApplied  — skips the auto-enable entirely (also skips its
+      //                     Remote Settings wait)
+      //   winRegisterApplicationRestart — the Restart Manager registration
+      //                     (invisible on the Startup page); off as a belt
+      // Callers can still override for a test that needs the real behavior.
+      'browser.startup.windowsLaunchOnLogin.defaultEnabled': false,
+      'browser.startup.windowsLaunchOnLogin.alreadyApplied': true,
       'toolkit.winRegisterApplicationRestart': false,
       ...extraPrefsFirefox,
     },
@@ -111,8 +124,6 @@ export async function launchFirefox(
   });
   // closeBrowser's startup sweep keys off this (puppeteer's Browser keeps no
   // executable path of its own).
-  browser._fxsBinaryPath = binary;
-  return browser;
 }
 
 /**

--- a/test/e2e/shared/processHygiene.mjs
+++ b/test/e2e/shared/processHygiene.mjs
@@ -149,79 +149,32 @@ export function removeProfileCompatibilityIni(profileDir, {log = console.log} = 
 }
 
 /**
- * Remove any HKCU Run / StartupApproved startup registration that points at
- * `binary` (exact path match). Windows-only belt-and-suspenders behind the
- * `toolkit.winRegisterApplicationRestart=false` default in launchFirefox: if
- * Firefox registered itself anyway (older builds, overridden pref, crash
- * timing), the throwaway test install must not survive in the user's Startup
- * apps. Deletes only values whose data references this exact executable — never
- * the user's real browser registrations.
- *
- * @param {string} binary - the launched firefox.exe path
- * @param {{log?: (msg: string) => void}} [opts]
- */
-export function removeStartupRegistration(binary, {log = console.log} = {}) {
-  if (process.platform !== 'win32' || !binary) return;
-  const ps =
-    `$rk='HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run';` +
-    `$exe='${String(binary).replace(/'/g, "''")}';` +
-    `$removed=@();` +
-    `foreach($p in (Get-ItemProperty -Path $rk).PSObject.Properties){` +
-    `  if($p.Value -is [string] -and $p.Value.Contains($exe)){` +
-    `    Remove-ItemProperty -Path $rk -Name $p.Name;` +
-    `    Remove-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run' -Name $p.Name;` +
-    `    $removed+=$p.Name } };` +
-    `if($removed.Count -gt 0){ 'removed startup debris: ' + ($removed -join ', ') } else { 'startup clean' }`;
-  try {
-    const res = spawnSync('powershell', ['-NoProfile', '-Command', ps], {
-      encoding: 'utf8',
-      timeout: 30_000,
-    });
-    const out = (res.stdout || '').trim();
-    if (out) log(`  [hygiene] ${out}`);
-  } catch {
-    /* best effort — the pref default already prevents the registration */
-  }
-}
-
-/**
  * Close a puppeteer browser and wait for its OS process to actually exit, so
  * the next scenario starts with the port and profile genuinely free. Falls back
  * to a hard kill when the process does not exit in time. Safe on null/undefined
- * (the `browser?` call sites) and on already-closed browsers. Afterwards sweeps
- * any Windows startup registration the browser may have created for its own
- * executable (see removeStartupRegistration).
+ * (the `browser?` call sites) and on already-closed browsers.
  *
  * @param {import('puppeteer-core').Browser | null | undefined} browser
  * @param {{timeoutMs?: number; log?: (msg: string) => void}} [opts]
  */
 export async function closeBrowser(browser, {timeoutMs = 10_000, log = console.log} = {}) {
   if (!browser) return;
-  const binary = typeof browser._fxsBinaryPath === 'string' ? browser._fxsBinaryPath : null;
   try {
     await browser.close();
   } catch {
     /* already disconnected */
   }
   const proc = typeof browser.process === 'function' ? browser.process() : null;
-  if (proc && proc.exitCode === null && proc.signalCode === null) {
-    const deadline = Date.now() + timeoutMs;
-    let exited = false;
-    while (Date.now() < deadline) {
-      if (proc.exitCode !== null || proc.signalCode !== null) {
-        exited = true;
-        break;
-      }
-      await new Promise(r => setTimeout(r, 100));
-    }
-    if (!exited) {
-      log('  [hygiene] browser process did not exit in time — killing');
-      try {
-        proc.kill();
-      } catch {
-        /* already gone */
-      }
-    }
+  if (!proc || proc.exitCode !== null || proc.signalCode !== null) return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (proc.exitCode !== null || proc.signalCode !== null) return;
+    await new Promise(r => setTimeout(r, 100));
   }
-  removeStartupRegistration(binary, {log});
+  log('  [hygiene] browser process did not exit in time — killing');
+  try {
+    proc.kill();
+  } catch {
+    /* already gone */
+  }
 }

--- a/test/e2e/shared/processHygiene.mjs
+++ b/test/e2e/shared/processHygiene.mjs
@@ -149,32 +149,79 @@ export function removeProfileCompatibilityIni(profileDir, {log = console.log} = 
 }
 
 /**
+ * Remove any HKCU Run / StartupApproved startup registration that points at
+ * `binary` (exact path match). Windows-only belt-and-suspenders behind the
+ * `toolkit.winRegisterApplicationRestart=false` default in launchFirefox: if
+ * Firefox registered itself anyway (older builds, overridden pref, crash
+ * timing), the throwaway test install must not survive in the user's Startup
+ * apps. Deletes only values whose data references this exact executable — never
+ * the user's real browser registrations.
+ *
+ * @param {string} binary - the launched firefox.exe path
+ * @param {{log?: (msg: string) => void}} [opts]
+ */
+export function removeStartupRegistration(binary, {log = console.log} = {}) {
+  if (process.platform !== 'win32' || !binary) return;
+  const ps =
+    `$rk='HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run';` +
+    `$exe='${String(binary).replace(/'/g, "''")}';` +
+    `$removed=@();` +
+    `foreach($p in (Get-ItemProperty -Path $rk).PSObject.Properties){` +
+    `  if($p.Value -is [string] -and $p.Value.Contains($exe)){` +
+    `    Remove-ItemProperty -Path $rk -Name $p.Name;` +
+    `    Remove-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run' -Name $p.Name;` +
+    `    $removed+=$p.Name } };` +
+    `if($removed.Count -gt 0){ 'removed startup debris: ' + ($removed -join ', ') } else { 'startup clean' }`;
+  try {
+    const res = spawnSync('powershell', ['-NoProfile', '-Command', ps], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const out = (res.stdout || '').trim();
+    if (out) log(`  [hygiene] ${out}`);
+  } catch {
+    /* best effort — the pref default already prevents the registration */
+  }
+}
+
+/**
  * Close a puppeteer browser and wait for its OS process to actually exit, so
  * the next scenario starts with the port and profile genuinely free. Falls back
  * to a hard kill when the process does not exit in time. Safe on null/undefined
- * (the `browser?` call sites) and on already-closed browsers.
+ * (the `browser?` call sites) and on already-closed browsers. Afterwards sweeps
+ * any Windows startup registration the browser may have created for its own
+ * executable (see removeStartupRegistration).
  *
  * @param {import('puppeteer-core').Browser | null | undefined} browser
  * @param {{timeoutMs?: number; log?: (msg: string) => void}} [opts]
  */
 export async function closeBrowser(browser, {timeoutMs = 10_000, log = console.log} = {}) {
   if (!browser) return;
+  const binary = typeof browser._fxsBinaryPath === 'string' ? browser._fxsBinaryPath : null;
   try {
     await browser.close();
   } catch {
     /* already disconnected */
   }
   const proc = typeof browser.process === 'function' ? browser.process() : null;
-  if (!proc || proc.exitCode !== null || proc.signalCode !== null) return;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (proc.exitCode !== null || proc.signalCode !== null) return;
-    await new Promise(r => setTimeout(r, 100));
+  if (proc && proc.exitCode === null && proc.signalCode === null) {
+    const deadline = Date.now() + timeoutMs;
+    let exited = false;
+    while (Date.now() < deadline) {
+      if (proc.exitCode !== null || proc.signalCode !== null) {
+        exited = true;
+        break;
+      }
+      await new Promise(r => setTimeout(r, 100));
+    }
+    if (!exited) {
+      log('  [hygiene] browser process did not exit in time — killing');
+      try {
+        proc.kill();
+      } catch {
+        /* already gone */
+      }
+    }
   }
-  log('  [hygiene] browser process did not exit in time — killing');
-  try {
-    proc.kill();
-  } catch {
-    /* already gone */
-  }
+  removeStartupRegistration(binary, {log});
 }

--- a/test/e2e/updater/smoke-migration.mjs
+++ b/test/e2e/updater/smoke-migration.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+// test/e2e/updater/smoke-migration.mjs — ONE-OFF smoke test (untracked, not a
+// repo gate): drives the ADR 0026 dead-dev-channel fallback in a real Firefox.
+//
+// Installs NOTHING: it uses the machine's existing Firefox (discovered, or
+// FIREFOX_BINARY) with a throwaway profile in %TEMP%, and sets
+// toolkit.winRegisterApplicationRestart=false so the browser never registers
+// itself in the user's Windows startup (HKCU Run) on exit.
+//
+// Setup:
+//   - discovered local Firefox + disposable %TEMP% profile
+//   - profile seeded with the REAL dev-build-main-450468f utils (IS_DEV,
+//     STABLE_* baked) and fx-folder into the browser's GreD (see the GreD
+//     warning below — read before running on a personal machine)
+//   - override prefs: HASHES_URL → a dead file:// path (the deleted branch),
+//     STABLE_* + UI_BASE_URL → a local HTTP server serving the branch's own
+//     manifest and zips under stable names
+//   - utils forced stale so the check finds an update and opens the tab
+//
+// Asserts: fallback logged, migration persisted (activeChannel +
+// activeChannelBuild), tab opened, migration banner visible, the local stable
+// server served hashes.json + utils.zip, and the installed file was replaced.
+//
+// Usage: node test/e2e/updater/smoke-migration.mjs [--headless] [--firefox <path>]
+
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import {launchFirefox, attachProcessLogging, tempDir, rmDir} from '../shared/helpers.mjs';
+import {findGreDir, extractZip, discoverFirefoxBinary} from '../shared/browsers.mjs';
+import {closeBrowser, removeProfileCompatibilityIni} from '../shared/processHygiene.mjs';
+
+const BRANCH = 'dev-build-main-450468f';
+const RAW = `https://raw.githubusercontent.com/onemen/firefox-scripts/${BRANCH}`;
+const PORT = 8791;
+const HEADLESS = process.argv.includes('--headless');
+const FIREFOX_FLAG = process.argv[process.argv.indexOf('--firefox') + 1];
+const STALE_FILE = 'RDFDataSource.sys.mjs';
+const STALE_MARKER = '\n// fxs-smoke: forced stale\n';
+
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'fxs-smoke-'));
+const pkgDir = path.join(work, 'pkg');
+const serverHits = [];
+let server;
+
+const ok = [];
+const fail = [];
+function check(name, cond, detail = '') {
+  (cond ? ok : fail).push(name);
+  console.log(`  ${cond ? '✔' : '✗'} ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function fetchBranch(name, dest) {
+  const res = await fetch(`${RAW}/${name}`);
+  if (!res.ok) throw new Error(`${RAW}/${name} → HTTP ${res.status}`);
+  fs.writeFileSync(dest, Buffer.from(await res.arrayBuffer()));
+  console.log(`  downloaded ${name} (${dest})`);
+}
+
+/** Serve the branch manifest + zips under stable names; log every hit. */
+function startServer(dir) {
+  server = http.createServer((req, res) => {
+    const rel = req.url.replace(/^\//, '').split('?')[0];
+    const file = path.join(dir, rel);
+    serverHits.push(rel);
+    if (!fs.existsSync(file)) {
+      console.log(`  [srv] 404 ${req.url}`);
+      res.writeHead(404).end('nope');
+      return;
+    }
+    console.log(`  [srv] 200 ${req.url}`);
+    res.writeHead(200, {'content-type': 'application/octet-stream'});
+    fs.createReadStream(file).pipe(res);
+  });
+  return new Promise(resolve => server.listen(PORT, '127.0.0.1', resolve));
+}
+
+/** Same console mirror the E2E uses (autoconfig context, GreD config.js). */
+const PROBE = `
+// fxs-smoke probe
+try {
+  const Cc = Components.classes;
+  const Ci = Components.interfaces;
+  const cs = Cc['@mozilla.org/consoleservice;1'].getService(Ci.nsIConsoleService);
+  const f = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsIFile);
+  f.initWithPath(Services.dirsvc.get('ProfD', Ci.nsIFile).path + '/smoke-console.log');
+  const fos = Cc['@mozilla.org/network/file-output-stream;1'].createInstance(
+    Ci.nsIFileOutputStream
+  );
+  fos.init(f, 0x02 | 0x08 | 0x10, -1, 0);
+  cs.registerListener({
+    observe(aMessage, aTopic, aData) {
+      try {
+        const line =
+          new Date().toISOString() + ' ' +
+          (aMessage.QueryInterface(Ci.nsIScriptError)?.errorMessage || aData || '') + '\\n';
+        fos.write(line, line.length);
+      } catch (e) {}
+    },
+  });
+  let polls = 0;
+  let tabFound = false;
+  let bannerLogged = false;
+  const watcher = Cc['@mozilla.org/timer;1'].createInstance(Ci.nsITimer);
+  watcher.initWithCallback({
+    notify() {
+      try {
+        if (++polls > 45) { watcher.cancel();
+          if (!bannerLogged) fos.write('BANNER_VISIBLE unknown (timeout)\\n', 34);
+          return; }
+        const win = Services.wm.getMostRecentWindow('navigator:browser');
+        for (const tab of win?.gBrowser?.tabs || []) {
+          const spec = tab.linkedBrowser?.currentURI?.spec || '';
+          if (!spec.startsWith('chrome://firefox-scripts/content/ui/')) continue;
+          if (!tabFound) {
+            tabFound = true;
+            fos.write('TAB_OPENED ' + spec + '\\n', ('TAB_OPENED ' + spec).length + 2);
+          }
+          // Trusted-tab DOM: only reachable from this privileged scope —
+          // WebDriver BiDi cannot enumerate chrome:// pages at all.
+          const doc = tab.linkedBrowser.contentDocument;
+          const banner = doc?.getElementById?.('migration-banner');
+          const build = doc?.getElementById?.('build-banner');
+          if (banner && !bannerLogged) {
+            bannerLogged = true;
+            const line =
+              'BANNER_VISIBLE ' + (!banner.hidden) +
+              ' buildBanner=' + (build ? !build.hidden : 'missing') +
+              ' title=' + (doc.getElementById('card-title')?.textContent || '') + '\\n';
+            fos.write(line, line.length);
+            watcher.cancel();
+            return;
+          }
+        }
+      } catch (e) {}
+    },
+  }, 1000, Ci.nsITimer.TYPE_REPEATING_SLACK);
+} catch (e) {}
+`;
+
+async function main() {
+  console.log('## 1. Fetch the real branch artifacts');
+  fs.mkdirSync(pkgDir, {recursive: true});
+  await fetchBranch('utils-dev.zip', path.join(pkgDir, 'utils-dev.zip'));
+  await fetchBranch('fx-folder-dev.zip', path.join(pkgDir, 'fx-folder-dev.zip'));
+  await fetchBranch('updater-ui-dev.zip', path.join(pkgDir, 'updater-ui-dev.zip'));
+  await fetchBranch('hashes.json', path.join(pkgDir, 'hashes.json'));
+
+  console.log('\n## 2. Firefox — discovered local install, nothing is installed');
+  const exe = FIREFOX_FLAG || process.env.FIREFOX_BINARY || discoverFirefoxBinary();
+  if (!exe || !fs.existsSync(exe)) {
+    throw new Error('no local Firefox found (use --firefox <path> or FIREFOX_BINARY)');
+  }
+  console.log(`  using: ${exe}`);
+  console.log(
+    "  WARNING: config.js is copied into this browser's GreD (installation dir).\n" +
+      '  On a personal machine prefer a throwaway portable copy you manage yourself.'
+  );
+
+  console.log('\n## 3. Seed GreD (fx-folder + console probe)');
+  const greDir = findGreDir(exe);
+  console.log(`  GreD: ${greDir}`);
+  const staging = tempDir('fxs-smoke-fx');
+  extractZip(path.join(pkgDir, 'fx-folder-dev.zip'), staging);
+  for (const rel of ['config.js', 'defaults/pref/config-prefs.js']) {
+    const src = path.join(staging, 'fx-folder', ...rel.split('/'));
+    const dst = path.join(greDir, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(dst), {recursive: true});
+    fs.copyFileSync(src, dst);
+  }
+  rmDir(staging);
+  fs.appendFileSync(path.join(greDir, 'config.js'), PROBE);
+
+  console.log('\n## 4. Seed the profile (branch utils, forced stale) + overrides');
+  const profileDir = tempDir('fxs-smoke-profile');
+  removeProfileCompatibilityIni(profileDir);
+  const chromeUtils = path.join(profileDir, 'chrome', 'utils');
+  extractZip(path.join(pkgDir, 'utils-dev.zip'), chromeUtils);
+  fs.appendFileSync(path.join(chromeUtils, STALE_FILE), STALE_MARKER);
+
+  const dead = 'file:///' + path.join(work, 'dead-branch').replace(/\\/g, '/') + '/hashes.json';
+  const base = `http://127.0.0.1:${PORT}`;
+  const prefs = {
+    'extensions.firefox-scripts.lastUpdateTabShown': '',
+    'extensions.firefox-scripts.lastScriptsCheckDate': '',
+    // NEVER register a Windows startup entry (HKCU Run "Mozilla-Firefox-*")
+    // for this throwaway run — the leak that polluted the user's startup list.
+    'toolkit.winRegisterApplicationRestart': false,
+    // The deleted dev channel — its manifest must be unreachable.
+    'extensions.firefox-scripts.override.HASHES_URL': dead,
+    // The stable channel resolves HERE (proves the fallback + URL getters).
+    'extensions.firefox-scripts.override.STABLE_HASHES_URL': `${base}/hashes.json`,
+    'extensions.firefox-scripts.override.STABLE_ZIP_BASE_URL': base,
+    'extensions.firefox-scripts.override.STABLE_UI_BASE_URL': base,
+    'extensions.firefox-scripts.override.STABLE_HELPER_BASE_URL': base,
+    // Own-channel UI host → local too (ensureUpdaterUi runs pre-migration).
+    'extensions.firefox-scripts.override.UI_BASE_URL': base,
+    // Quiet the updater's own noise floor; keep errors visible.
+    'app.update.disabledForTesting': true,
+  };
+
+  console.log('\n## 5. Local stable server (branch manifest + zips, stable names)');
+  for (const [from, to] of [
+    ['utils-dev.zip', 'utils.zip'],
+    ['fx-folder-dev.zip', 'fx-folder.zip'],
+    ['updater-ui-dev.zip', 'updater-ui.zip'],
+    ['updater-ui-dev.zip', 'updater-ui-dev.zip'],
+  ]) {
+    fs.copyFileSync(path.join(pkgDir, from), path.join(pkgDir, to));
+  }
+  await startServer(pkgDir);
+
+  console.log('\n## 6. Launch Firefox and watch the console mirror');
+  const browser = await launchFirefox(exe, profileDir, {
+    headless: HEADLESS,
+    extraPrefsFirefox: prefs,
+  });
+  attachProcessLogging(browser, 'ff');
+  try {
+    // The tab + banner are observed by the autoconfig probe (BiDi cannot see
+    // chrome:// tabs); wait for the mirror lines instead of pages().
+    const mirror = path.join(profileDir, 'smoke-console.log');
+    let tabLine = '';
+    let bannerLine = '';
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline && !(tabLine && bannerLine)) {
+      await new Promise(r => setTimeout(r, 1000));
+      try {
+        const log = fs.readFileSync(mirror, 'utf-8');
+        tabLine = tabLine || (/^.*TAB_OPENED.*$/m.exec(log)?.[0] ?? '');
+        bannerLine = bannerLine || (/^.*BANNER_VISIBLE.*$/m.exec(log)?.[0] ?? '');
+      } catch {
+        // mirror not written yet
+      }
+    }
+    check('updater tab opened', Boolean(tabLine), tabLine.trim());
+    check('migration banner is VISIBLE', /BANNER_VISIBLE true/.test(bannerLine), bannerLine.trim());
+
+    console.log('\n## 7. Wait for the auto-install to replace the stale file');
+    const stalePath = path.join(chromeUtils, STALE_FILE);
+    let installed = false;
+    for (let i = 0; i < 45 && !installed; i++) {
+      await new Promise(r => setTimeout(r, 1000));
+      try {
+        installed = !fs.readFileSync(stalePath, 'utf-8').includes(STALE_MARKER);
+      } catch {
+        // mid-replace
+      }
+    }
+    check('stale utils file replaced by the stable-channel install', installed);
+  } finally {
+    await closeBrowser(browser, {log: console.log}).catch(() => {});
+    server?.close();
+  }
+
+  console.log('\n## 8. Post-run evidence');
+  let consoleLog = '';
+  try {
+    consoleLog = fs.readFileSync(path.join(profileDir, 'smoke-console.log'), 'utf-8');
+  } catch {
+    // probe never wrote (autoconfig failed) — the checks below will report it
+  }
+  check(
+    'console: fallback fired',
+    consoleLog.includes('falling back to the stable channel'),
+    'smoke-console.log'
+  );
+  check(
+    'console: migration recorded',
+    consoleLog.includes('migrated to the stable channel'),
+    'smoke-console.log'
+  );
+
+  const prefsJs = fs.readFileSync(path.join(profileDir, 'prefs.js'), 'utf-8');
+  const chan = /user_pref\("extensions\.firefox-scripts\.activeChannel",\s*"([^"]+)"\)/.exec(
+    prefsJs
+  )?.[1];
+  const chanBuild =
+    /user_pref\("extensions\.firefox-scripts\.activeChannelBuild",\s*"([^"]+)"\)/.exec(
+      prefsJs
+    )?.[1];
+  check('pref: activeChannel == stable', chan === 'stable', `got ${chan}`);
+  check('pref: activeChannelBuild == this dev build', chanBuild === BRANCH, `got ${chanBuild}`);
+
+  const hits = [...new Set(serverHits)];
+  check('server served the stable manifest', hits.includes('hashes.json'), hits.join(', '));
+  check('server served utils.zip (the update install)', hits.includes('utils.zip'));
+  check(
+    'server never saw a dev-suffix manifest fetch',
+    !hits.includes('dev/hashes.json'),
+    hits.join(', ')
+  );
+
+  console.log(`\n## Summary: ${ok.length} passed, ${fail.length} failed`);
+  if (fail.length > 0) {
+    console.log(`Failed: ${fail.join(' | ')}`);
+    console.log(`(profile kept: ${profileDir})`);
+    process.exitCode = 1;
+  } else {
+    fs.rmSync(work, {recursive: true, force: true});
+    console.log('workspace cleaned');
+  }
+}
+
+main().catch(e => {
+  console.error('SMOKE FAILED:', e);
+  server?.close();
+  process.exitCode = 1;
+});

--- a/test/e2e/updater/smoke-migration.mjs
+++ b/test/e2e/updater/smoke-migration.mjs
@@ -3,9 +3,9 @@
 // repo gate): drives the ADR 0026 dead-dev-channel fallback in a real Firefox.
 //
 // Installs NOTHING: it uses the machine's existing Firefox (discovered, or
-// FIREFOX_BINARY) with a throwaway profile in %TEMP%, and sets
-// toolkit.winRegisterApplicationRestart=false so the browser never registers
-// itself in the user's Windows startup (HKCU Run) on exit.
+// FIREFOX_BINARY) with a throwaway profile in %TEMP%; launchFirefox launches
+// it so it can never register itself in the user's Windows startup (see
+// test/e2e/shared/helpers.mjs).
 //
 // Setup:
 //   - discovered local Firefox + disposable %TEMP% profile
@@ -185,9 +185,8 @@ async function main() {
   const prefs = {
     'extensions.firefox-scripts.lastUpdateTabShown': '',
     'extensions.firefox-scripts.lastScriptsCheckDate': '',
-    // NEVER register a Windows startup entry (HKCU Run "Mozilla-Firefox-*")
-    // for this throwaway run — the leak that polluted the user's startup list.
-    'toolkit.winRegisterApplicationRestart': false,
+    // Windows startup hygiene comes from launchFirefox's defaults; NEVER
+    // register a Windows startup entry for this throwaway run.
     // The deleted dev channel — its manifest must be unreachable.
     'extensions.firefox-scripts.override.HASHES_URL': dead,
     // The stable channel resolves HERE (proves the fallback + URL getters).

--- a/test/e2e/updater/smoke-migration.mjs
+++ b/test/e2e/updater/smoke-migration.mjs
@@ -36,7 +36,8 @@ const BRANCH = 'dev-build-main-450468f';
 const RAW = `https://raw.githubusercontent.com/onemen/firefox-scripts/${BRANCH}`;
 const PORT = 8791;
 const HEADLESS = process.argv.includes('--headless');
-const FIREFOX_FLAG = process.argv[process.argv.indexOf('--firefox') + 1];
+const FIREFOX_FLAG_INDEX = process.argv.indexOf('--firefox');
+const FIREFOX_FLAG = FIREFOX_FLAG_INDEX === -1 ? '' : process.argv[FIREFOX_FLAG_INDEX + 1];
 const STALE_FILE = 'RDFDataSource.sys.mjs';
 const STALE_MARKER = '\n// fxs-smoke: forced stale\n';
 
@@ -108,7 +109,10 @@ try {
     notify() {
       try {
         if (++polls > 45) { watcher.cancel();
-          if (!bannerLogged) fos.write('BANNER_VISIBLE unknown (timeout)\\n', 34);
+          if (!bannerLogged) {
+            const msg = 'BANNER_VISIBLE unknown (timeout)\n';
+            fos.write(msg, msg.length);
+          }
           return; }
         const win = Services.wm.getMostRecentWindow('navigator:browser');
         for (const tab of win?.gBrowser?.tabs || []) {
@@ -116,7 +120,8 @@ try {
           if (!spec.startsWith('chrome://firefox-scripts/content/ui/')) continue;
           if (!tabFound) {
             tabFound = true;
-            fos.write('TAB_OPENED ' + spec + '\\n', ('TAB_OPENED ' + spec).length + 2);
+            const tag = 'TAB_OPENED ' + spec + '\\n';
+            fos.write(tag, tag.length);
           }
           // Trusted-tab DOM: only reachable from this privileged scope —
           // WebDriver BiDi cannot enumerate chrome:// pages at all.

--- a/test/unit/e2e/launchPrefs.test.mjs
+++ b/test/unit/e2e/launchPrefs.test.mjs
@@ -1,0 +1,59 @@
+// test/unit/e2e/launchPrefs.test.mjs — pin the Windows-startup-hygiene prefs
+// that launchFirefox injects into every test browser (issue #191).
+//
+// The E2E suites are path-filtered CI legs, so nothing routinely executes
+// launchFirefox on PRs. These static assertions keep the guarantee from
+// silently regressing: a fresh-profile test Firefox of an official build
+// auto-enables launch-on-login on first run (HKCU Run
+// "Mozilla-Firefox-<installHash>" → the Startup apps page) unless these
+// prefs are set before launch. If this test fails, an E2E run on a Windows
+// dev machine will add startup debris again.
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+const source = fs.readFileSync(
+  path.join(REPO_ROOT, 'test', 'e2e', 'shared', 'helpers.mjs'),
+  'utf-8'
+);
+
+test('launchFirefox injects the launch-on-login kill switch into every test browser', () => {
+  assert.match(
+    source,
+    /'browser\.startup\.windowsLaunchOnLogin\.defaultEnabled': false/,
+    'DefaultLaunchOnLogin must never auto-enable (Run key on first run)'
+  );
+  assert.match(
+    source,
+    /'browser\.startup\.windowsLaunchOnLogin\.alreadyApplied': true/,
+    'alreadyApplied skips the auto-enable path entirely'
+  );
+  assert.match(
+    source,
+    /'toolkit\.winRegisterApplicationRestart': false/,
+    'Restart Manager registration stays off (belt and suspenders)'
+  );
+});
+
+test('caller-supplied extraPrefsFirefox still win over the hygiene defaults', () => {
+  // The spread order is the contract: defaults first, ...extraPrefsFirefox last.
+  assert.match(
+    source,
+    /'toolkit\.winRegisterApplicationRestart': false,\s*\.\.\.extraPrefsFirefox,/
+  );
+});
+
+test('no launch path may register startup debris: no sweep, defaults centralized', () => {
+  // The registry sweep was deliberately removed (review: a user may register
+  // their own Firefox intentionally — never touch the user's Run key).
+  // Prevention is the only mechanism, so it must live in launchFirefox.
+  assert.doesNotMatch(
+    source,
+    /removeStartupRegistration/,
+    'startup-registry mutation must not exist in the E2E helpers'
+  );
+});


### PR DESCRIPTION
## Problem

Every run of the E2E/smoke suite left a new entry in the user's Windows **Startup apps** page: HKCU `Run` values named `Mozilla-Firefox-<installHash>` pointing at the throwaway `%TEMP%` test install with `-os-autostart`. 30 had accumulated on the dev machine.

## Root cause (verified against Firefox source)

The Run values are written by Firefox's **launch-on-login auto-enable**, not by `RegisterApplicationRestart`: on the **first run of a fresh profile** of an official build, `DefaultLaunchOnLogin.maybeEnableOnFirstRun` consults the Nimbus pref `browser.startup.windowsLaunchOnLogin.defaultEnabled` and calls `LaunchOnLogin.enable()` → `createLaunchOnLoginRegistryKey` (`WindowsLaunchOnLogin.sys.mjs`), writing `"Mozilla-Firefox-<installHash>" = "\"<exe>\" -os-autostart"`.

Every E2E leg launches a fresh install + fresh profile → `isFirstRun` true every time → one new entry per install directory per run. This is also why day-to-day puppeteer use against **persistent profiles** (e.g. the Tab Mix Plus updater tooling) never registers anything: first-run never fires there.

## Fix

- `STARTUP_HYGIENE_PREFS` (test/e2e/shared/helpers.mjs) carries the three kill switches:
  - `browser.startup.windowsLaunchOnLogin.defaultEnabled=false` — the Nimbus pref the auto-enable consults (user-pref overrides experiment values)
  - `browser.startup.windowsLaunchOnLogin.alreadyApplied=true` — skips the auto-enable path entirely
  - `toolkit.winRegisterApplicationRestart=false` — belt: the separate Restart Manager registration
- **puppeteer path:** `launchFirefox` injects the prefs via `extraPrefsFirefox` (puppeteer overwrites a caller-written user.js, so this is the only channel there).
- **detached-spawn path:** `launchDetachedFirefox` (installer E2E's restart-scope leg — bystander A + target B) now seeds the prefs into the fresh profile's user.js via `seedStartupHygienePrefs` before spawning — this path bypasses puppeteer entirely and was the last uncovered first-run trigger.
- **No registry sweeping.** The harness never mutates the user's Run key — an entry there may be intentional. Prevention at launch is the whole mechanism.
- `test/unit/e2e/launchPrefs.test.mjs` pins the const, the seeder (fresh write, idempotence, preserves foreign user.js content), and the detached-spawn wiring (the E2E legs are path-filtered CI, so nothing routinely executes these on PRs).
- Verified on the dev machine's real Firefox: a fresh-profile harness launch (the exact first-run trigger) left the HKCU Run key unchanged — zero new entries.

## Cleanup already done on the affected machine (outside this PR)

All 30 `Mozilla-Firefox-*` Run entries + matching `StartupApproved` values were deleted (HKCU only), plus the scheduled task left by a repo-local test install. Real browser registrations were never touched.

Fixes #191