### PR TITLE
docs(readme): finding your version and reverting (date-based packages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ by hand. After your first install from this repository, the browser will notify 
 version is available (see
 [How the updater keeps your scripts up to date](#how-the-updater-keeps-your-scripts-up-to-date)).
 
+### Finding your version and reverting
+
+The packages are dated, not version-numbered: every publish stamps each package with the date its
+content last changed (`YYYY-MM-DD`, UTC). To find what you have:
+
+- **Updater tab** — open the updater from the browser menu. Next to each package's manual-download
+  link it shows the date of the current published package; "Up to Date" means your installed copy
+  matches it.
+- **Installer** — re-running the installer shows the same per-package dates next to the
+  manual-download links, plus each browser's Up to Date / Update Available status.
+
+To **revert** a package to an earlier build, open the
+[releases page](https://github.com/onemen/firefox-scripts/releases): the `latest` release always
+holds the newest build of every file, and the frozen `scripts-<date>` (package zips) and
+`installer-<date>` (installer binaries + helpers) releases hold each past publish. Download the
+package zip from the dated release you want and install it by hand (updater tab → manual download
+link, or unpack into your profile's `chrome/utils/` — see the
+[original scripts](#original-scripts-and-core-folders) section for the layout). The next daily check
+will offer the newer version again; use the tab's skip option if you want to stay on the older build
+for that update.
+
 The original scripts are governed by the
 [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/); the in-browser updater
 (`core/chrome/utils/updater/`) is custom to this project and licensed under the


### PR DESCRIPTION
Part of #4's "Version visibility" item: per-package dates verified in the installer + updater UI, plus a README "find your version / revert" section.

## What

A single README section, **"Finding your version and reverting"** (after the packages section, before the license):

- Explains the date-based package identity (ADR 0019): each package carries the date its content last changed (`YYYY-MM-DD`, UTC) — there are no version numbers.
- **Where to see it**: the updater tab and the installer both show the published package dates next to the manual-download links (`fx-download-date` / `utils-download-date`, rendered by `setDownloadDate` in `updater.js` / `installer/web/script.js`), with Up to Date / Update Available status per browser.
- **How to revert**: `latest` always holds the newest build; the frozen `scripts-<date>` / `installer-<date>` component releases (#176, ADR 0019) hold each past publish. Download the zip from the dated release and install it by hand (manual download link, or unpack into `chrome/utils/`), then use the per-update "Don't show again for this update" skip checkbox (`extensions.firefox-scripts.skippedHash.*`) to stay on the older build until the next published change.

## Verification

- Every claim checked against the code: date rendering in both UIs, the skip pref + checkbox, and the component-release naming from the publish automation.
- Note: `latest` currently has no assets (the next `pnpm release` materializes the mirror — #195 machinery is merged, the run is pending), so the revert flow becomes fully usable on the next publish. The section describes the shipped behavior, not the current empty state.
- Lint + format clean; docs-only change (no CI path filters triggered beyond docs).

Closes part of #4.
